### PR TITLE
Wake-on-LAN

### DIFF
--- a/src/board/system76/addw2/gpio.c
+++ b/src/board/system76/addw2/gpio.c
@@ -12,6 +12,7 @@ struct Gpio __code DGPU_PWR_EN =    GPIO(H, 4);
 struct Gpio __code EC_EN =          GPIO(B, 6); // renamed to SUSBC_EN
 struct Gpio __code EC_RSMRST_N =    GPIO(E, 5);
 struct Gpio __code GC6_FB_EN =      GPIO(H, 3);
+struct Gpio __code LAN_WAKEUP_N =   GPIO(B, 2);
 struct Gpio __code LED_ACIN =       GPIO(C, 7);
 struct Gpio __code LED_AIRPLANE_N = GPIO(H, 7);
 struct Gpio __code LED_CAP_N =      GPIO(J, 2);

--- a/src/board/system76/addw2/include/board/gpio.h
+++ b/src/board/system76/addw2/include/board/gpio.h
@@ -23,6 +23,7 @@ extern struct Gpio __code DGPU_PWR_EN;
 extern struct Gpio __code EC_EN; // renamed to SUSBC_EN
 extern struct Gpio __code EC_RSMRST_N;
 extern struct Gpio __code GC6_FB_EN;
+extern struct Gpio __code LAN_WAKEUP_N;
 extern struct Gpio __code LED_ACIN;
 extern struct Gpio __code LED_AIRPLANE_N;
 extern struct Gpio __code LED_CAP_N;

--- a/src/board/system76/bonw14/gpio.c
+++ b/src/board/system76/bonw14/gpio.c
@@ -15,6 +15,7 @@ struct Gpio __code DGPU_PWR_EN =    GPIO(A, 0);
 struct Gpio __code EC_EN =          GPIO(B, 6);
 struct Gpio __code EC_RSMRST_N =    GPIO(E, 5);
 struct Gpio __code GC6_FB_EN =      GPIO(H, 3);
+struct Gpio __code LAN_WAKEUP_N =   GPIO(B, 2); // renamed to LAN_WAKE#
 struct Gpio __code LED_ACIN =       GPIO(C, 7);
 struct Gpio __code LED_BAT_CHG =    GPIO(H, 5);
 struct Gpio __code LED_BAT_FULL =   GPIO(J, 0);

--- a/src/board/system76/bonw14/include/board/gpio.h
+++ b/src/board/system76/bonw14/include/board/gpio.h
@@ -26,6 +26,7 @@ extern struct Gpio __code DGPU_PWR_EN;
 extern struct Gpio __code EC_EN;
 extern struct Gpio __code EC_RSMRST_N;
 extern struct Gpio __code GC6_FB_EN;
+extern struct Gpio __code LAN_WAKEUP_N;
 extern struct Gpio __code LED_ACIN;
 #define HAVE_LED_AIRPLANE_N 0
 extern struct Gpio __code LED_BAT_CHG;

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -24,6 +24,10 @@
     #define HAVE_EC_EN 1
 #endif
 
+#ifndef HAVE_LAN_WAKEUP_N
+    #define HAVE_LAN_WAKEUP_N 1
+#endif
+
 #ifndef HAVE_LED_BAT_CHG
     #define HAVE_LED_BAT_CHG 1
 #endif
@@ -485,6 +489,24 @@ void power_event(void) {
             power_off_s5();
         }
     }
+
+#if HAVE_LAN_WAKEUP_N
+    static bool wake_last = true;
+    bool wake_new = gpio_get(&LAN_WAKEUP_N);
+    if (!wake_new && wake_last) {
+        update_power_state();
+        DEBUG("%02X: LAN_WAKEUP# asserted\n", main_cycle);
+        if (power_state == POWER_STATE_DS5) {
+            power_on_s5();
+        }
+    }
+    #if LEVEL >= LEVEL_DEBUG
+        else if (wake_new && !wake_last) {
+            DEBUG("%02X: LAN_WAKEUP# de-asserted\n", main_cycle);
+        }
+    #endif
+    wake_last = wake_new;
+#endif // HAVE_LAN_WAKEUP_N
 
     static uint32_t last_time = 0;
     uint32_t time = time_get();

