### PR TITLE
Add magic strings read by uecflash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: $(BUILD)/ec.rom
 COMMON_DIR=src/common
 SRC=$(wildcard $(COMMON_DIR)/*.c)
 INCLUDE=$(wildcard $(COMMON_DIR)/include/common/*.h) $(COMMON_DIR)/common.mk
-CFLAGS=-I$(COMMON_DIR)/include -D__FIRMWARE_VERSION__=$(VERSION)
+CFLAGS=-I$(COMMON_DIR)/include -D__FIRMWARE_VERSION__=$(VERSION) -D__FIRMWARE_DATE__=$(DATE)
 include $(COMMON_DIR)/common.mk
 
 # Include the board's source

--- a/src/board/system76/common/uecflash_compat.c
+++ b/src/board/system76/common/uecflash_compat.c
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <common/macro.h>
+
+// Prevent failures to compile on AVR
+#ifndef __SDCC
+    #define __code
+#endif
+
+// Magic strings read by uecflash
+static const char __code UECFLASH_PROJECT[] = "PRJ:" xstr(__BOARD__) "$";
+static const char __code UECFLASH_VERSION[] = "VER: 1.0.0$";
+static const char __code UECFLASH_DATE[] = "DATE: " xstr(__FIRMWARE_DATE__) "$";


### PR DESCRIPTION
uecflash, the program used to flash the EC from firmware-update, expects the binary to have specfic embedded strings in order to report the EC project, version, and date.