### PR TITLE
RFC: Enable user-configurable settings including Fn Lock, Debounce, etc

### DIFF
--- a/src/arch/8051/arch.mk
+++ b/src/arch/8051/arch.mk
@@ -18,7 +18,7 @@ $(BUILD)/ec.rom: $(BUILD)/ec.ihx
 # Link object files into Intel Hex file
 $(BUILD)/ec.ihx: $(OBJ)
 	@mkdir -p $(@D)
-	$(CC) -o $@ $^
+	$(CC) $(LDFLAGS) -o $@ $^
 
 # Compile C files into object files
 $(OBJ): $(BUILD)/%.rel: src/%.c $(INCLUDE)

--- a/src/arch/8051/arch.mk
+++ b/src/arch/8051/arch.mk
@@ -1,4 +1,5 @@
-CC=sdcc -mmcs51 --model-large --Werror
+CODE_SIZE=65536
+CC=sdcc -mmcs51 --model-large --code-size ${CODE_SIZE} --Werror
 OBJ=$(patsubst src/%.c,$(BUILD)/%.rel,$(SRC))
 
 # Run EC rom in simulator
@@ -12,7 +13,7 @@ sim: $(BUILD)/ec.rom
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
 	@mkdir -p $(@D)
-	makebin -p < $< > $@
+	makebin -s ${CODE_SIZE} -p < $< > $@
 
 # Link object files into Intel Hex file
 $(BUILD)/ec.ihx: $(OBJ)

--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -25,6 +25,9 @@ CFLAGS+=-I$(SYSTEM76_COMMON_DIR)/include
 # Add scratch ROM
 include $(SYSTEM76_COMMON_DIR)/scratch/scratch.mk
 
