### PR TITLE
Improve ectool performance and implement darp6 UK layout

### DIFF
--- a/src/board/system76/addw1/include/board/keymap.h
+++ b/src/board/system76/addw1/include/board/keymap.h
@@ -13,6 +13,14 @@
 // common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
 #include <common/keymap.h>
 
+// International keys
+#ifndef KI1
+    #define KI1 K_INT_1
+#endif
+#ifndef KI2
+    #define KI2 K_INT_2
+#endif
+
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F, K0G, K0H, K0I, K0J, \
@@ -34,7 +42,7 @@
     { K5C, K34, K36, K02, ___, K4G, K3B, K45 }, \
     { K1F, K48, ___, K2B, K32, K08, K06, K12 }, \
     { K1G, K49, K17, K33, ___, ___, K11, K2A }, \
-    { K2D, ___, K31, K4A, ___, K03, K28, K16 }, \
+    { K2D, KI1, K31, K4A, KI2, K03, K28, K16 }, \
     { ___, K44, K0D, K09, K46, K29, K15, K05 }, \
     { K21, K0A, K2E, K04, K3E, K0E, K0F, K14 }, \
     { K56, K42, K3C, K2H, K27, K2G, K13, K1D }, \

--- a/src/board/system76/addw2/include/board/keymap.h
+++ b/src/board/system76/addw2/include/board/keymap.h
@@ -13,6 +13,14 @@
 // common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
 #include <common/keymap.h>
 
+// International keys
+#ifndef KI1
+    #define KI1 K_INT_1
+#endif
+#ifndef KI2
+    #define KI2 K_INT_2
+#endif
+
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F, K0G, K0H, K0I, K0J, \
@@ -34,7 +42,7 @@
     { K5C, K34, K36, K02, ___, K4G, K3B, K45 }, \
     { K1F, K48, ___, K2B, K32, K08, K06, K12 }, \
     { K1G, K49, K17, K33, ___, ___, K11, K2A }, \
-    { K2D, ___, K31, K4A, ___, K03, K28, K16 }, \
+    { K2D, KI1, K31, K4A, KI2, K03, K28, K16 }, \
     { ___, K44, K0D, K09, K46, K29, K15, K05 }, \
     { K21, K0A, K2E, K04, K3E, K0E, K0F, K14 }, \
     { K56, K42, K3C, K2H, K27, K2G, K13, K1D }, \

--- a/src/board/system76/darp5/include/board/keymap.h
+++ b/src/board/system76/darp5/include/board/keymap.h
@@ -13,6 +13,14 @@
 // common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
 #include <common/keymap.h>
 
+// International keys
+#ifndef KI1
+    #define KI1 K_INT_1
+#endif
+#ifndef KI2
+    #define KI2 K_INT_2
+#endif
+
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F, K0G, K0H, K0I, K0J, \
@@ -34,7 +42,7 @@
     { K5C, K34, K36, K02, ___, K4G, K3B, K45 }, \
     { K1F, K48, ___, K2B, K32, K08, K06, K12 }, \
     { K1G, K49, K17, K33, ___, ___, K11, K2A }, \
-    { K2D, ___, K31, K4A, ___, K03, K28, K16 }, \
+    { K2D, KI1, K31, K4A, KI2, K03, K28, K16 }, \
     { ___, K44, K0D, K09, K46, K29, K15, K05 }, \
     { K21, K0A, K2E, K04, K3E, K0E, K0F, K14 }, \
     { K56, K42, K3C, K2H, K27, K2G, K13, K1D }, \

--- a/src/board/system76/gaze15/include/board/keymap.h
+++ b/src/board/system76/gaze15/include/board/keymap.h
@@ -13,6 +13,14 @@
 // common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
 #include <common/keymap.h>
 
+// International keys
+#ifndef KI1
+    #define KI1 K_INT_1
+#endif
+#ifndef KI2
+    #define KI2 K_INT_2
+#endif
+
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F, K0G, K0H, K0I, K0J, \
@@ -34,7 +42,7 @@
     { K5C, K34, K36, K02, ___, K4G, K3B, K45 }, \
     { K1F, K48, ___, K2B, K32, K08, K06, K12 }, \
     { K1G, K49, K17, K33, ___, ___, K11, K2A }, \
-    { K2D, ___, K31, K4A, ___, K03, K28, K16 }, \
+    { K2D, KI1, K31, K4A, KI2, K03, K28, K16 }, \
     { ___, K44, K0D, K09, K46, K29, K15, K05 }, \
     { K21, K0A, K2E, K04, K3E, K0E, K0F, K14 }, \
     { K56, K42, K3C, K2H, K27, K2G, K13, K1D }, \

