### PR TITLE
Keyboard configuration saved in flash

### DIFF
--- a/src/board/system76/addw2/include/board/keymap.h
+++ b/src/board/system76/addw2/include/board/keymap.h
@@ -3,9 +3,15 @@
 #ifndef _BOARD_KEYMAP_H
 #define _BOARD_KEYMAP_H
 
-#include <common/keymap.h>
+// Keymap layers (normal, Fn)
+#define KM_LAY 2
+// Keymap output pins
+#define KM_OUT 18
+// Keymap input pins
+#define KM_IN 8
 
-#define ___ 0
+// common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
+#include <common/keymap.h>
 
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
@@ -35,16 +41,6 @@
     { K0H, K0G, K43, K4C, K59, K10, K0B, K0C }, \
     { K35, K1C, K4F, K51, K4D, K58, K5A, ___ } \
 }
-
-// Keymap output pins
-#define KM_OUT 18
-// Keymap input pins
-#define KM_IN 8
-// Keymap layers (normal, Fn)
-#define KM_LAY 2
-
-// Keymap
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Position of physical Esc key in the matrix
 #define MATRIX_ESC_INPUT    7

--- a/src/board/system76/addw2/keymap/default.c
+++ b/src/board/system76/addw2/keymap/default.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/addw2/keymap/jeremy.c
+++ b/src/board/system76/addw2/keymap/jeremy.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/bonw14/include/board/keymap.h
+++ b/src/board/system76/bonw14/include/board/keymap.h
@@ -3,9 +3,17 @@
 #ifndef _BOARD_KEYMAP_H
 #define _BOARD_KEYMAP_H
 
-#include <common/keymap.h>
+// Keymap layers (normal, Fn)
+#define KM_LAY 2
+// Keymap output pins
+#define KM_OUT 18
+// Keymap input pins
+#define KM_IN 8
+// Keyboard has n-key rollover
+#define KM_NKEY 1
 
-#define ___ 0
+// common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
+#include <common/keymap.h>
 
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
@@ -35,18 +43,6 @@
     { ___, ___, ___, ___, ___, ___, ___, ___ }, /* 16 */ \
     { ___, ___, ___, ___, ___, ___, ___, ___ }  /* 17 */ \
 }
-
-// Keymap output pins
-#define KM_OUT 18
-// Keymap input pins
-#define KM_IN 8
-// Keymap layers (normal, Fn)
-#define KM_LAY 2
-// Keyboard has n-key rollover
-#define KM_NKEY 1
-
-// Keymap
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Position of physical Esc key in the matrix
 #define MATRIX_ESC_INPUT    0

--- a/src/board/system76/bonw14/keymap/default.c
+++ b/src/board/system76/bonw14/keymap/default.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/bonw14/keymap/jeremy.c
+++ b/src/board/system76/bonw14/keymap/jeremy.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/common/config.c
+++ b/src/board/system76/common/config.c
@@ -4,6 +4,7 @@
 
 #include <board/battery.h>
 #include <board/kbscan.h>
+#include <board/keymap.h>
 #include <common/debug.h>
 
 /**
@@ -17,6 +18,8 @@ bool config_should_reset(void) {
  * Reset the EC configuration data.
  */
 void config_reset(void) {
-    battery_reset();
     INFO("Reset configuration\n");
+    battery_reset();
+    keymap_erase_config();
+    keymap_load_default();
 }

