### PR TITLE
Reset EC config if Fn+Esc held during power on

### DIFF
--- a/src/board/system76/addw2/include/board/keymap.h
+++ b/src/board/system76/addw2/include/board/keymap.h
@@ -46,4 +46,12 @@
 // Keymap
 extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
+// Position of physical Esc key in the matrix
+#define MATRIX_ESC_INPUT    7
+#define MATRIX_ESC_OUTPUT   7
+
+// Position of physical Fn key in the matrix
+#define MATRIX_FN_INPUT     3
+#define MATRIX_FN_OUTPUT    17
+
 #endif // _BOARD_KEYMAP_H

--- a/src/board/system76/bonw14/include/board/keymap.h
+++ b/src/board/system76/bonw14/include/board/keymap.h
@@ -48,4 +48,12 @@
 // Keymap
 extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
+// Position of physical Esc key in the matrix
+#define MATRIX_ESC_INPUT    0
+#define MATRIX_ESC_OUTPUT   6
+
+// Position of physical Fn key in the matrix
+#define MATRIX_FN_INPUT     0
+#define MATRIX_FN_OUTPUT    4
+
 #endif // _BOARD_KEYMAP_H

--- a/src/board/system76/common/battery.c
+++ b/src/board/system76/common/battery.c
@@ -225,3 +225,8 @@ void battery_debug(void) {
 
     #undef command
 }
+
+void battery_reset(void) {
+    battery_start_threshold = BATTERY_START_THRESHOLD;
+    battery_end_threshold = BATTERY_END_THRESHOLD;
+}

--- a/src/board/system76/common/config.c
+++ b/src/board/system76/common/config.c
@@ -3,7 +3,15 @@
 #include <board/config.h>
 
 #include <board/battery.h>
+#include <board/kbscan.h>
 #include <common/debug.h>
+
+/**
+ * Test if the EC should reset its configuration.
+ */
+bool config_should_reset(void) {
+    return kbscan_fn_held && kbscan_esc_held;
+}
 
 /**
  * Reset the EC configuration data.

--- a/src/board/system76/common/config.c
+++ b/src/board/system76/common/config.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/config.h>
+
+#include <board/battery.h>
+#include <common/debug.h>
+
+/**
+ * Reset the EC configuration data.
+ */
+void config_reset(void) {
+    battery_reset();
+    INFO("Reset configuration\n");
+}

--- a/src/board/system76/common/include/board/battery.h
+++ b/src/board/system76/common/include/board/battery.h
@@ -29,5 +29,6 @@ int battery_charger_enable(void);
 int battery_charger_configure(void);
 void battery_event(void);
 void battery_debug(void);
+void battery_reset(void);
 
 #endif // _BOARD_BATTERY_H

--- a/src/board/system76/common/include/board/config.h
+++ b/src/board/system76/common/include/board/config.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#ifndef _BOARD_CONFIG_H
+#define _BOARD_CONFIG_H
+
+void config_reset(void);
+
+#endif // _BOARD_CONFIG_H

--- a/src/board/system76/common/include/board/config.h
+++ b/src/board/system76/common/include/board/config.h
@@ -3,6 +3,9 @@
 #ifndef _BOARD_CONFIG_H
 #define _BOARD_CONFIG_H
 
+#include <stdbool.h>
+
+bool config_should_reset(void);
 void config_reset(void);
 
 #endif // _BOARD_CONFIG_H

--- a/src/board/system76/common/include/board/kbscan.h
+++ b/src/board/system76/common/include/board/kbscan.h
@@ -7,6 +7,10 @@
 
 #include <ec/kbscan.h>
 
+// EC config reset key combo: Fn+Esc
+extern bool kbscan_fn_held;
+extern bool kbscan_esc_held;
+
 extern bool kbscan_enabled;
 
 // ms between repeating key

--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -18,6 +18,9 @@
 #define KM_NKEY 0
 #endif // KM_NKEY
 
+bool kbscan_fn_held = false;
+bool kbscan_esc_held = false;
+
 bool kbscan_enabled = false;
 uint16_t kbscan_repeat_period = 91;
 uint16_t kbscan_repeat_delay = 500;