--- a/src/board/system76/oryp5/include/board/keymap.h
+++ b/src/board/system76/oryp5/include/board/keymap.h
@@ -13,6 +13,14 @@
 // common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
 #include <common/keymap.h>
 
+// International keys
+#ifndef KI1
+    #define KI1 K_INT_1
+#endif
+#ifndef KI2
+    #define KI2 K_INT_2
+#endif
+
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F, K0G, K0H, K0I, K0J, \
@@ -34,7 +42,7 @@
     { K5C, K34, K36, K02, ___, K4G, K3B, K45 }, \
     { K1F, K48, ___, K2B, K32, K08, K06, K12 }, \
     { K1G, K49, K17, K33, ___, ___, K11, K2A }, \
-    { K2D, ___, K31, K4A, ___, K03, K28, K16 }, \
+    { K2D, KI1, K31, K4A, KI2, K03, K28, K16 }, \
     { ___, K44, K0D, K09, K46, K29, K15, K05 }, \
     { K21, K0A, K2E, K04, K3E, K0E, K0F, K14 }, \
     { K56, K42, K3C, K2H, K27, K2G, K13, K1D }, \

--- a/src/board/system76/oryp5/keymap/default.c
+++ b/src/board/system76/oryp5/keymap/default.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+// Default layout
+
 #include <board/keymap.h>
 
 uint16_t __code KEYMAP[KM_LAY][KM_OUT][KM_IN] = {

--- a/src/board/system76/oryp6/include/board/keymap.h
+++ b/src/board/system76/oryp6/include/board/keymap.h
@@ -13,6 +13,14 @@
 // common/keymap.h requires KM_LAY, KM_OUT, and KM_IN definitions
 #include <common/keymap.h>
 
+// International keys
+#ifndef KI1
+    #define KI1 K_INT_1
+#endif
+#ifndef KI2
+    #define KI2 K_INT_2
+#endif
+
 // Conversion of physical layout to keyboard matrix
 #define LAYOUT( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, K0C, K0D, K0E, K0F, K0G, K0H, K0I, K0J, \
@@ -34,7 +42,7 @@
     { K5C, K34, K36, K02, ___, K4G, K3B, K45 }, \
     { K1F, K48, ___, K2B, K32, K08, K06, K12 }, \
     { K1G, K49, K17, K33, ___, ___, K11, K2A }, \
-    { K2D, ___, K31, K4A, ___, K03, K28, K16 }, \
+    { K2D, KI1, K31, K4A, KI2, K03, K28, K16 }, \
     { ___, K44, K0D, K09, K46, K29, K15, K05 }, \
     { K21, K0A, K2E, K04, K3E, K0E, K0F, K14 }, \
     { K56, K42, K3C, K2H, K27, K2G, K13, K1D }, \

--- a/src/common/include/common/keymap.h
+++ b/src/common/include/common/keymap.h
@@ -264,4 +264,9 @@ uint16_t keymap_translate(uint16_t key);
 #define K_NUM_8 (0x75)
 #define K_NUM_9 (0x7D)
 
+// International keys
+
+#define K_INT_1 (0x61)
+#define K_INT_2 (0x5D)
+
 #endif // _COMMON_KEYMAP_H

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -11,13 +11,13 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -32,16 +32,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "system76_ectool"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hidapi 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_hwio 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum cc 1.0.60 (registry+https://github.com/rust-lang/crates.io-index)" = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 "checksum hidapi 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5c6ffb97f2ec5835ec73bcea5256fc2cd57a13c5958230778ef97f11900ba661"
-"checksum libc 0.2.78 (registry+https://github.com/rust-lang/crates.io-index)" = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
+"checksum libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)" = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 "checksum pkg-config 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 "checksum redox_hwio 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "41aa2c4c67329a04106644cad336238aa5adecfd73d06fb10339d472ce6d8070"

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76_ectool"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 description = "System76 EC tool"
 license = "MIT"

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(feature = "std"), no_std)]
-
 //! Library for accessing System76 ECs
 //! First, construct an access method, using an object implementing the `Access` trait. Next, an Ec
 //! object can be contructed, which exposes the command interface.
@@ -13,6 +11,11 @@
 //!  - `EcLegacy`, `Pmc`, and `SuperIo` all require the `redox_hwio` feature and a nightly
 //!    compiler. It is only recommended to use these in firmware, as mutual exclusion is not
 //!    guaranteed.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 pub use self::access::*;
 mod access;


### PR DESCRIPTION
The UK layout is simple, just specifying which keys should be international keys. We won't support remapping those keys, yet. The work to allow remapping can be done entirely in the keyboard configurator. I have also synced other compatible layouts, in case international keyboards are ever used on those.

And I updated ectool to improve SPI performance. It is on par with performance prior to abstracting the backend. I will need to cargo publish after this is rebased.