--- a/src/board/system76/darp5/gpio.c
+++ b/src/board/system76/darp5/gpio.c
@@ -11,6 +11,7 @@ struct Gpio __code CCD_EN =         GPIO(G, 0);
 struct Gpio __code DD_ON =          GPIO(E, 4);
 struct Gpio __code EC_EN =          GPIO(E, 1);
 struct Gpio __code EC_RSMRST_N =    GPIO(E, 5);
+struct Gpio __code LAN_WAKEUP_N =   GPIO(B, 2);
 struct Gpio __code LED_ACIN =       GPIO(C, 7);
 struct Gpio __code LED_AIRPLANE_N = GPIO(G, 6);
 struct Gpio __code LED_BAT_CHG =    GPIO(A, 5);

--- a/src/board/system76/darp5/include/board/gpio.h
+++ b/src/board/system76/darp5/include/board/gpio.h
@@ -22,6 +22,7 @@ extern struct Gpio __code CCD_EN;
 extern struct Gpio __code DD_ON;
 extern struct Gpio __code EC_EN;
 extern struct Gpio __code EC_RSMRST_N;
+extern struct Gpio __code LAN_WAKEUP_N;
 extern struct Gpio __code LED_ACIN;
 extern struct Gpio __code LED_AIRPLANE_N;
 extern struct Gpio __code LED_BAT_CHG;

--- a/src/board/system76/galp3-c/gpio.c
+++ b/src/board/system76/galp3-c/gpio.c
@@ -11,6 +11,7 @@ struct Gpio __code CCD_EN =         GPIO(G, 0);
 struct Gpio __code DD_ON =          GPIO(E, 4);
 struct Gpio __code EC_EN =          GPIO(E, 1);
 struct Gpio __code EC_RSMRST_N =    GPIO(E, 5);
+struct Gpio __code LAN_WAKEUP_N =   GPIO(B, 2);
 struct Gpio __code LED_ACIN =       GPIO(C, 7);
 struct Gpio __code LED_AIRPLANE_N = GPIO(G, 6);
 struct Gpio __code LED_BAT_CHG =    GPIO(A, 5);

--- a/src/board/system76/galp3-c/include/board/gpio.h
+++ b/src/board/system76/galp3-c/include/board/gpio.h
@@ -22,6 +22,7 @@ extern struct Gpio __code CCD_EN;
 extern struct Gpio __code DD_ON;
 extern struct Gpio __code EC_EN;
 extern struct Gpio __code EC_RSMRST_N;
+extern struct Gpio __code LAN_WAKEUP_N;
 extern struct Gpio __code LED_ACIN;
 extern struct Gpio __code LED_AIRPLANE_N;
 extern struct Gpio __code LED_BAT_CHG;

--- a/src/board/system76/gaze15/gpio.c
+++ b/src/board/system76/gaze15/gpio.c
@@ -12,6 +12,7 @@ struct Gpio __code DD_ON =          GPIO(E, 4);
 struct Gpio __code DGPU_PWR_EN =    GPIO(J, 2);
 struct Gpio __code EC_RSMRST_N =    GPIO(E, 5);
 struct Gpio __code GC6_FB_EN =      GPIO(J, 3);
+struct Gpio __code LAN_WAKEUP_N =   GPIO(B, 2);
 struct Gpio __code LED_ACIN =       GPIO(C, 7);
 struct Gpio __code LED_AIRPLANE_N = GPIO(H, 7);
 struct Gpio __code LED_BAT_CHG =    GPIO(H, 5);