@@ -182,12 +185,16 @@ bool kbscan_press(uint16_t key, bool pressed, uint8_t * layer) {
         case (KT_NORMAL):
             if (kbscan_enabled) {
                 kbc_scancode(&KBC, key, pressed);
+                if ((key & 0xFF) == K_ESC)
+                    kbscan_esc_held = pressed;
             }
             break;
         case (KT_FN):
             if (layer != NULL) {
                 if (pressed) *layer = 1;
                 else *layer = 0;
+
+                kbscan_fn_held = pressed;
             } else {
                 // In the case no layer can be set, reset bit
                 return false;

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -5,6 +5,7 @@
 #include <board/acpi.h>
 #include <board/battery.h>
 #include <board/board.h>
+#include <board/config.h>
 #include <board/gpio.h>
 #include <board/kbled.h>
 #include <board/lid.h>
@@ -405,6 +406,8 @@ void power_event(void) {
             // Enable S5 power if necessary, before sending PWR_BTN
             update_power_state();
             if (power_state == POWER_STATE_DS5) {
+                if (config_should_reset())
+                    config_reset();
                 power_on_s5();
             }
         }

--- a/src/board/system76/darp5/include/board/keymap.h
+++ b/src/board/system76/darp5/include/board/keymap.h
@@ -46,4 +46,12 @@
 // Keymap
 extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
+// Position of physical Esc key in the matrix
+#define MATRIX_ESC_INPUT    7
+#define MATRIX_ESC_OUTPUT   7
+
+// Position of physical Fn key in the matrix
+#define MATRIX_FN_INPUT     3
+#define MATRIX_FN_OUTPUT    17
+
 #endif // _BOARD_KEYMAP_H

--- a/src/board/system76/galp3-c/include/board/keymap.h
+++ b/src/board/system76/galp3-c/include/board/keymap.h
@@ -44,4 +44,12 @@
 // Keymap
 extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
+// Position of physical Esc key in the matrix
+#define MATRIX_ESC_INPUT    7
+#define MATRIX_ESC_OUTPUT   7
+
+// Position of physical Fn key in the matrix
+#define MATRIX_FN_INPUT     0
+#define MATRIX_FN_OUTPUT    6
+
 #endif // _BOARD_KEYMAP_H

--- a/src/board/system76/gaze15/include/board/keymap.h
+++ b/src/board/system76/gaze15/include/board/keymap.h
@@ -46,4 +46,12 @@
 // Keymap
 extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
+// Position of physical Esc key in the matrix
+#define MATRIX_ESC_INPUT    7
+#define MATRIX_ESC_OUTPUT   7
+
+// Position of physical Fn key in the matrix
+#define MATRIX_FN_INPUT     3
+#define MATRIX_FN_OUTPUT    17
+
 #endif // _BOARD_KEYMAP_H

--- a/src/board/system76/lemp9/include/board/keymap.h
+++ b/src/board/system76/lemp9/include/board/keymap.h
@@ -45,4 +45,12 @@
 // Keymap
 extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
+// Position of physical Esc key in the matrix
+#define MATRIX_ESC_INPUT    7
+#define MATRIX_ESC_OUTPUT   7
+
+// Position of physical Fn key in the matrix
+#define MATRIX_FN_INPUT     0
+#define MATRIX_FN_OUTPUT    6
+
 #endif // _BOARD_KEYMAP_H

--- a/src/board/system76/oryp5/include/board/keymap.h
+++ b/src/board/system76/oryp5/include/board/keymap.h
@@ -46,4 +46,12 @@
 // Keymap
 extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
+// Position of physical Esc key in the matrix
+#define MATRIX_ESC_INPUT    7
+#define MATRIX_ESC_OUTPUT   7
+
+// Position of physical Fn key in the matrix
+#define MATRIX_FN_INPUT     3
+#define MATRIX_FN_OUTPUT    17
+
 #endif // _BOARD_KEYMAP_H

--- a/src/board/system76/oryp6/include/board/keymap.h
+++ b/src/board/system76/oryp6/include/board/keymap.h
@@ -46,4 +46,12 @@
 // Keymap
 extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
+// Position of physical Esc key in the matrix
+#define MATRIX_ESC_INPUT    7
+#define MATRIX_ESC_OUTPUT   7
+
+// Position of physical Fn key in the matrix
+#define MATRIX_FN_INPUT     3
+#define MATRIX_FN_OUTPUT    17
+
 #endif // _BOARD_KEYMAP_H


### PR DESCRIPTION
Reset EC configuration; Currently only battery charging thresholds.

To test:

- Plug into AC power
- Flash this firmware
- Modify charging thresholds
- Power off and on
- Confirm charging thresholds are unchanged
- Power off
- Hold Fn+Esc and press power button to power on
  - Once the power LED turns green, they can be released
- Confirm charging thresholds have reset to 0 and 100