### PR TITLE
Fix compilation on AVR

### DIFF
--- a/src/common/include/common/i2c.h
+++ b/src/common/include/common/i2c.h
@@ -6,6 +6,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+// Prevent failures to compile on AVR
+#ifndef __SDCC
+    #define __reentrant
+#endif
+
 // I2C bus, should be defined elsewhere
 struct I2C;
 


### PR DESCRIPTION
The `__reentrant` keyword introduced in common code is for SDCC.