--- a/src/board/system76/gaze15/include/board/gpio.h
+++ b/src/board/system76/gaze15/include/board/gpio.h
@@ -24,6 +24,7 @@ extern struct Gpio __code DGPU_PWR_EN;
 #define HAVE_EC_EN 0
 extern struct Gpio __code EC_RSMRST_N;
 extern struct Gpio __code GC6_FB_EN;
+extern struct Gpio __code LAN_WAKEUP_N;
 extern struct Gpio __code LED_ACIN;
 extern struct Gpio __code LED_AIRPLANE_N;
 extern struct Gpio __code LED_BAT_CHG;

--- a/src/board/system76/lemp9/include/board/gpio.h
+++ b/src/board/system76/lemp9/include/board/gpio.h
@@ -23,6 +23,7 @@ extern struct Gpio __code DD_ON;
 extern struct Gpio __code EC_EN;
 extern struct Gpio __code EC_RSMRST_N;
 extern struct Gpio __code EC_SMD_EN_N;
+#define HAVE_LAN_WAKEUP_N 0
 extern struct Gpio __code LED_ACIN;
 #define HAVE_LED_AIRPLANE_N 0
 #define HAVE_LED_BAT_CHG 0

--- a/src/board/system76/oryp6/gpio.c
+++ b/src/board/system76/oryp6/gpio.c
@@ -13,6 +13,7 @@ struct Gpio __code DGPU_PWR_EN =    GPIO(F, 7);
 struct Gpio __code EC_EN =          GPIO(B, 6); // renamed to SUSBC_EN
 struct Gpio __code EC_RSMRST_N =    GPIO(E, 5);
 struct Gpio __code GC6_FB_EN =      GPIO(J, 7);
+struct Gpio __code LAN_WAKEUP_N =   GPIO(B, 2);
 struct Gpio __code LED_ACIN =       GPIO(C, 7);
 struct Gpio __code LED_BAT_CHG =    GPIO(H, 5);
 struct Gpio __code LED_BAT_FULL =   GPIO(J, 0);

--- a/src/board/system76/oryp6/include/board/gpio.h
+++ b/src/board/system76/oryp6/include/board/gpio.h
@@ -24,6 +24,7 @@ extern struct Gpio __code DGPU_PWR_EN;
 extern struct Gpio __code EC_EN;
 extern struct Gpio __code EC_RSMRST_N;
 extern struct Gpio __code GC6_FB_EN;
+extern struct Gpio __code LAN_WAKEUP_N;
 extern struct Gpio __code LED_ACIN;
 #define HAVE_LED_AIRPLANE_N 0
 extern struct Gpio __code LED_BAT_CHG;


### PR DESCRIPTION
~Currently only works during S5.
Does not work during S3 (`LAN_WAKEUP#` not asserted; device disabled during sleep?).~
_Should_ work from S3 and S5 when magic packet wake support is enabled in the Ethernet controller.

## Testing

1. Get the MAC address for the Ethernet adapter: `ip link [show <device>]`
2. Ensure it supports Wake-on-Lan: `sudo ethtool <device>  | grep Wake` (must have `g`)
3. Enable WoL: `sudo ethtool -s <device> wol g`
4. Power off target, plug in Ethernet cable
5. Send magic packet: `wol <mac-address>`

### Example

Target output:
```
[oryp6 ~]$ ip link show enp40s0
2: enp40s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether 80:fa:5b:80:dd:69 brd ff:ff:ff:ff:ff:ff
[oryp6 ~]$ sudo ethtool enp40s0 | grep Wake
	Supports Wake-on: pumbg
	Wake-on: d
[oryp6 ~]$ sudo ethtool -s enp40s0 wol g
[oryp6 ~]$ sudo ethtool enp40s0 | grep Wake
	Supports Wake-on: pumbg
	Wake-on: g
```
Host output:
```
[pop-os ~]$ wol 80:fa:5b:80:dd:69
Waking up 80:fa:5b:80:dd:69...
```
Target machine should boot.