### PR TITLE
Implement key repeat

### DIFF
--- a/src/board/system76/darp5/include/board/kbscan.h
+++ b/src/board/system76/darp5/include/board/kbscan.h
@@ -7,6 +7,11 @@
 
 extern bool kbscan_enabled;
 
+// ms between repeating key
+extern uint16_t kbscan_repeat_period;
+// ms between pressing key and repeating
+extern uint16_t kbscan_repeat_delay;
+
 void kbscan_init(void);
 void kbscan_event(void);
 

--- a/src/board/system76/darp5/kbscan.c
+++ b/src/board/system76/darp5/kbscan.c
@@ -121,6 +121,10 @@ void kbscan_event(void) {
     static bool debounce = false;
     static uint32_t debounce_time = 0;
 
+    static bool repeat = false;
+    static uint16_t repeat_key = 0;
+    static uint32_t repeat_key_time = 0;
+
     // If debounce complete
     if (debounce) {
         uint32_t time = time_get();
@@ -166,6 +170,7 @@ void kbscan_event(void) {
         uint8_t new = ~KSI;
         uint8_t last = kbscan_last[i];
         if (new != last) {
+            // A key was pressed or released
             int j;
             for (j = 0; j < KM_IN; j++) {
                 bool new_b = new & (1 << j);
@@ -190,6 +195,17 @@ void kbscan_event(void) {
                                 // In the case of ignored key press/release, reset bit
                                 reset = true;
                             }
+
+                            if (new_b) {
+                                // New key pressed, update last key
+                                repeat_key = key;
+                                repeat_key_time = time_get();
+                                repeat = false;
+                            } else if (key == repeat_key) {
+                                // Repeat key was released
+                                repeat_key = 0;
+                                repeat = false;
+                            }
                         } else {
                             WARN("KB %d, %d, %d missing\n", i, j, kbscan_layer);
                         }
@@ -207,6 +223,29 @@ void kbscan_event(void) {
             }
 
             kbscan_last[i] = new;
+        } else if (new && repeat_key != 0) {
+            // A key is being pressed
+            uint32_t time = time_get();
+            static uint32_t repeat_start = 0;
+
+            if (!repeat) {
+                if (time < repeat_key_time) {
+                    // Overflow, reset repeat_key_time
+                    repeat_key_time = time;
+                } else if ((time - repeat_key_time) >= 500) {
+                    // Typematic repeat
+                    repeat = true;
+                    repeat_start = time;
+                }
+            }
+
+            if (repeat) {
+                // FIXME: resend key at typematic rate
+                if ((time - repeat_start) > 60) {
+                    kbscan_press(repeat_key, true, &layer);
+                    repeat_start = time;
+                }
+            }
         }
     }
 

--- a/src/board/system76/darp5/kbscan.c
+++ b/src/board/system76/darp5/kbscan.c
@@ -9,6 +9,8 @@
 #include <common/debug.h>
 
 bool kbscan_enabled = false;
+uint16_t kbscan_repeat_period = 91;
+uint16_t kbscan_repeat_delay = 500;
 
 uint8_t sci_extra = 0;
 
@@ -232,7 +234,7 @@ void kbscan_event(void) {
                 if (time < repeat_key_time) {
                     // Overflow, reset repeat_key_time
                     repeat_key_time = time;
-                } else if ((time - repeat_key_time) >= 500) {
+                } else if ((time - repeat_key_time) >= kbscan_repeat_delay) {
                     // Typematic repeat
                     repeat = true;
                     repeat_start = time;
@@ -240,8 +242,7 @@ void kbscan_event(void) {
             }
 
             if (repeat) {
-                // FIXME: resend key at typematic rate
-                if ((time - repeat_start) > 60) {
+                if ((time - repeat_start) > kbscan_repeat_period) {
                     kbscan_press(repeat_key, true, &layer);
                     repeat_start = time;
                 }

--- a/src/board/system76/galp3-c/include/board/kbscan.h
+++ b/src/board/system76/galp3-c/include/board/kbscan.h
@@ -7,6 +7,11 @@
 
 extern bool kbscan_enabled;
 
+// ms between repeating key
+extern uint16_t kbscan_repeat_period;
+// ms between pressing key and repeating
+extern uint16_t kbscan_repeat_delay;
+
 void kbscan_init(void);
 void kbscan_event(void);
 

--- a/src/board/system76/galp3-c/kbscan.c
+++ b/src/board/system76/galp3-c/kbscan.c
@@ -10,6 +10,8 @@
 #include <common/debug.h>
 
 bool kbscan_enabled = false;
+uint16_t kbscan_repeat_period = 91;
+uint16_t kbscan_repeat_delay = 500;
 
 uint8_t sci_extra = 0;
 
@@ -231,7 +233,7 @@ void kbscan_event(void) {
                 if (time < repeat_key_time) {
                     // Overflow, reset repeat_key_time
                     repeat_key_time = time;
-                } else if ((time - repeat_key_time) >= 500) {
+                } else if ((time - repeat_key_time) >= kbscan_repeat_delay) {
                     // Typematic repeat
                     repeat = true;
                     repeat_start = time;
@@ -239,8 +241,7 @@ void kbscan_event(void) {
             }
 
             if (repeat) {
-                // FIXME: resend key at typematic rate
-                if ((time - repeat_start) > 60) {
+                if ((time - repeat_start) > kbscan_repeat_period) {
                     kbscan_press(repeat_key, true, &layer);
                     repeat_start = time;
                 }

--- a/src/board/system76/lemp9/include/board/kbscan.h
+++ b/src/board/system76/lemp9/include/board/kbscan.h
@@ -7,6 +7,11 @@
 
 extern bool kbscan_enabled;
 
+// ms between repeating key
+extern uint16_t kbscan_repeat_period;
+// ms between pressing key and repeating
+extern uint16_t kbscan_repeat_delay;
+
 void kbscan_init(void);
 void kbscan_event(void);
 

--- a/src/board/system76/lemp9/kbscan.c
+++ b/src/board/system76/lemp9/kbscan.c
@@ -10,6 +10,8 @@
 #include <common/debug.h>
 
 bool kbscan_enabled = false;
+uint16_t kbscan_repeat_period = 91;
+uint16_t kbscan_repeat_delay = 500;
 
 uint8_t sci_extra = 0;
 
@@ -231,7 +233,7 @@ void kbscan_event(void) {
                 if (time < repeat_key_time) {
                     // Overflow, reset repeat_key_time
                     repeat_key_time = time;
-                } else if ((time - repeat_key_time) >= 500) {
+                } else if ((time - repeat_key_time) >= kbscan_repeat_delay) {
                     // Typematic repeat
                     repeat = true;
                     repeat_start = time;
@@ -239,8 +241,7 @@ void kbscan_event(void) {
             }
 
             if (repeat) {
-                // FIXME: resend key at typematic rate
-                if ((time - repeat_start) > 60) {
+                if ((time - repeat_start) > kbscan_repeat_period) {
                     kbscan_press(repeat_key, true, &layer);
                     repeat_start = time;
                 }


### PR DESCRIPTION
Per [\[1\]], use a default delay of 500ms and a rate of 10.9 characters per second. When the Linux kernel starts, this will be updated by `atkbd` to the fastest settings possible [\[2\]]: 250ms delay and 30 CPS.

Modifying these values with `kbdrate` to test settings will cause two spurious ACKs in the kernel. This behavior is also present in the proprietary firmware.

Resolves: #19

[\[1\]]: https://web.archive.org/web/20180217074705/http://computer-engineering.org/ps2keyboard/
[\[2\]]: https://github.com/torvalds/linux/blob/c5f86891185c408b2241ba9a82ae8622d8386aff/drivers/input/keyboard/atkbd.c#L863-L868