### PR TITLE
Power on after reset from scratch rom

### DIFF
--- a/src/board/system76/darp5/power.c
+++ b/src/board/system76/darp5/power.c
@@ -8,6 +8,7 @@
 #include <board/pmc.h>
 #include <board/pnp.h>
 #include <common/debug.h>
+#include <ec/bram.h>
 
 // Platform does not currently support Deep Sx
 #define DEEP_SX 0
@@ -256,6 +257,15 @@ void power_event(void) {
     // Always switch to ds5 if EC is running
     if (power_state == POWER_STATE_DEFAULT) {
         power_on_ds5();
+
+        // If power on key is not found
+        if (BRAM[0x76] != 0xEC) {
+            // Set the key
+            BRAM[0x76] = 0xEC;
+
+            // Power on system
+            power_on_s5();
+        }
     }
 
     // Check if the adapter line goes low

--- a/src/board/system76/darp5/scratch.c
+++ b/src/board/system76/darp5/scratch.c
@@ -22,6 +22,9 @@ void scratch_trampoline(void) {
 
     //TODO: Clear keyboard presses
 
+    // Clear power on key
+    BRAM[0x76] = 0;
+
     // Start watchdog timer
     smfi_watchdog();
 

--- a/src/board/system76/galp3-c/power.c
+++ b/src/board/system76/galp3-c/power.c
@@ -7,6 +7,7 @@
 #include <board/pmc.h>
 #include <board/pnp.h>
 #include <common/debug.h>
+#include <ec/bram.h>
 
 // Platform does not currently support Deep Sx
 #define DEEP_SX 0
@@ -255,6 +256,15 @@ void power_event(void) {
     // Always switch to ds5 if EC is running
     if (power_state == POWER_STATE_DEFAULT) {
         power_on_ds5();
+
+        // If power on key is not found
+        if (BRAM[0x76] != 0xEC) {
+            // Set the key
+            BRAM[0x76] = 0xEC;
+
+            // Power on system
+            power_on_s5();
+        }
     }
 
     // Check if the adapter line goes low

--- a/src/board/system76/galp3-c/scratch.c
+++ b/src/board/system76/galp3-c/scratch.c
@@ -22,6 +22,9 @@ void scratch_trampoline(void) {
 
     //TODO: Clear keyboard presses
 
+    // Clear power on key
+    BRAM[0x76] = 0;
+
     // Start watchdog timer
     smfi_watchdog();
 

--- a/src/board/system76/lemp9/power.c
+++ b/src/board/system76/lemp9/power.c
@@ -7,6 +7,7 @@
 #include <board/pmc.h>
 #include <board/pnp.h>
 #include <common/debug.h>
+#include <ec/bram.h>
 
 // Platform does not currently support Deep Sx
 #define DEEP_SX 0
@@ -255,6 +256,15 @@ void power_event(void) {
     // Always switch to ds5 if EC is running
     if (power_state == POWER_STATE_DEFAULT) {
         power_on_ds5();
+
+        // If power on key is not found
+        if (BRAM[0x76] != 0xEC) {
+            // Set the key
+            BRAM[0x76] = 0xEC;
+
+            // Power on system
+            power_on_s5();
+        }
     }
 
     // Check if the adapter line goes low

--- a/src/board/system76/lemp9/scratch.c
+++ b/src/board/system76/lemp9/scratch.c
@@ -3,6 +3,7 @@
 
 #include <board/smfi.h>
 #include <common/macro.h>
+#include <ec/bram.h>
 #include <ec/pwm.h>
 
 // Include scratch ROM
@@ -21,6 +22,9 @@ void scratch_trampoline(void) {
     DCR2 = 0xFF;
 
     //TODO: Clear keyboard presses
+
+    // Clear power on key
+    BRAM[0x76] = 0;
 
     // Start watchdog timer
     smfi_watchdog();

--- a/src/ec/it5570e/include/ec/bram.h
+++ b/src/ec/it5570e/include/ec/bram.h
@@ -1,0 +1,8 @@
+#ifndef _EC_BRAM_H
+#define _EC_BRAM_H
+
+#include <stdint.h>
+
+volatile uint8_t __xdata __at(0x2200) BRAM[192];
+
+#endif // _EC_BRAM_H

--- a/src/ec/it8587e/include/ec/bram.h
+++ b/src/ec/it8587e/include/ec/bram.h
@@ -1,0 +1,8 @@
+#ifndef _EC_BRAM_H
+#define _EC_BRAM_H
+
+#include <stdint.h>
+
+volatile uint8_t __xdata __at(0x2200) BRAM[192];
+
+#endif // _EC_BRAM_H


### PR DESCRIPTION
This adds a flag stored in battery-backed RAM that will cause the EC to power on automatically if it is not set to a magic value.

This flag is cleared when entering the scratch ROM, ensuring that the system automatically powers on when flashed.