### PR TITLE
Add battery detection

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -99,8 +99,10 @@ uint8_t acpi_read(uint8_t addr) {
                 // AC adapter connected
                 data |= 1 << 0;
             }
-            // BAT0 always connected - TODO
-            data |= 1 << 2;
+            if (battery_status & BATTERY_INITIALIZED) {
+                // BAT0 connected
+                data |= 1 << 2;
+            }
             break;
 
         ACPI_16(0x16, battery_design_capacity);

--- a/src/board/system76/common/include/board/battery.h
+++ b/src/board/system76/common/include/board/battery.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define BATTERY_INITIALIZED (1U << 7)
+
 extern uint16_t battery_temp;
 extern uint16_t battery_voltage;
 extern uint16_t battery_current;

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -552,7 +552,11 @@ void power_event(void) {
 
 //TODO: do not require both LEDs
 #if HAVE_LED_BAT_CHG && HAVE_LED_BAT_FULL
-    if (ac_new) {
+    if (!(battery_status & BATTERY_INITIALIZED)) {
+        // No battery connected
+        gpio_set(&LED_BAT_CHG, false);
+        gpio_set(&LED_BAT_FULL, false);
+    } else if (ac_new) {
         // Discharging (no AC adapter)
         gpio_set(&LED_BAT_CHG, false);
         gpio_set(&LED_BAT_FULL, false);
@@ -563,7 +567,6 @@ void power_event(void) {
         gpio_set(&LED_BAT_FULL, true);
     } else {
         // Charging
-        // TODO: detect no battery connected
         gpio_set(&LED_BAT_CHG, true);
         gpio_set(&LED_BAT_FULL, false);
     }


### PR DESCRIPTION
Don't turn on battery LEDs or report it connected if not initialized.