### PR TITLE
Sort object files

### DIFF
--- a/src/arch/8051/arch.mk
+++ b/src/arch/8051/arch.mk
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 CC=sdcc -mmcs51 --model-large --code-size $(CODE_SIZE) --xram-size $(SRAM_SIZE) --Werror
-OBJ=$(patsubst src/%.c,$(BUILD)/%.rel,$(SRC))
+OBJ=$(sort $(patsubst src/%.c,$(BUILD)/%.rel,$(SRC)))
 
 # Run EC rom in simulator
 sim: $(BUILD)/ec.rom

--- a/src/arch/avr/arch.mk
+++ b/src/arch/avr/arch.mk
@@ -2,7 +2,7 @@
 
 CC=avr-gcc -mmcu=$(EC)
 CFLAGS+=-Os -fstack-usage -Wall -Werror -Wl,--gc-sections -Wl,-u,vfprintf -lprintf_flt
-OBJ=$(patsubst src/%.c,$(BUILD)/%.o,$(SRC))
+OBJ=$(sort $(patsubst src/%.c,$(BUILD)/%.o,$(SRC)))
 
 # Run EC rom in simulator
 sim: $(BUILD)/ec.elf

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -17,7 +17,7 @@ FLASH_INCLUDE+=$(wildcard $(FLASH_DIR)/include/flash/*.h) $(FLASH_DIR)/flash.mk
 FLASH_CFLAGS+=-I$(FLASH_DIR)/include -D__FLASH__
 
 FLASH_BUILD=$(BUILD)/flash
-FLASH_OBJ=$(patsubst src/%.c,$(FLASH_BUILD)/%.rel,$(FLASH_SRC))
+FLASH_OBJ=$(sort $(patsubst src/%.c,$(FLASH_BUILD)/%.rel,$(FLASH_SRC)))
 FLASH_CC=\
 	sdcc \
 	-mmcs51 \

--- a/src/board/system76/common/scratch/scratch.mk
+++ b/src/board/system76/common/scratch/scratch.mk
@@ -20,7 +20,7 @@ SCRATCH_SRC+=\
 	$(SYSTEM76_COMMON_DIR)/smfi.c
 
 SCRATCH_BUILD=$(BUILD)/scratch
-SCRATCH_OBJ=$(patsubst src/%.c,$(SCRATCH_BUILD)/%.rel,$(SCRATCH_SRC))
+SCRATCH_OBJ=$(sort $(patsubst src/%.c,$(SCRATCH_BUILD)/%.rel,$(SCRATCH_SRC)))
 SCRATCH_CC=\
 	sdcc \
 	-mmcs51 \


### PR DESCRIPTION
ROMs produced of Pop!_OS 20.10 and Fedora 33 with SDCC 4.0.0 cause uecflash to crash after verifying the block write, leaving the  system unbootable until all power is removed to force an EC reset.

Sorting object files appears to resolve this issue, creates a smaller binary (~200 bytes from 20.04), and gives more reproducible builds.

Resolves: system76/firmware-update#26