+# Add scratch ROM for flash access
+include $(SYSTEM76_COMMON_DIR)/flash/flash.mk
+
 console_internal:
 	cargo build --manifest-path tool/Cargo.toml --release
 	sudo tool/target/release/system76_ectool console

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -1,0 +1,56 @@
+# Set flash ROM parameters
+FLASH_OFFSET=2048
+FLASH_SIZE=1024
+CFLAGS+=-DFLASH_OFFSET=$(FLASH_OFFSET) -DFLASH_SIZE=$(FLASH_SIZE)
+
+# Copy parameters to use when compiling flash ROM
+FLASH_INCLUDE=$(INCLUDE)
+FLASH_CFLAGS=$(CFLAGS)
+
+# Include flash source.
+FLASH_DIR=$(SYSTEM76_COMMON_DIR)/flash
+# Note: main.c *must* be first to ensure that flash_start is at the correct address
+FLASH_SRC=$(FLASH_DIR)/main.c
+FLASH_INCLUDE+=$(wildcard $(FLASH_DIR)/include/flash/*.h) $(FLASH_DIR)/flash.mk
+FLASH_CFLAGS+=-I$(FLASH_DIR)/include -D__FLASH__
+
+# Add minimal source from other directories
+FLASH_SRC+=
+
+FLASH_BUILD=$(BUILD)/flash
+FLASH_OBJ=$(patsubst src/%.c,$(FLASH_BUILD)/%.rel,$(FLASH_SRC))
+FLASH_CC=\
+	sdcc \
+	-mmcs51 \
+	--model-large \
+	--opt-code-size \
+	--acall-ajmp \
+	--code-loc $(FLASH_OFFSET) \
+	--code-size $(FLASH_SIZE) \
+	--Werror
+
+# Convert from binary file to C header
+$(BUILD)/include/flash.h: $(FLASH_BUILD)/flash.rom
+	@mkdir -p $(@D)
+	xxd -s $(FLASH_OFFSET) --include < $< > $@
+
+# Convert from Intel Hex file to binary file
+$(FLASH_BUILD)/flash.rom: $(FLASH_BUILD)/flash.ihx
+	@mkdir -p $(@D)
+	makebin -p < $< > $@
+
+# Link object files into Intel Hex file
+$(FLASH_BUILD)/flash.ihx: $(FLASH_OBJ)
+	@mkdir -p $(@D)
+	$(FLASH_CC) -o $@ $^
+
+# Compile C files into object files
+$(FLASH_OBJ): $(FLASH_BUILD)/%.rel: src/%.c $(FLASH_INCLUDE)
+	@mkdir -p $(@D)
+	$(FLASH_CC) $(FLASH_CFLAGS) -o $@ -c $<
+
+# Include flash header in main firmware
+CFLAGS+=-I$(BUILD)/include
+LDFLAGS+=-Wl -g_flash_entry=$(FLASH_OFFSET)
+INCLUDE+=$(BUILD)/include/flash.h
+SRC+=$(FLASH_DIR)/wrapper.c

--- a/src/board/system76/common/flash/main.c
+++ b/src/board/system76/common/flash/main.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2020 Evan Lojewski
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdint.h>
+#include <board/flash.h>
+
+// EC indirect flash access
+volatile uint8_t __xdata __at(0x103B) ECINDAR0;
+volatile uint8_t __xdata __at(0x103C) ECINDAR1;
+volatile uint8_t __xdata __at(0x103D) ECINDAR2;
+volatile uint8_t __xdata __at(0x103E) ECINDAR3;
+volatile uint8_t __xdata __at(0x103F) ECINDDR;
+
+#define SPI_DEVICE                  (0x70)
+#define SPI_FOLLOW_MODE             (0x0F)
+#define SPI_CHIP_SELECT             (0xFD)
+#define SPI_CHIP_DESELECT           (0xFE)
+
+#define SPI_READ_STATUS_COMMAND     (0x05)
+#define SPI_READ_COMMAND            (0x0B)
+#define SPI_WRITE_COMMAND           (0x02)
+#define SPI_WRITE_ENABLE_COMMAND    (0x06)
+#define SPI_READ_STATUS_COMMAND     (0x05)
+
+#define SPI_ERASE_SECTOR_COMMAND    (0xD7)
+
+#define SPI_STATUS_WIP              (0x01)
+
+void flash_enter_follow_mode(void);
+void flash_exit_follow_mode(void);
+void flash_wait(void);
+void flash_write_enable(void);
+
+/**
+ * Main flash API entry point.
+ *
+ * NOTE: This *must* be the first function in this file to ensure that it is placed
+ *          first in the resulting binary. This is required to ensure that address
+ *          matches the address (FLASH_OFFSET) for flash_entry in wrapper.c.
+ * NOTE: __reentrant so that parameters and temperary vairables are placed on the
+ *          stack, ensuring the main application __data variables are not stomped on.
+ * NOTE: __critical to ensure interrupts are disabled. This does mean that interrupt
+ *          such as the timer will be block until flash acccess is complete
+ */
+void flash_entry(uint32_t addr, uint8_t * data, uint8_t length, uint8_t command) __reentrant __critical {
+    // Only allow access from 64KB to 128KB.
+    if (addr < 0x10000 || addr >= 0x20000 || (addr + length) > 0x20000) return;
+
+    if (command == FLASH_COMMAND_READ) {
+        while (length) {
+            // Fast read.
+            ECINDAR3 = SPI_DEVICE;
+            ECINDAR2 = addr >> 16;
+            ECINDAR1 = addr >> 8;
+            ECINDAR0 = addr;
+
+            *data = ECINDDR;
+
+            addr++;
+            data++;
+            length--;
+        }
+    } else if (command == FLASH_COMMAND_WRITE) {
+        flash_enter_follow_mode();
+
+        while (length) {
+            // Note, this is the slow way to do it, but it's simple and all bytes are written properly.
+            flash_write_enable();
+
+            // Select the device
+            ECINDAR1 = SPI_CHIP_SELECT;
+
+            // Send write command
+            ECINDDR = SPI_WRITE_COMMAND;
+            ECINDDR = addr >> 16;
+            ECINDDR = addr >> 8;
+            ECINDDR = addr;
+
+            ECINDDR = *data;
+
+            data++;
+            length--;
+            addr++;
+
+            // Deselect
+            ECINDAR1 = SPI_CHIP_DESELECT;
+            ECINDDR  = 0x00;
+
+
+            // Wait WIP to be cleared
+            flash_wait();
+        }
+
+        flash_exit_follow_mode();
+    } else if (command == FLASH_COMMAND_ERASE_1K) {
+        flash_enter_follow_mode();
+
+        flash_write_enable();
+
+        // Select the device
+        ECINDAR1 = SPI_CHIP_SELECT;
+
+        // Send erase command
+        ECINDDR = SPI_ERASE_SECTOR_COMMAND;
+        ECINDDR = addr >> 16;
+        ECINDDR = addr >> 8;
+        ECINDDR = addr;
+
+        // Deselect
+        ECINDAR1 = SPI_CHIP_DESELECT;
+        ECINDDR  = 0x00;
+
+        // Wait WIP to be cleared
+        flash_wait();
+
+        flash_exit_follow_mode();
+    }
+}
+
+void flash_enter_follow_mode(void) {
+    // Enter follow mode.
+    ECINDAR3 = SPI_FOLLOW_MODE | SPI_DEVICE;
+    ECINDAR2 = 0xFF;
+    ECINDAR1 = SPI_CHIP_DESELECT;
+    ECINDAR0 = 0x00;
+    ECINDDR = 0x00;
+}
+
+void flash_exit_follow_mode(void) {
+    // Exit follow mode
+    ECINDAR3 = SPI_DEVICE;
+    ECINDAR2 = 0;
+    ECINDAR1 = 0;
+    ECINDAR0 = 0;
+}
+
+void flash_wait(void) {
+    uint8_t status;
+
+    do {
+        // Select the device
+        ECINDAR1 = SPI_CHIP_SELECT;
+
+        // Send command
+        ECINDDR = SPI_READ_STATUS_COMMAND;
+
+        // read status
+        status = ECINDDR;
+
+        // Deselect
+        ECINDAR1 = SPI_CHIP_DESELECT;
+        ECINDDR  = 0x00;
+    } while(status & SPI_STATUS_WIP);
+}
+
+void flash_write_enable(void) {
+    // Select the device
+    ECINDAR1 = SPI_CHIP_SELECT;
+
+    // Send device id command
+    ECINDDR = SPI_WRITE_ENABLE_COMMAND;
+
+    // Deselect
+    ECINDAR1 = SPI_CHIP_DESELECT;
+    ECINDDR  = 0x00;
+}

--- a/src/board/system76/common/flash/wrapper.c
+++ b/src/board/system76/common/flash/wrapper.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 Evan Lojewski
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <board/flash.h>
+#include <common/ec.h>
+
+#if __EC__ == it5570e
+// IT5570: SCAR0 is stored in processor cache, not in xram
+volatile uint8_t __xdata __at(0x1040) SCAR0L;
+volatile uint8_t __xdata __at(0x1041) SCAR0M;
+volatile uint8_t __xdata __at(0x1042) SCAR0H;
+
+#define SCARL SCAR0L
+#define SCARM SCAR0M
+#define SCARH SCAR0H
+
+#elif __EC__ == it8587e
+// IT8587: SCAR1 is in xram at 0x800-0xC00
+volatile uint8_t __xdata __at(0x1043) SCAR1L;
+volatile uint8_t __xdata __at(0x1044) SCAR1M;
+volatile uint8_t __xdata __at(0x1045) SCAR1H;
+
+#define SCARL SCAR1L
+#define SCARM SCAR1M
+#define SCARH SCAR1H
+
+#else
+#error Unknown EC
+#endif
+
+
+void flash_entry(uint32_t addr, uint8_t * data, uint8_t length, uint8_t command) __reentrant;
+
+// Include flash ROM
+uint8_t __code __at(FLASH_OFFSET) flash_rom[] = {
+    #include <flash.h>
+};
+
+void flash_init(void) {
+    // Use DMA mapping to copy flash data
+    SCARH = 0x80;
+    SCARL = (uint8_t)(FLASH_OFFSET);
+    SCARM = (uint8_t)(FLASH_OFFSET >> 8);
+    SCARH = 0;
+}
+
+void flash_read(uint32_t addr, __xdata uint8_t * data, uint8_t length) {
+    flash_entry(addr, data, length, FLASH_COMMAND_READ);
+}
+
+uint32_t flash_read_u32(uint32_t addr) {
+    uint32_t data;
+
+    flash_entry(addr, (uint8_t *)&data, sizeof(data), FLASH_COMMAND_READ);
+
+    return data;
+}
+
+uint16_t flash_read_u16(uint32_t addr) {
+    uint16_t data;
+
+    flash_entry(addr, (uint8_t *)&data, sizeof(data), FLASH_COMMAND_READ);
+
+    return data;
+}
+
+uint8_t flash_read_u8(uint32_t addr) {
+    uint8_t data;
+
+    flash_entry(addr, &data, sizeof(data), FLASH_COMMAND_READ);
+
+    return data;
+}
+
+void flash_write(uint32_t addr, __xdata uint8_t *data, uint8_t length) {
+    flash_entry(addr, data, length, FLASH_COMMAND_WRITE);
+}
+
+void flash_write_u32(uint32_t addr, uint32_t data) {
+    flash_entry(addr, (uint8_t *)&data, sizeof(data), FLASH_COMMAND_WRITE);
+}
+
+void flash_write_u16(uint32_t addr, uint16_t data) {
+    flash_entry(addr, (uint8_t *)&data, sizeof(data), FLASH_COMMAND_WRITE);
+}
+
+void flash_write_u8(uint32_t addr, uint8_t data) {
+    flash_entry(addr, &data, sizeof(data), FLASH_COMMAND_WRITE);
+}
+
+void flash_erase(uint32_t addr) {
+    flash_entry(addr, NULL, 0, FLASH_COMMAND_ERASE_1K);
+}

--- a/src/board/system76/common/include/board/flash.h
+++ b/src/board/system76/common/include/board/flash.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2020 Evan Lojewski
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef _BOARD_FLASH_H
+#define _BOARD_FLASH_H
+
+#include <stdint.h>
+
+/** \cond INTERNAL
+ * Internal defines
+ */
+#define FLASH_COMMAND_READ      (0x0)
+#define FLASH_COMMAND_WRITE     (0x1)
+#define FLASH_COMMAND_ERASE_1K  (0x2)
+/** \endcond */
+
+/**
+ * Intiailize hardware for the flash APIs.
+ *
+ * Note: This uses SCAR0 (it5570e) or SCAR1 (it8587e) to place the flash APIs into RAM.
+ */
+void flash_init(void);
+
+/**
+ * Read data from flash to the specified buffer.
+ *
+ * \param[in]  addr   The flash address to read.
+ * \param[out] data   The memory area to copy to.
+ * \param[in]  length The number of bytes to copy.
+ */
+void flash_read(uint32_t addr, __xdata uint8_t * data, uint8_t length);
+
+/**
+ * Read a single byte from flash.
+ *
+ * \param[in] addr   The flash address to read.
+ *
+ * \return The value read from flash.
+ */
+uint8_t flash_read_u8(uint32_t addr);
+
+/**
+ * Read two bytes from flash.
+ *
+ * \param[in] addr   The flash address to read.
+ *
+ * \return The value read from flash.
+ */
+uint16_t flash_read_u16(uint32_t addr);
+
+/**
+ * Read four bytes from flash.
+ *
+ * \param[in] addr   The flash address to read.
+ *
+ * \return The value read from flash.
+ */
+uint32_t flash_read_u32(uint32_t addr);
+
+/**
+ * Write data to flash from the specified buffer.
+ *
+ * \param[in] addr   The flash address to read.
+ * \param[in] data   The memory area to copy from.
+ * \param[in] length The number of bytes to copy.
+ */
+void flash_write(uint32_t addr, __xdata uint8_t * data, uint8_t length);
+
+/**
+ * Write a single byte to flash.
+ *
+ * \param[in] addr   The flash address to read.
+ * \param[in] data   The value to write to flash.
+ */
+void flash_write_u8(uint32_t addr, uint8_t data);
+
+/**
+ * Write two bytes to flash.
+ *
+ * \param[in] addr   The flash address to read.
+ * \param[in] data   The value to write to flash.
+ */
+void flash_write_u16(uint32_t addr, uint16_t data);
+
+/**
+ * Write two bytes to flash.
+ *
+ * \param[in] addr   The flash address to read.
+ * \param[in] data   The value to write to flash.
+ */
+void flash_write_u32(uint32_t addr, uint32_t data);
+
+/**
+ * Erase a 1K block of flash.
+ *
+ * \param[in] addr  The flash address contained in the 1K block.
+ */
+void flash_erase(uint32_t addr);
+
+#endif // _BOARD_FLASH_H

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -8,6 +8,7 @@
 #include <board/board.h>
 #include <board/dgpu.h>
 #include <board/ecpm.h>
+#include <board/flash.h>
 #include <board/gpio.h>
 #include <board/gctrl.h>
 #include <board/kbc.h>
@@ -46,6 +47,7 @@ void init(void) {
     arch_init();
     ec_init();
     gctrl_init();
+    flash_init();
     gpio_init();
 
     // Can happen in any order

--- a/src/board/system76/common/smfi.c
+++ b/src/board/system76/common/smfi.c
@@ -298,6 +298,14 @@ void smfi_event(void) {
             case CMD_SET_CONFIG_VALUE:
                 smfi_cmd[1] = cmd_config_set_value_by_index();
                 break;
+            case CMD_COMPACT_CONFIG:
+                if (config_save_entries()) {
+                    smfi_cmd[1] = RES_OK;
+                } else {
+                    smfi_cmd[1] = RES_ERR;
+                }
+                break;
+
 
 #endif // __SCRATCH__
             default:

--- a/src/common/config.c
+++ b/src/common/config.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2020 Evan Lojewski
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <board/flash.h>
+#include <common/config.h>
+#include <common/debug.h>
+#include <stddef.h>
+#include <string.h>
+
+// Prevent failures to compile on AVR
+#ifndef __SDCC
+    #define __code
+#endif
+
+config_t *g_config_entries = NULL;
+
+#define CONFIG_ADDRESS  (0x10000L)
+#define CONFIG_SIZE   (1 * 1024)  /* 1K block - code currently assumes this matches the erase size */
+#define CONFIG_PERSISTANT_MAGIC     (0xCF1C0F11)
+#define CONFIG_HEADER_SIZE          (sizeof(uint32_t) + 4) /* Magic number plus four reserved bytes */
+
+#define CONFIG_ENTRIES_START        (CONFIG_ADDRESS + CONFIG_HEADER_SIZE)
+
+uint32_t __code __at(CONFIG_ADDRESS) config_magic;
+uint8_t __code __at(CONFIG_ENTRIES_START) config_persistant[CONFIG_SIZE - CONFIG_HEADER_SIZE];
+
+#define CONFIG_FLASH_ENTRY_EMPTY            (0xFFFFFFFF)
+#define CONFIG_FLASH_ENTRY_CURRENT          (0xFF)
+#define CONFIG_FLASH_ENTRY_OBSOLETE         (0x00)
+
+// config_persistant format
+// (4) bytes: Configuration ID, 0xFFFFFFFF when an entry is not set.
+// (1) bytes: Entry current (valid) or obsolete (invalid)
+// (1) bytes: Entry type (0xFF: 32bit value follows)
+// (4) bytes: Configuration Value
+#define CONFIG_FLASH_ENTRY_ID_OFFSET        (0)
+#define CONFIG_FLASH_ENTRY_CURRENT_OFFSET   (4)
+#define CONFIG_FLASH_ENTRY_TYPE_OFFSET      (5) /* Unused - RFU */
+#define CONFIG_FLASH_ENTRY_VALUE_OFFSET     (6)
+#define CONFIG_FLASH_ENTRY_SIZE             (10)
+
+uint8_t config_validate_magic(void) {
+    uint32_t magic = flash_read_u32(CONFIG_ADDRESS);
+
+    return (CONFIG_PERSISTANT_MAGIC == magic);
+}
+
+uint32_t config_find_free_entry() {
+    if (!config_validate_magic()) {
+        // Write magic.
+        flash_write_u32(CONFIG_ADDRESS, CONFIG_PERSISTANT_MAGIC);
+
+        // Check that that magic wrote properly. If not, we'll need to erase.
+        if (!config_validate_magic()) {
+            return 0;
+        }
+    }
+
+    uint32_t addr = CONFIG_ENTRIES_START;
+    uint32_t limit = addr + sizeof(config_persistant);
+    while(addr < limit) {
+        // configuration present.
+        uint32_t id;
+        id = flash_read_u32(addr + CONFIG_FLASH_ENTRY_ID_OFFSET);
+
+        if(CONFIG_FLASH_ENTRY_EMPTY == id) {
+            // Free entry found.
+            return addr;
+        }
+
+        // Go to the next entry.
+        addr += CONFIG_FLASH_ENTRY_SIZE;
+    }
+
+    return 0;
+}
+
+void config_save_entry_id(uint32_t addr, uint32_t id) {
+    flash_write_u32(addr + CONFIG_FLASH_ENTRY_ID_OFFSET, id);
+}
+
+void config_save_entry_value(uint32_t addr, int32_t value) {
+    flash_write_u32(addr + CONFIG_FLASH_ENTRY_VALUE_OFFSET, value);
+}
+
+bool config_save_entry(config_t *entry) {
+    uint32_t id = (uint32_t)entry->config_id[3] << 24 | (uint32_t)entry->config_id[2] << 16 | (uint32_t)entry->config_id[1] << 8 | entry->config_id[0];
+    int32_t value = entry->value.value;
+    uint32_t addr = config_find_free_entry();
+
+    if (addr && ((addr + CONFIG_FLASH_ENTRY_SIZE - CONFIG_ADDRESS) < sizeof(config_persistant))) {
+        DEBUG("Saving config: %s", entry->config_short);
+        DEBUG(" = %ld\n", value);
+
+        config_save_entry_id(addr, id);
+
+        config_save_entry_value(addr, value);
+
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void config_save_entries() __reentrant {
+    flash_erase(CONFIG_ADDRESS);
+
+    config_t *entry = g_config_entries;
+
+    while (entry) {
+        (void)config_save_entry(entry);
+        entry = entry->next;
+    }
+}
+
+bool config_flash_valid(uint32_t addr) {
+    return (CONFIG_FLASH_ENTRY_CURRENT == flash_read_u8(addr + CONFIG_FLASH_ENTRY_CURRENT_OFFSET));
+}
+
+uint32_t config_flash_id(uint32_t addr) {
+    return flash_read_u32(addr + CONFIG_FLASH_ENTRY_ID_OFFSET);
+}
+
+int32_t config_flash_value(uint32_t addr) {
+    return flash_read_u32(addr + CONFIG_FLASH_ENTRY_VALUE_OFFSET);
+}
+
+uint32_t condif_flash_next(uint32_t addr) {
+    return addr + CONFIG_FLASH_ENTRY_SIZE;
+}
+
+uint32_t config_find_entry(const unsigned char config_id[4]) {
+    uint32_t int_id = (uint32_t)config_id[3] << 24 | (uint32_t)config_id[2] << 16 | (uint32_t)config_id[1] << 8 | config_id[0];
+
+    if(config_validate_magic()) {
+        uint32_t addr = CONFIG_ENTRIES_START;
+        uint32_t limit = addr + sizeof(config_persistant);
+
+        while(addr < limit) {
+            uint32_t id;
+            // configuration present.
+            id = config_flash_id(addr);
+
+            if(id == CONFIG_FLASH_ENTRY_EMPTY) {
+                // no more entries exist.
+                break;
+            }
+
+            if(config_flash_valid(addr)) {
+                if(int_id == id) {
+                    return addr;
+                }
+            }
+
+            // Go to the next entry.
+            addr = condif_flash_next(addr);
+        }
+    }
+
+    // Not found.
+    return 0;
+}
+
+void config_invalidate_entry(uint32_t addr) {
+    if (addr) {
+        flash_write_u8(addr + CONFIG_FLASH_ENTRY_CURRENT_OFFSET, CONFIG_FLASH_ENTRY_OBSOLETE);
+    }
+}
+
+bool config_register(config_t *entry) __reentrant {
+    // Validate entry parameters.
+    if (!entry) {
+        return false;
+    }
+
+    // Short name and desc must be set.
+    if (!entry->config_short || !entry->config_desc) {
+        return false;
+    }
+
+    // Config validated, register it
+    entry->next = g_config_entries;
+    g_config_entries = entry;
+
+    // Read the stored value from flash, if present.
+    uint32_t flash_addr = config_find_entry(entry->config_id);
+    if (flash_addr) {
+        int32_t saved_value = config_flash_value(flash_addr);
+
+        int64_t min = entry->value.min_value;
+        int64_t max = entry->value.max_value;
+
+        if (min <= saved_value &&
+            max >= saved_value) {
+            entry->value.value = saved_value;
+
+            /* Notify any listeners. */
+            if (entry->set_callback) {
+                entry->set_callback(entry);
+            }
+        }
+    }
+
+
+    return true;
+}
+
+config_t *config_get_config(const char *config_short) {
+    config_t *current = g_config_entries;
+
+    while (current && 0 != strcmp(current->config_short, config_short)) {
+        current = current->next;
+    }
+
+    return current;
+}
+
+config_t *config_next(config_t *current) {
+    if (current) {
+        current = current->next;
+    }
+
+    return current;
+}
+
+config_t *config_index(int32_t index) {
+    config_t *current = g_config_entries;
+
+    while (current && index) {
+        current = current->next;
+        index = index - 1;
+    }
+
+    return current;
+}
+
+int32_t config_get_value(config_t *config) __reentrant {
+    if (config) {
+        return config->value.value;
+    }
+    else {
+        // Invalid
+        return 0;
+    }
+
+}
+
+bool config_set_value(config_t *config, int32_t value) __reentrant {
+    bool valid = false;
+
+    if (config) {
+        bool saved = true;
+        int64_t min = config->value.min_value;
+        int64_t max = config->value.max_value;
+
+        if (min <= value &&
+            max >= value) {
+            config->value.value = value;
+            valid = true;
+
+            /* Save the new value to flash, if it's changed */
+            uint32_t flash_addr = config_find_entry(config->config_id);
+
+            if (flash_addr) {
+                int32_t oldval = config_flash_value(flash_addr);
+
+                if(oldval != value) {
+                    config_invalidate_entry(flash_addr);
+                    saved = config_save_entry(config);
+                }
+            } else {
+                // No entry, create one.
+                saved = config_save_entry(config);
+            }
+
+            /* Notify any listeners. */
+            if (config->set_callback) {
+                config->set_callback(config);
+            }
+        }
+
+        if (!saved) {
+            // Not enough space exists. clear out flash and re-write.
+            flash_erase(CONFIG_ADDRESS);
+
+            config_save_entries();
+
+        }
+    }
+
+    return valid;
+}

--- a/src/common/config.c
+++ b/src/common/config.c
@@ -105,15 +105,21 @@ bool config_save_entry(config_t *entry) {
     }
 }
 
-void config_save_entries() __reentrant {
+bool config_save_entries() __reentrant {
+    bool status = true;
+
     flash_erase(CONFIG_ADDRESS);
 
     config_t *entry = g_config_entries;
 
     while (entry) {
-        (void)config_save_entry(entry);
+        if (!config_save_entry(entry)) {
+            status = false;
+        }
         entry = entry->next;
     }
+
+    return status;
 }
 
 bool config_flash_valid(uint32_t addr) {
@@ -286,7 +292,9 @@ bool config_set_value(config_t *config, int32_t value) __reentrant {
             // Not enough space exists. clear out flash and re-write.
             flash_erase(CONFIG_ADDRESS);
 
-            config_save_entries();
+            if (!config_save_entries()) {
+                valid = false;
+            }
 
         }
     }

--- a/src/common/i2c.c
+++ b/src/common/i2c.c
@@ -1,6 +1,6 @@
 #include <common/i2c.h>
 
-int i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, int length) {
+int i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, int length) __reentrant {
     int res = 0;
 
     res = i2c_start(i2c, addr, true);
@@ -14,7 +14,7 @@ int i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, int length) {
 	return res;
 }
 
-int i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, int length) {
+int i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, int length) __reentrant {
     int res = 0;
 
     res = i2c_start(i2c, addr, false);
@@ -28,7 +28,7 @@ int i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, int length) {
 	return res;
 }
 
-int i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int length) {
+int i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int length) __reentrant {
     int res = 0;
 
     res = i2c_start(i2c, addr, false);
@@ -40,7 +40,7 @@ int i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int leng
     return i2c_recv(i2c, addr, data, length);
 }
 
-int i2c_set(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int length) {
+int i2c_set(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int length) __reentrant {
     int res = 0;
 
     res = i2c_start(i2c, addr, false);

--- a/src/common/include/common/command.h
+++ b/src/common/include/common/command.h
@@ -20,6 +20,16 @@ enum Command {
     CMD_FAN_GET = 7,
     // Set fan speeds
     CMD_FAN_SET = 8,
+
+    // Get Config by name from index.
+    CMD_GET_CONFIG_NAME = 32,
+    // Get configuration descrption from index.
+    CMD_GET_CONFIG_DESC = 33,
+    // Get config value from index
+    CMD_GET_CONFIG_VALUE = 34,
+    // Set config value from index
+    CMD_SET_CONFIG_VALUE = 35,
+
     //TODO
 };
 

--- a/src/common/include/common/command.h
+++ b/src/common/include/common/command.h
@@ -29,6 +29,8 @@ enum Command {
     CMD_GET_CONFIG_VALUE = 34,
     // Set config value from index
     CMD_SET_CONFIG_VALUE = 35,
+    // Compact the configuration data in flash.
+    CMD_COMPACT_CONFIG = 36,
 
     //TODO
 };

--- a/src/common/include/common/config.h
+++ b/src/common/include/common/config.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Evan Lojewski
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef _COMMON_CONFIG_H
+#define _COMMON_CONFIG_H
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct config_t;
+typedef struct config_t config_t;
+
+typedef void (*config_callback_t)(struct config_t *entry);
+
+typedef struct {
+    int32_t max_value;
+    int32_t min_value;
+    int32_t value;
+} config_value_t;
+
+struct config_t {
+    const unsigned char config_id[4]; /* Note: SDCC does not support uint32_t being set to values such as 'ASCI', as such, this an explicit array instead */
+    const char *config_short;
+    const char *config_desc;
+    config_callback_t set_callback;
+    config_value_t value;
+    struct config_t* next;
+} __xdata;
+
+/**
+ * Register a configuration type
+ */
+bool config_register(config_t *entry) __reentrant;
+
+/**
+ * Get the configuration handler for a given name.
+ */
+config_t *config_get_config(const char *config_short);
+
+/**
+ * Get the configuration handler by index.
+ */
+config_t *config_index(int32_t index);
+
+/**
+ * Get the next registered configuration item.
+ */
+config_t *config_next(config_t *current);
+
+/**
+ * Update the configuration value, calling callbacks as needed.
+ */
+bool config_set_value(config_t *config, int32_t value) __reentrant;
+
+/**
+ * Retrieve the current configuration value
+ */
+int32_t config_get_value(config_t *config) __reentrant;
+
+#endif // _COMMON_CONFIG_H

--- a/src/common/include/common/config.h
+++ b/src/common/include/common/config.h
@@ -61,4 +61,12 @@ bool config_set_value(config_t *config, int32_t value) __reentrant;
  */
 int32_t config_get_value(config_t *config) __reentrant;
 
+/**
+ * Rewrite all configuration values into flash.
+ *
+ * Note: This will compact flash by erasing and then writing
+ * all known configuration values.
+ */
+bool config_save_entries() __reentrant;
+
 #endif // _COMMON_CONFIG_H

--- a/src/common/include/common/ec.h
+++ b/src/common/include/common/ec.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef _COMMON_EC_H
+#define _COMMON_EC_H
+
+#ifndef __EC__
+#error __EC__ must be defined
+#endif
+
+#define it5570e 5570
+#define it8587e 8587
+#define atmega328p 328
+#define atmega32u4  32
+#define atmega2560  2560
+
+#endif // _COMMON_EC_H

--- a/src/common/include/common/i2c.h
+++ b/src/common/include/common/i2c.h
@@ -9,30 +9,30 @@ struct I2C;
 
 // Start i2c transaction
 // Must be defined by arch, board, or ec
-int i2c_start(struct I2C * i2c, uint8_t addr, bool read);
+int i2c_start(struct I2C * i2c, uint8_t addr, bool read) __reentrant;
 
 // Stop i2c transaction
 // Must be defined by arch, board, or ec
-void i2c_stop(struct I2C * i2c);
+void i2c_stop(struct I2C * i2c) __reentrant;
 
 // Send a byte on i2c bus
 // Must be defined by arch, board, or ec
-int i2c_write(struct I2C * i2c, uint8_t * data, int length);
+int i2c_write(struct I2C * i2c, uint8_t * data, int length) __reentrant;
 
 // Read bytes from bus
 // Must be defined by arch, board, or ec
-int i2c_read(struct I2C * i2c, uint8_t * data, int length);
+int i2c_read(struct I2C * i2c, uint8_t * data, int length) __reentrant;
 
 // Read multiple bytes from address in one transaction
-int i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, int length);
+int i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, int length) __reentrant;
 
 // Write multiple bytes to address in one transaction
-int i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, int length);
+int i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, int length) __reentrant;
 
 // Read multiple bytes from a register in one transaction
