### PR TITLE
Typo: "not be be provided" -> "not be provided"

### DIFF
--- a/doc/mega2560.md
+++ b/doc/mega2560.md
@@ -22,7 +22,7 @@ A flexible printed circuit (FPC) breakout board is required. It should have:
 - One side with 1.0mm pitch FPC connector (for all other models)
 
 Depending on the vendor, the connectors may not come soldered to the board (or
-at all). A header block will likely not be be provided, so male breakaway
+at all). A header block will likely not be provided, so male breakaway
 headers will need to be purchased separately.
 
 ### Connecting to the Mega 2560


### PR DESCRIPTION
Deleted a duplicate word