--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -125,6 +125,8 @@ static uint8_t kbscan_get_real_keys(int row, uint8_t rowdata) {
     // Remove any "active" blanks from the matrix.
     uint8_t realdata = 0;
     for (uint8_t col = 0; col < KM_IN; col++) {
+        // This tests the default keymap intentionally, to avoid blanks in the
+        // dynamic keymap
         if (KEYMAP[0][row][col] && (rowdata & (1 << col))) {
             realdata |=  1 << col;
         }
@@ -349,9 +351,7 @@ void kbscan_event(void) {
                         }
                         uint8_t key_layer = kbscan_last_layer[i][j];
                         uint16_t key = 0;
-                        if (key_layer < KM_LAY) {;
-                            key = KEYMAP[key_layer][i][j];
-                        }
+                        keymap_get(key_layer, i, j, &key);
                         if (key) {
                             DEBUG("KB %d, %d, %d = 0x%04X, %d\n", i, j, key_layer, key, new_b);
                             if(!kbscan_press(key, new_b, &layer)){

--- a/src/board/system76/common/keymap.c
+++ b/src/board/system76/common/keymap.c
@@ -37,7 +37,7 @@ bool keymap_load_config(void) {
     if (flash_read_u16(CONFIG_ADDR) != CONFIG_SIGNATURE) return false;
 
     // Read the keymap if signature is valid
-    flash_read(CONFIG_ADDR + 2, (uint8_t *)DYNAMIC_KEYMAP, sizeof(DYNAMIC_KEYMAP));
+    flash_read(CONFIG_ADDR + sizeof(CONFIG_SIGNATURE), (uint8_t *)DYNAMIC_KEYMAP, sizeof(DYNAMIC_KEYMAP));
     return true;
 }
 
@@ -46,7 +46,7 @@ bool keymap_save_config(void) {
     if (!keymap_erase_config()) return false;
 
     // Write the keymap
-    flash_write(CONFIG_ADDR + 2, (uint8_t *)DYNAMIC_KEYMAP, sizeof(DYNAMIC_KEYMAP));
+    flash_write(CONFIG_ADDR + sizeof(CONFIG_SIGNATURE), (uint8_t *)DYNAMIC_KEYMAP, sizeof(DYNAMIC_KEYMAP));
 
     // Write the length of the keymap, as a signature
     flash_write_u16(CONFIG_ADDR, CONFIG_SIGNATURE);

--- a/src/board/system76/common/keymap.c
+++ b/src/board/system76/common/keymap.c
@@ -1,0 +1,74 @@
+#include <board/flash.h>
+#include <board/keymap.h>
+
+uint16_t __xdata DYNAMIC_KEYMAP[KM_LAY][KM_OUT][KM_IN];
+
+// Config is in the last sector of flash
+const uint32_t CONFIG_ADDR = 0x1FC00;
+// Signature is the size of the keymap
+const uint16_t CONFIG_SIGNATURE = sizeof(DYNAMIC_KEYMAP);
+
+void keymap_init(void) {
+    if (!keymap_load_config()) {
+        keymap_load_default();
+    }
+}
+
+void keymap_load_default(void) {
+    for (int layer = 0; layer < KM_LAY; layer++) {
+        for (int output = 0; output < KM_OUT; output++) {
+            for (int input = 0; input < KM_IN; input++) {
+                DYNAMIC_KEYMAP[layer][output][input] = KEYMAP[layer][output][input];
+            }
+        }
+    }
+}
+
+bool keymap_erase_config(void) {
+    // This will erase 1024 bytes
+    flash_erase(CONFIG_ADDR);
+
+    // Verify signature is erased
+    return flash_read_u16(CONFIG_ADDR) == 0xFFFF;
+}
+
+bool keymap_load_config(void) {
+    // Check signature
+    if (flash_read_u16(CONFIG_ADDR) != CONFIG_SIGNATURE) return false;
+
+    // Read the keymap if signature is valid
+    flash_read(CONFIG_ADDR + 2, (uint8_t *)DYNAMIC_KEYMAP, sizeof(DYNAMIC_KEYMAP));
+    return true;
+}
+
+bool keymap_save_config(void) {
+    // Erase config region
+    if (!keymap_erase_config()) return false;
+
+    // Write the keymap
+    flash_write(CONFIG_ADDR + 2, (uint8_t *)DYNAMIC_KEYMAP, sizeof(DYNAMIC_KEYMAP));
+
+    // Write the length of the keymap, as a signature
+    flash_write_u16(CONFIG_ADDR, CONFIG_SIGNATURE);
+
+    // Verify signature is valid
+    return flash_read_u16(CONFIG_ADDR) == CONFIG_SIGNATURE;
+}
+
+bool keymap_get(int layer, int output, int input, uint16_t * value) {
+    if (layer < KM_LAY && output < KM_OUT && input < KM_IN) {
+        *value = DYNAMIC_KEYMAP[layer][output][input];
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool keymap_set(int layer, int output, int input, uint16_t value) {
+    if (layer < KM_LAY && output < KM_OUT && input < KM_IN) {
+        DYNAMIC_KEYMAP[layer][output][input] = value;
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -15,6 +15,7 @@
 #include <board/kbc.h>
 #include <board/kbled.h>
 #include <board/kbscan.h>
+#include <board/keymap.h>
 #include <board/lid.h>
 #include <board/peci.h>
 #include <board/pmc.h>
@@ -66,6 +67,7 @@ void init(void) {
     {
         kbscan_init();
     }
+    keymap_init();
     peci_init();
     pmc_init();
     pwm_init();

--- a/src/board/system76/darp5/include/board/keymap.h
+++ b/src/board/system76/darp5/include/board/keymap.h
@@ -3,9 +3,15 @@
 #ifndef _BOARD_KEYMAP_H
 #define _BOARD_KEYMAP_H
 
-#include <common/keymap.h>
+// Keymap layers (normal, Fn)
+#define KM_LAY 2
+// Keymap output pins
+#define KM_OUT 18
+// Keymap input pins
+#define KM_IN 8
 
-#define ___ 0
+// common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
+#include <common/keymap.h>
 
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
@@ -35,16 +41,6 @@
     { K0H, K0G, K43, K4C, K59, K10, K0B, K0C }, \
     { K35, K1C, K4F, K51, K4D, K58, K5A, ___ } \
 }
-
-// Keymap output pins
-#define KM_OUT 18
-// Keymap input pins
-#define KM_IN 8
-// Keymap layers (normal, Fn)
-#define KM_LAY 2
-
-// Keymap
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Position of physical Esc key in the matrix
 #define MATRIX_ESC_INPUT    7

--- a/src/board/system76/darp5/keymap/default.c
+++ b/src/board/system76/darp5/keymap/default.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/darp5/keymap/jeremy.c
+++ b/src/board/system76/darp5/keymap/jeremy.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/galp3-c/include/board/keymap.h
+++ b/src/board/system76/galp3-c/include/board/keymap.h
@@ -3,9 +3,15 @@
 #ifndef _BOARD_KEYMAP_H
 #define _BOARD_KEYMAP_H
 
-#include <common/keymap.h>
+// Keymap layers (normal, Fn)
+#define KM_LAY 2
+// Keymap output pins
+#define KM_OUT 16
+// Keymap input pins
+#define KM_IN 8
 
-#define ___ 0
+// common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
+#include <common/keymap.h>
 
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
@@ -33,16 +39,6 @@
     { ___, K2D, K58, K1D, K2E, K0F, K1E, K0G }, \
     { K56, ___, K3C, ___, K59, K0C, K4D, K3D } \
 }
-
-// Keymap output pins
-#define KM_OUT 16
-// Keymap input pins
-#define KM_IN 8
-// Keymap layers (normal, Fn)
-#define KM_LAY 2
-
-// Keymap
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Position of physical Esc key in the matrix
 #define MATRIX_ESC_INPUT    7

--- a/src/board/system76/galp3-c/keymap/carl.c
+++ b/src/board/system76/galp3-c/keymap/carl.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, 0 /* pause */, K_INSERT, K_DEL,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_HOME,

--- a/src/board/system76/galp3-c/keymap/default.c
+++ b/src/board/system76/galp3-c/keymap/default.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, 0 /* pause */, K_INSERT, K_DEL,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_HOME,

--- a/src/board/system76/galp3-c/keymap/jeremy.c
+++ b/src/board/system76/galp3-c/keymap/jeremy.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, 0 /* pause */, K_INSERT, K_DEL,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_HOME,

--- a/src/board/system76/gaze15/include/board/keymap.h
+++ b/src/board/system76/gaze15/include/board/keymap.h
@@ -3,9 +3,15 @@
 #ifndef _BOARD_KEYMAP_H
 #define _BOARD_KEYMAP_H
 
-#include <common/keymap.h>
+// Keymap layers (normal, Fn)
+#define KM_LAY 2
+// Keymap output pins
+#define KM_OUT 18
+// Keymap input pins
+#define KM_IN 8
 
-#define ___ 0
+// common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
+#include <common/keymap.h>
 
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
@@ -35,16 +41,6 @@
     { K0H, K0G, K43, K4C, K59, K10, K0B, K0C }, \
     { K35, K1C, K4F, K51, K4D, K58, K5A, ___ } \
 }
-
-// Keymap output pins
-#define KM_OUT 18
-// Keymap input pins
-#define KM_IN 8
-// Keymap layers (normal, Fn)
-#define KM_LAY 2
-
-// Keymap
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Position of physical Esc key in the matrix
 #define MATRIX_ESC_INPUT    7

--- a/src/board/system76/gaze15/keymap/default.c
+++ b/src/board/system76/gaze15/keymap/default.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/gaze15/keymap/jeremy.c
+++ b/src/board/system76/gaze15/keymap/jeremy.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/lemp9/include/board/keymap.h
+++ b/src/board/system76/lemp9/include/board/keymap.h
@@ -3,9 +3,15 @@
 #ifndef _BOARD_KEYMAP_H
 #define _BOARD_KEYMAP_H
 
-#include <common/keymap.h>
+// Keymap layers (normal, Fn)
+#define KM_LAY 2
+// Keymap output pins
+#define KM_OUT 16
+// Keymap input pins
+#define KM_IN 8
 
-#define ___ 0
+// common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
+#include <common/keymap.h>
 
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
@@ -34,16 +40,6 @@
     { ___, K2D, K60, K1D, K57, K0F, ___, K0G }, \
     { ___, ___, K3C, ___, K61, K0C, ___, K59 } \
 }
-
-// Keymap output pins
-#define KM_OUT 16
-// Keymap input pins
-#define KM_IN 8
-// Keymap layers (normal, Fn)
-#define KM_LAY 2
-
-// Keymap
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Position of physical Esc key in the matrix
 #define MATRIX_ESC_INPUT    7

--- a/src/board/system76/lemp9/keymap/default.c
+++ b/src/board/system76/lemp9/keymap/default.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_HOME, K_END, K_PRINT_SCREEN, K_DEL,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP,

--- a/src/board/system76/lemp9/keymap/ins-prtsc.c
+++ b/src/board/system76/lemp9/keymap/ins-prtsc.c
@@ -5,7 +5,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_HOME, K_END, K_INSERT, K_DEL,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP,

--- a/src/board/system76/lemp9/keymap/jeremy.c
+++ b/src/board/system76/lemp9/keymap/jeremy.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_HOME, K_END, K_PRINT_SCREEN, K_DEL,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP,

--- a/src/board/system76/lemp9/keymap/levi.c
+++ b/src/board/system76/lemp9/keymap/levi.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_HOME, K_END, K_PRINT_SCREEN, K_DEL,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_BRACE_OPEN, K_BRACE_CLOSE, K_BKSP,

--- a/src/board/system76/oryp5/include/board/keymap.h
+++ b/src/board/system76/oryp5/include/board/keymap.h
@@ -3,9 +3,15 @@
 #ifndef _BOARD_KEYMAP_H
 #define _BOARD_KEYMAP_H
 
-#include <common/keymap.h>
+// Keymap layers (normal, Fn)
+#define KM_LAY 2
+// Keymap output pins
+#define KM_OUT 18
+// Keymap input pins
+#define KM_IN 8
 
-#define ___ 0
+// common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
+#include <common/keymap.h>
 
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
@@ -35,16 +41,6 @@
     { K0H, K0G, K43, K4C, K59, K10, K0B, K0C }, \
     { K35, K1C, K4F, K51, K4D, K58, K5A, ___ } \
 }
-
-// Keymap output pins
-#define KM_OUT 18
-// Keymap input pins
-#define KM_IN 8
-// Keymap layers (normal, Fn)
-#define KM_LAY 2
-
-// Keymap
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Position of physical Esc key in the matrix
 #define MATRIX_ESC_INPUT    7

--- a/src/board/system76/oryp5/keymap/default.c
+++ b/src/board/system76/oryp5/keymap/default.c
@@ -2,7 +2,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/oryp6/include/board/keymap.h
+++ b/src/board/system76/oryp6/include/board/keymap.h
@@ -3,9 +3,15 @@
 #ifndef _BOARD_KEYMAP_H
 #define _BOARD_KEYMAP_H
 
-#include <common/keymap.h>
+// Keymap layers (normal, Fn)
+#define KM_LAY 2
+// Keymap output pins
+#define KM_OUT 18
+// Keymap input pins
+#define KM_IN 8
 
-#define ___ 0
+// common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
+#include <common/keymap.h>
 
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
@@ -35,16 +41,6 @@
     { K0H, K0G, K43, K4C, K59, K10, K0B, K0C }, \
     { K35, K1C, K4F, K51, K4D, K58, K5A, ___ } \
 }
-
-// Keymap output pins
-#define KM_OUT 18
-// Keymap input pins
-#define KM_IN 8
-// Keymap layers (normal, Fn)
-#define KM_LAY 2
-
-// Keymap
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Position of physical Esc key in the matrix
 #define MATRIX_ESC_INPUT    7

--- a/src/board/system76/oryp6/keymap/default.c
+++ b/src/board/system76/oryp6/keymap/default.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/board/system76/oryp6/keymap/jeremy.c
+++ b/src/board/system76/oryp6/keymap/jeremy.c
@@ -4,7 +4,7 @@
 
 #include <board/keymap.h>
 
-uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
+uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {
 LAYOUT(
     K_ESC, K_F1, K_F2, K_F3, K_F4, K_F5, K_F6, K_F7, K_F8, K_F9, K_F10, K_F11, K_F12, K_PRINT_SCREEN, K_INSERT, K_DEL, K_HOME, K_END, K_PGUP, K_PGDN,
     K_TICK, K_1, K_2, K_3, K_4, K_5, K_6, K_7, K_8, K_9, K_0, K_MINUS, K_EQUALS, K_BKSP, K_NUM_LOCK, K_NUM_SLASH, K_NUM_ASTERISK, K_NUM_MINUS,

--- a/src/common/include/common/keymap.h
+++ b/src/common/include/common/keymap.h
@@ -5,8 +5,15 @@
 
 #include <stdint.h>
 
+#if defined(KM_LAY) && defined(KM_OUT) && defined(KM_IN)
+extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
+#endif
+
 // Translate a keycode from PS/2 set 2 to PS/2 set 1
 uint16_t keymap_translate(uint16_t key);
+
+// Helper definition for empty key
+#define ___ 0
 
 // Key types
 #define KT_MASK (0xF000)

--- a/src/common/include/common/keymap.h
+++ b/src/common/include/common/keymap.h
@@ -3,10 +3,33 @@
 #ifndef _COMMON_KEYMAP_H
 #define _COMMON_KEYMAP_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
+// Keymap defined by board
 #if defined(KM_LAY) && defined(KM_OUT) && defined(KM_IN)
-extern uint16_t __xdata KEYMAP[KM_LAY][KM_OUT][KM_IN];
+    extern uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN];
+    extern uint16_t __xdata DYNAMIC_KEYMAP[KM_LAY][KM_OUT][KM_IN];
+    #define HAVE_KEYMAP 1
+#else
+    #define HAVE_KEYMAP 0
+#endif
+
+#if HAVE_KEYMAP
+    // Initialize the dynamic keymap
+    void keymap_init(void);
+    // Set the dynamic keymap to the default keymap
+    void keymap_load_default(void);
+    // Erase dynamic keymap in flash
+    bool keymap_erase_config(void);
+    // Load dynamic keymap from flash
+    bool keymap_load_config(void);
+    // Save dynamic keymap to flash
+    bool keymap_save_config(void);
+    // Get a keycode from the dynamic keymap
+    bool keymap_get(int layer, int output, int input, uint16_t * value);
+    // Set a keycode in the dynamic keymap
+    bool keymap_set(int layer, int output, int input, uint16_t value);
 #endif
 
 // Translate a keycode from PS/2 set 2 to PS/2 set 1


### PR DESCRIPTION
Before this PR, turning off a laptop and unplugging the AC adapter would clear custom mapping.
Afther this PR, mappings should be preserved through such an event when.

Test with https://github.com/pop-os/keyboard-configurator/pull/1