### PR TITLE
Allow overriding version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 # Calculate version
 DATE=$(shell git show --format="%cd" --date="format:%Y-%m-%d" --no-patch)
 REV=$(shell git describe --always --dirty)
-VERSION=$(DATE)_$(REV)
+VERSION?=$(DATE)_$(REV)
 
 # Set build directory
 BUILD=build/$(BOARD)/$(VERSION)


### PR DESCRIPTION
In order to use the same version as the board firmware we need to be able to specify the version string for the EC.

Ref: system76/firmware-open#75