-int i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int length);
+int i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int length) __reentrant;
 
 // Write multiple bytes to a register in one transaction
-int i2c_set(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int length);
+int i2c_set(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int length) __reentrant;
 
 #endif // _COMMON_I2C_H

--- a/src/ec/it5570e/i2c.c
+++ b/src/ec/it5570e/i2c.c
@@ -53,7 +53,7 @@ void i2c_reset(struct I2C * i2c, bool kill) {
     *(i2c->hoctl2) = 0;
 }
 
-int i2c_start(struct I2C * i2c, uint8_t addr, bool read) {
+int i2c_start(struct I2C * i2c, uint8_t addr, bool read) __reentrant {
     // If we are already in a transaction
     if (*(i2c->hosta) & HOSTA_BYTE_DONE) {
         // If we are switching direction
@@ -149,10 +149,10 @@ static int i2c_transaction(struct I2C * i2c, uint8_t * data, int length, bool re
     return i;
 }
 
-int i2c_read(struct I2C * i2c, uint8_t * data, int length) {
+int i2c_read(struct I2C * i2c, uint8_t * data, int length) __reentrant {
     return i2c_transaction(i2c, data, length, true);
 }
 
-int i2c_write(struct I2C * i2c, uint8_t * data, int length) {
+int i2c_write(struct I2C * i2c, uint8_t * data, int length) __reentrant {
     return i2c_transaction(i2c, data, length, false);
 }

--- a/src/ec/it8587e/i2c.c
+++ b/src/ec/it8587e/i2c.c
@@ -45,7 +45,7 @@ void i2c_reset(struct I2C * i2c, bool kill) {
     *(i2c->hoctl2) = 0;
 }
 
-int i2c_start(struct I2C * i2c, uint8_t addr, bool read) {
+int i2c_start(struct I2C * i2c, uint8_t addr, bool read) __reentrant {
     // If we are already in a transaction
     if (*(i2c->hosta) & HOSTA_BYTE_DONE) {
         // If we are switching direction
@@ -141,10 +141,10 @@ static int i2c_transaction(struct I2C * i2c, uint8_t * data, int length, bool re
     return i;
 }
 
-int i2c_read(struct I2C * i2c, uint8_t * data, int length) {
+int i2c_read(struct I2C * i2c, uint8_t * data, int length) __reentrant {
     return i2c_transaction(i2c, data, length, true);
 }
 
-int i2c_write(struct I2C * i2c, uint8_t * data, int length) {
+int i2c_write(struct I2C * i2c, uint8_t * data, int length) __reentrant {
     return i2c_transaction(i2c, data, length, false);
 }

--- a/tool/src/ec.rs
+++ b/tool/src/ec.rs
@@ -29,6 +29,7 @@ pub enum Cmd {
     ConfigGetDesc = 33,
     ConfigGetValue = 34,
     ConfigSetValue = 35,
+    ConfigCompact = 36,
 }
 
 pub const CMD_SPI_FLAG_READ: u8 = 1 << 0;
@@ -326,6 +327,13 @@ impl<T: Timeout> Ec<T> {
 
         Ok(())
     }
+
+    pub unsafe fn config_compact(&mut self) -> Result<(), Error> {
+        self.command(Cmd::ConfigCompact)?;
+
+        Ok(())
+    }
+
 }
 
 pub struct EcSpi<'a, T: Timeout> {

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -378,12 +378,23 @@ unsafe fn config_set_value(name: String, value: i32) -> Result<(), Error> {
     }
 }
 
+unsafe fn config_compact() -> Result<(), Error> {
+    iopl();
+
+    let mut ec = Ec::new(
+        StdTimeout::new(Duration::new(1, 0)),
+    )?;
+
+    ec.config_compact()
+}
+
 fn usage() {
     eprintln!("  console");
     eprintln!("  flash [file]");
     eprintln!("  flash_backup [file]");
     eprintln!("  fan [index] <duty>");
     eprintln!("  config <name> <value>");
+    eprintln!("  config_compact");
     eprintln!("  info");
     eprintln!("  print [message]");
 }
@@ -506,6 +517,15 @@ fn main() {
                             process::exit(1);
                         }
                     };
+                }
+            },
+            "config_compact" => {
+                match unsafe { config_compact() } {
+                    Ok(()) => (),
+                    Err(err) => {
+                        eprintln!("failed to compact configuration: {:X?}", err);
+                        process::exit(1);
+                    },
                 }
             },
 


### PR DESCRIPTION
- Feature Name: user-configuration
- Start Date: 2020-05-18
- Relevant Issues:  system76/firmware-open#78 and PRs #62 and #80 

# Summary
[summary]: #summary

The change add support for users to configure the EC behavior without having to build and flash a custom firmware image. A new flash API has been added, allowing for arbitrary read/write access to flash. A new configuration API has been added, persistently storing saved settings into an unused region of flash.

# Motivation
[motivation]: #motivation

While I am able to customize and rebuild the EC firmware, not all users are able or willing to do so, especially with the risks towards bricking their device. Additionally, any time a firmware update is release, a new customized EC binary must be generated to contain the user customization.

This change will allow users to customize the EC without the above mentioned risks, while also allowing those customization to persists across firmware updates.

# Guide-level explanation
[guide-level-explanation]: #guide-level-explanation

A user may list all configurable options within the EC by using the ectool.
```
meklort@lemur ~/g/ec (config-pull)> ./ectool.sh config
    Finished release [optimized] target(s) in 0.00s
Fn Lock: When enabled, F1-F12 will activate their default function
Min: 1
Max: 0
Current Value: 1

Keyboard Debounce Time: Debounce time in milliseconds
Min: 1000
Max: 1
Current Value: 15
```
If a user wishes to customize a setting, they can also do so using the ectool.
```
meklort@lemur ~/g/ec (config-pull)> ./ectool.sh config "Keyboard Debounce Time" 20
    Finished release [optimized] target(s) in 0.01s
meklort@lemur ~/g/ec (config-pull)> ./ectool.sh config "Keyboard Debounce Time"
    Finished release [optimized] target(s) in 0.00s
Dump "Keyboard Debounce Time"
Keyboard Debounce Time: Debounce time in milliseconds
Min: 1000
Max: 1
Current Value: 20
```

# Reference-level explanation
[reference-level-explanation]: #reference-level-explanation

Two new modules are provided with this change:
## Flash API
A new flash API is added, allowing code to read/write arbitrary locations in flash. Due to the XIP nature of the EC, this code must run out of RAM. As such, it is modeled and based off of the scratch ROM code used for firmware updates.

- A new flash application with a single entry point is added.
- The flash API is configured to use *no* globals and to place all locals on the stack
   This ensures that no memory in the standard application is mangled.
- During early init, the flash API is copied to RAM using SCAR0/SCAR2
   Note: This conflicts with the scratch ROM, however this is not an issue as firmware flashing requires a full system reboot.

## Config API
A new configuration API is added, allowing existing code to register a configuration entry with the system. Each configuration entry contains a short name, description, default, min, and, max values. Additionally, an option callback can bet set, allowing a function to be called when a configuration value is updated.

Using SMFI, all configuration entries are exported to the host. Additionally, the host is able to specify a new value, within the limits, for the configuration entry. All configuration settings are stored in the EC, allowing for the host to auto detect available parameters.

When a configuration entry is registered with the system, the flash APIs are used to update the configuration value with any user-customized settings. If no user customization is found, the default value is used instead.

When a configuration entry is updated by the user, the flash API is used to store the new value persistently. In order to allow quick updates to the settings, old values in flash are invalidated before a new setting is added. This allows new settings to be stored without having to first erase flash.

## Existing Modules

Existing modules can easily be updated to support user configurations. As an example, the keyboard module has been updated to allow configurable function lock and default state in #80 . 

# Drawbacks
[drawbacks]: #drawbacks

This code not yet complete, and it does add a couple of risks:
- ~~Currently, no code handles a full flash. If the full 4KB are used with configuration entries, no more settings can be saved. In this case, the firmware should be updated to (1) erase the sector and (2) store all known settings back into flash.~~
- This code calls between two applications. The flash API is a separate image which has no knowledge of XSEG / DSEG usage. As a result, the a developer modifying the must take special not to mangle existing registers.
- Any mistakes in the flash writing code could accidentally erase or overwrite the main EC binary, bricking the device. Special care need to be taken to ensure that a device is not bricked. Note: Additional checking could be added to the flash API to limit writes to a small window.
- The configuration APIs only support a single 32bit value. In some cases, a larger value may be desired. As an example, the keyboard layout could be stored in flash using a similar mechanism. This would allow custom keymaps. At present, this use case is not supported.
- The code currently does a linear search in flash. As the ~~4KB~~ 1KB configuration space fills up, read/write access time can be impacted. This can slow down the initial boot, as well as reconfiguration time by the user.

# Rationale and alternatives
[rationale-and-alternatives]: #rationale-and-alternatives

A couple of additional possibilities were considered including:
- Using the UEFI payload to store setting in nvram. This would allow the EC firmware to never touch flash, and instead could use the existing nvram APIs in UEFI. This would require (1) UEFI to scan nvram for all EC related variables (using a new GUID) and passing these to the EC. (2) Adding a mechanism to set the UEFI variables by first reading possible entries from the EC, then writing these to NVRAM. This means the change cannot be standalone, and so it was not really considered.
- Using a more compact format on flash could have been done. The flash usage could be minimized by only storing a  single 32bit value. This compresses the used space, however means that the location in flash cannot change. As a result, firmware updates must maintain past locations and the flash must be erased to update each value. Due to these limitations, a method supporting auto-detection and arbitrary locations in flash is supported instead. Also due to the large 128KB flash vs the (current) 32KB firmware size, the larger size seems acceptable.

# Prior art
[prior-art]: #prior-art

N/A

# Unresolved questions
[unresolved-questions]: #unresolved-questions

- What is the best way for the user to interact with this? The firmware-setup UEFI app could be updated to expose these to the user. The Pop! OS settings page could be updated instead to provide a gui for these settings instead. 

# Future possibilities
[future-possibilities]: #future-possibilities

This can be further enhanced in the future (as mentioned above) to support other configuration value types (strings, blobs, etc) instead of just 32bit integers.
A number of additional settings make sense to be implemented (I have done some, but have not cleaned them up and included them here yet). These include:
- Battery charge thresholds
- Startup keyboard back light value
- (possibly, if hardware supported) Start on lid open
- Additional keyboard customization (remap pgup/pgdwn to left/right,
- USB port settings (disable left usb port when in a sleep power state)
