### PR TITLE
lemp9: lower maximum fan speed

### DIFF
--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -38,7 +38,8 @@ struct FanPoint __code FAN_POINTS[] = {
     FAN_POINT(70, 40),
     FAN_POINT(75, 50),
     FAN_POINT(80, 60),
-    FAN_POINT(90, 60)
+    FAN_POINT(85, 65),
+    FAN_POINT(90, 65)
 };
 
 // Get duty cycle based on temperature, adapted from

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -35,10 +35,10 @@ struct FanPoint {
 
 // Fan curve with temperature in degrees C, duty cycle in percent
 struct FanPoint __code FAN_POINTS[] = {
-    FAN_POINT(65,  40),
-    FAN_POINT(70,  55),
-    FAN_POINT(75,  75),
-    FAN_POINT(80, 100)
+    FAN_POINT(70, 40),
+    FAN_POINT(75, 50),
+    FAN_POINT(80, 60),
+    FAN_POINT(90, 60)
 };
 
 // Get duty cycle based on temperature, adapted from


### PR DESCRIPTION
This adjusts the fan curve to start at 70C instead of 65C, and max out at 60%. Tests with stress-ng indicate that this still is able to prevent thermal throttling, system is still able to run CPU above 20W power limit 1, and frequencies are as expected with a TDP-up system. Fan speeds of 40% and 75% were tested as well. 40% led to thermal runaway and lower performance (18W CPU power when thermals settled). 75% was overkill, kept CPU well below thermal throttling limit. 60% keeps the CPU indefinitely near the throttling limit while also maintaining 20W CPU power.

In short, the new maximum value of 60% is a goldilocks zone for quiet operation and high performance. It appears that users prefer increased heat to the jet aircraft noises this system makes at 100%. Please test that chassis temperature is still good.