### PR TITLE
acpi: Handle ACPI queries for charging thresholds

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -128,6 +128,14 @@ uint8_t acpi_read(uint8_t addr) {
 
         ACPI_8(0x68, acpi_ecos);
 
+        case 0xBC:
+            data = battery_get_start_threshold();
+            break;
+
+        case 0xBD:
+            data = battery_get_end_threshold();
+            break;
+
         ACPI_8(0xCC, sci_extra);
 
         ACPI_8(0xCE, DCR2);
@@ -175,6 +183,14 @@ void acpi_write(uint8_t addr, uint8_t data) {
 
         case 0x68:
             acpi_ecos = data;
+            break;
+
+        case 0xBC:
+            battery_set_start_threshold(data);
+            break;
+
+        case 0xBD:
+            battery_set_end_threshold(data);
             break;
 
 #if HAVE_LED_AIRPLANE_N

--- a/src/board/system76/common/battery.c
+++ b/src/board/system76/common/battery.c
@@ -89,7 +89,7 @@ int battery_charger_disable(void) {
     res = smbus_write(CHARGER_ADDRESS, 0x3F, 0);
     if (res < 0) return res;
 
-    DEBUG("Charged disabled\n");
+    DEBUG("Charger disabled\n");
     charger_enabled = false;
     return 0;
 }
@@ -123,7 +123,7 @@ int battery_charger_enable(void) {
         SBC_IDCHC_GAIN
     );
 
-    DEBUG("Charged enabled\n");
+    DEBUG("Charger enabled\n");
     charger_enabled = true;
     return 0;
 }


### PR DESCRIPTION
Requires: system76/coreboot#15
Ref: pop-os/system76-acpi-dkms#4