### PR TITLE
Docs update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,36 +39,23 @@ Acronym | Feature                      | Description
 ------- | ---------------------------- | -----------
 USB     | Universal serial bus         | Can be used to provide access to EC functions either to the host or to a remote machine
 
-## Flashing
+## Dependencies
 
-Requirements:
+The complete set of dependencies can be installed using the `deps.sh` script
+from the [Open Firmware](https://github.com/system76/firmware-open) repo.
 
-- [sdcc](http://sdcc.sourceforge.net/)
-- [Rust](https://www.rust-lang.org/)
-
-### Internal programmer
-
-Use this method for flashing a system already running System76 EC.
+Dependencies specific to EC development can be installed with:
 
 ```
-make BOARD=<vendor>/<model> flash_internal
+sudo apt install \
+  avr-libc \
+  avrdude \
+  gcc-avr \
+  sdcc
 ```
 
-### External programmer
+## Documentation
 
-Use this method for first-time flashing or flashing a bricked controller.
-
-**The system must not have any power!**
-
-1. Turn off the computer
-2. Unplug the AC adapter
-3. Remove the bottom panel
-4. Disconnect the battery
-5. Ground the laptop to the programmer
-6. Disconnect the keyboard from its port
-7. Attach the programmer to the keyboard port
-8. Flash the firmware
-
-```
-make BOARD=<vendor>/<model> flash_external
-```
+- [flashing](./doc/flashing.md)
+- [debugging](./doc/debugging.md)
+- [custom keyboard layout](./doc/keyboard-layout-customization.md)

--- a/README.md
+++ b/README.md
@@ -1,43 +1,14 @@
 # System76 EC
 
 System76 EC is a GPLv3 licensed embedded controller firmware for System76
-laptops. It is designed to be portable to boards using several 8-bit
-microcontrollers, such as:
+laptops.
 
-Board              | Embedded Controller | Architecture
------------------- | ------------------- | --------------
-System76 ecsim     | Simulated ITE EC    | 8051
-System76 Laptops   | ITE IT8587E         | 8051
-System76 Laptops   | ITE IT5570E         | 8051
-System76 Thelio Io | Atmel ATMEGA32U4    | AVR
-Arduino Mega 2560  | Atmel ATMEGA2560    | AVR
+## Documentation
 
-Shared features (that can be used across different micro-controllers):
-
-Acronym | Feature                      | Description
-------- | ---------------------------- | -----------
-ADC     | Analog-digital converter     | Reads voltages from batteries and temperature from thermistors
-DAC     | Digital-analog converter     | Brightness control of keyboard backlight
-GPIO    | General purpose input/output | Control of LED's, buttons, and enable lines for other hardware
-KBSC    | Keyboard scan controller     | Detects laptop keyboard presses. Keyboard scanning can be done using GPIOs, the ITE EC has hardware acceleration
-PS/2    | Keyboard and mouse bus       | Interfaces with touchpad. PS/2 can be done using GPIOs, the ITE EC has hardware acceleration
-PWM     | Pulse-width modulation       | Fan control and brightness control of LED's
-SMBUS   | System management bus        | Reads battery information
-SPI     | Serial peripheral interface  | Reads and programs the EC's firmware
-UART    | Universal asynchronous receiver-transmitter | Provides EC console input/output
-
-Features specific to ITE embedded controllers:
-
-Acronym | Feature                      | Description
-------- | ---------------------------- | -----------
-LPC     | Low pin count                | Forwards memory and I/O access to EC. Most EC functions are exposed to the host through this interface. High frequency makes a GPIO implementation not possible. Simulation is provided by System76 ecsim
-PECI    | Platform environment control interface | Reads CPU temperature (relative to throttle point). Proprietary nature means a GPIO implementation is unlikely, though not technically impossible
-
-Features specific to Atmel embedded controllers:
-
-Acronym | Feature                      | Description
-------- | ---------------------------- | -----------
-USB     | Universal serial bus         | Can be used to provide access to EC functions either to the host or to a remote machine
+- [Supported embedded controllers](./doc/controllers.md)
+- [Flashing firmware](./doc/flashing.md)
+- [Debugging](./doc/debugging.md)
+- [Creating a custom keyboard layout](./doc/keyboard-layout-customization.md)
 
 ## Dependencies
 
@@ -53,9 +24,3 @@ sudo apt install \
   gcc-avr \
   sdcc
 ```
-
-## Documentation
-
-- [flashing](./doc/flashing.md)
-- [debugging](./doc/debugging.md)
-- [custom keyboard layout](./doc/keyboard-layout-customization.md)

--- a/doc/controllers.md
+++ b/doc/controllers.md
@@ -1,0 +1,41 @@
+# Embedded Controllers
+
+System76 EC is designed to be portable to boards using several 8-bit
+microcontrollers, such as:
+
+Board              | Embedded Controller | Architecture
+------------------ | ------------------- | --------------
+System76 ecsim     | Simulated ITE EC    | 8051
+System76 Laptops   | ITE IT8587E         | 8051
+System76 Laptops   | ITE IT5570E         | 8051
+System76 Thelio Io | Atmel ATMEGA32U4    | AVR
+Arduino Mega 2560  | Atmel ATMEGA2560    | AVR
+
+## Features
+
+Shared features (that can be used across different micro-controllers):
+
+Acronym | Feature                      | Description
+------- | ---------------------------- | -----------
+ADC     | Analog-digital converter     | Reads voltages from batteries and temperature from thermistors
+DAC     | Digital-analog converter     | Brightness control of keyboard backlight
+GPIO    | General purpose input/output | Control of LED's, buttons, and enable lines for other hardware
+KBSC    | Keyboard scan controller     | Detects laptop keyboard presses. Keyboard scanning can be done using GPIOs, the ITE EC has hardware acceleration
+PS/2    | Keyboard and mouse bus       | Interfaces with touchpad. PS/2 can be done using GPIOs, the ITE EC has hardware acceleration
+PWM     | Pulse-width modulation       | Fan control and brightness control of LED's
+SMBUS   | System management bus        | Reads battery information
+SPI     | Serial peripheral interface  | Reads and programs the EC's firmware
+UART    | Universal asynchronous receiver-transmitter | Provides EC console input/output
+
+Features specific to ITE embedded controllers:
+
+Acronym | Feature                      | Description
+------- | ---------------------------- | -----------
+LPC     | Low pin count                | Forwards memory and I/O access to EC. Most EC functions are exposed to the host through this interface. High frequency makes a GPIO implementation not possible. Simulation is provided by System76 ecsim
+PECI    | Platform environment control interface | Reads CPU temperature (relative to throttle point). Proprietary nature means a GPIO implementation is unlikely, though not technically impossible
+
+Features specific to Atmel embedded controllers:
+
+Acronym | Feature                      | Description
+------- | ---------------------------- | -----------
+USB     | Universal serial bus         | Can be used to provide access to EC functions either to the host or to a remote machine

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -13,27 +13,12 @@ external USB keyboard or SSH session.
 
 Requirements:
 - Arduino Mega 2560 compatible board
-- 24 pin flexible printed circuit
+- 24 pin FPC breakout board and cables
     - 0.5mm or 1.0mm pitch, depending on target connector
-- 24 pin FPC breakout board with connectors
 - USB-C cable
 
-### Configuring the Mega 2560
-
-If the breakout board did not come preassembled, assemble it before
-starting. This will require soldering.
-
-1. Connect the breakout board to the Mega 2560
-    - Orientation will affect the mapping of GPIO pins
-2. Connect the Mega 2560 to the host
-3. Configure GPIO pin mapping in `parallel.c` based on how it will
-    connect to the target parallel port
-    - Trace pin 1 on motherboard connector to Mega's GPIO pins
-4. Build and flash the firmware for the Mega 2560
-```
-make BOARD=arduino/mega2560
-make BOARD=arduino/mega2560 flash
-```
+For details on configuring the Mega 2560 and breakout board, see
+[mega2560](./mega2560.md).
 
 ### Setup
 
@@ -44,10 +29,10 @@ make BOARD=arduino/mega2560 flash
 3. Remove bottom panel
 4. Unplug keyboard cable
     - May require removing keyboard depending on port location
-5. Connect Mega 2560 to host
-    - This will create an ACM device at `/dev/ttyACM*`
-6. Ground target to host
+5. Ground target to host
     - Connect USB cable from USB-C port on target to host
+6. Connect Mega 2560 to host
+    - This will create an ACM device at `/dev/ttyACM*`
 7. Connect Mega 2560 to target
 8. Start the console
 ```
@@ -57,7 +42,7 @@ make BOARD=system76/<model> console_external
 EC logs should now print to the console on the host. This can be tested
 by removing or inserting the AC adapter to trigger a power event.
 
-To return the Mega to host mode, reset the device.
+To return the Mega 2560 to host mode, reset the device.
 
 If logs are corrupted, try power cycling the Mega or reseating the cable.
 

--- a/doc/flashing.md
+++ b/doc/flashing.md
@@ -1,0 +1,30 @@
+# Flashing firmware
+
+## Internal programmer
+
+Use this method for flashing a system already running System76 EC.
+
+```
+make BOARD=<vendor>/<model> flash_internal
+```
+
+## External programmer
+
+Use this method for first-time flashing or flashing a bricked controller.
+
+[A Mega 2560 is required for flashing.](./mega2560.md)
+
+**The system must not have any power!**
+
+1. Turn off the computer
+2. Unplug the AC adapter
+3. Remove the bottom panel
+4. Disconnect the battery
+5. Ground the laptop to the programmer
+6. Disconnect the keyboard from its port
+7. Attach the programmer to the keyboard port
+8. Flash the firmware
+
+```
+make BOARD=<vendor>/<model> flash_external
+```

--- a/doc/mega2560.md
+++ b/doc/mega2560.md
@@ -1,0 +1,72 @@
+# Mega 2560
+
+The Mega 2560 is the recommended tool for EC flashing and debugging.
+
+The Mega 2560 is an open-source hardware design by [Arduino] based on the 8-bit
+Atmel ATmega2560. Arduino's official model sells for around 40 USD. Multiple
+clones exist, and can be bought for around 15 USD.
+
+## Clone compatibility
+
+Multiple clones of the Arduino Mega 2560 exist. Clones can be used, but must be
+compatible with the Arduino model. Some have replaced the ATmega16U2 chip used
+for USB communication with a CH340G chip. If it does not explicitly state that
+it uses the ATmega16U2, find a different model.
+
+## FPC breakout board
+
+A flexible printed circuit (FPC) breakout board is required. It should have:
+
+- 24 pins with 0.1" (2.54mm) pitch
+- One side with 0.5mm pitch FPC connector (for lemp9)
+- One side with 1.0mm pitch FPC connector (for all other models)
+
+Depending on the vendor, the connectors may not come soldered to the board (or
+at all). A header block will likely not be be provided, so male breakaway
+headers will need to be purchased separately.
+
+### Connecting to the Mega 2560
+
+The FPC board should be assembled so the 1.0mm pitch connector faces up. When
+connected to the Mega 2560, the FPC connector should face away from the Mega
+2560. In this orientation, pin 1 of the FPC connector connects to pin 22 (PA0)
+of the Mega 2560.
+
+### Connecting to the laptop
+
+A 24 pin flexible flat cable (FFC) is used to connect the Mega 2560 to the
+laptop. It may be worth buying both a set of standard cables (traces exposed on
+same side at each end) and reversed cables (traces exposed on opposite sides at
+each end). With both, it will always be possible to have pin 1 of the breakout
+board go to pin 1 of the keyboard port.
+
+The orientation of the FFC traces can be determined by looking at how the
+keyboard connects to its port.
+
+The laptop keyboard may use a 26-pin connection. Ensure that the FFC is aligned
+so the traces line up with pins 1-24 on the keyboard port.
+
+A second cable (typically, USB-C) must be used for grounding the target laptop
+to the host system (what the Mega 2560 is connected to).
+
+## Firmware
+
+`mega2560/parallel.c` must be modified for the mapping of the keyboard pins to
+the GPIO pins.
+
+- [Arduino Mega 2560 pin mapping][PinMapping2560]
+
+Using the orientation described above, pin 1 of the keyboard maps to
+
+- pin 22 (PA0) of the Mega 2560 when using the 1.0mm pitch connector
+- pin 45 (PL4) of the Mega 2560 when using the 0.5mm pitch connector
+
+Once the GPIO mapping is updated, the firmware can be compiled and flashed.
+
+```
+make BOARD=arduino/mega2560
+make BOARD=arduino/mega2560 flash
+```
+
+[Arduino]: https://www.arduino.cc/
+[PinMapping2560]: https://www.arduino.cc/en/Hacking/PinMapping2560


### PR DESCRIPTION
- Add a more comprehensive document describing the Mega 2560 and FPC breakout board
- Move flashing information to a separate file
- Point users to firmware-open for installing full set of dependencies
