### PR TITLE
fan smoothing and syncing

### DIFF
--- a/src/board/system76/common/dgpu.c
+++ b/src/board/system76/common/dgpu.c
@@ -53,7 +53,7 @@ static struct Fan __code FAN = {
     .heatup_size = ARRAY_SIZE(FAN_HEATUP),
     .cooldown = FAN_COOLDOWN,
     .cooldown_size = ARRAY_SIZE(FAN_COOLDOWN),
-    #ifdef FAN_SMOOTHING
+    #if defined(FAN_SMOOTHING) || defined(FAN_SMOOTHING_UP) || defined(FAN_SMOOTHING_DOWN)
       .interpolate = true,
     #else
       .interpolate = false,
@@ -93,7 +93,7 @@ void dgpu_event(void) {
         // Apply heatup and cooldown filters to duty
         duty = fan_heatup(&FAN, duty);
         duty = fan_cooldown(&FAN, duty);
-        #ifdef FAN_SMOOTHING
+        #if defined(FAN_SMOOTHING) || defined(FAN_SMOOTHING_UP) || defined(FAN_SMOOTHING_DOWN)
           duty = fan_smooth(last_duty_dgpu, duty);
           last_duty_dgpu = duty;
         #endif

--- a/src/board/system76/common/dgpu.c
+++ b/src/board/system76/common/dgpu.c
@@ -27,7 +27,6 @@ static uint8_t FAN_HEATUP[BOARD_DGPU_HEATUP] = { 0 };
 static uint8_t FAN_COOLDOWN[BOARD_DGPU_COOLDOWN] = { 0 };
 
 int16_t dgpu_temp = 0;
-uint8_t last_duty_dgpu = 0;
 
 #define DGPU_TEMP(X) ((int16_t)(X))
 
@@ -65,7 +64,7 @@ void dgpu_init(void) {
     i2c_reset(&I2C_DGPU, true);
 }
 
-void dgpu_event(void) {
+uint8_t dgpu_get_fan_duty(void) {
     uint8_t duty;
     if (power_state == POWER_STATE_S0 && gpio_get(&DGPU_PWR_EN) && !gpio_get(&GC6_FB_EN)) {
         // Use I2CS if in S0 state
@@ -93,22 +92,18 @@ void dgpu_event(void) {
         // Apply heatup and cooldown filters to duty
         duty = fan_heatup(&FAN, duty);
         duty = fan_cooldown(&FAN, duty);
-        #if defined(FAN_SMOOTHING) || defined(FAN_SMOOTHING_UP) || defined(FAN_SMOOTHING_DOWN)
-          duty = fan_smooth(last_duty_dgpu, duty);
-          last_duty_dgpu = duty;
-        #endif
     }
 
-    if (duty != DCR4) {
-        DCR4 = duty;
-        DEBUG("DGPU temp=%d = %d\n", dgpu_temp, duty);
-    }
+    DEBUG("DGPU temp=%d\n", dgpu_temp);
+    return duty;
 }
 
 #else
 
 void dgpu_init(void) {}
 
-void dgpu_event(void) {}
+uint8_t dgpu_get_fan_duty(void) {
+  return PWM_DUTY(0);
+}
 
 #endif // HAVE_DGPU

--- a/src/board/system76/common/dgpu.c
+++ b/src/board/system76/common/dgpu.c
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/dgpu.h>
+#include <board/fan.h>
 
 #if HAVE_DGPU
-
-#include <board/fan.h>
 #include <board/gpio.h>
 #include <board/power.h>
 #include <common/debug.h>

--- a/src/board/system76/common/fan.c
+++ b/src/board/system76/common/fan.c
@@ -25,6 +25,9 @@ uint8_t last_duty_peci = 0;
 
   const uint8_t max_jump_up = (max_speed - min_speed) / (uint8_t) FAN_SMOOTHING_UP;
   const uint8_t max_jump_down = (max_speed - min_speed) / (uint8_t) FAN_SMOOTHING_DOWN;
+#else
+  const uint8_t max_jump_up = max_speed - min_speed;
+  const uint8_t max_jump_down = max_speed - min_speed;
 #endif
 
 void fan_reset(void) {
@@ -122,34 +125,32 @@ uint8_t fan_cooldown(const struct Fan * fan, uint8_t duty) __reentrant {
     return highest;
 }
 
-#ifdef FAN_SMOOTHING
-  uint8_t fan_smooth(uint8_t last_duty, uint8_t duty) __reentrant {
-    uint8_t next_duty = duty;
+uint8_t fan_smooth(uint8_t last_duty, uint8_t duty) __reentrant {
+  uint8_t next_duty = duty;
 
-    // ramping down
-    if (duty < last_duty) {
-      // out of bounds (lower) safeguard
-      uint8_t smoothed = last_duty < min_speed + max_jump_down
-        ? min_speed
-        : last_duty - max_jump_down;
+  // ramping down
+  if (duty < last_duty) {
+    // out of bounds (lower) safeguard
+    uint8_t smoothed = last_duty < min_speed + max_jump_down
+      ? min_speed
+      : last_duty - max_jump_down;
 
-      if (smoothed > duty) {
-        next_duty = smoothed;
-      }
+    if (smoothed > duty) {
+      next_duty = smoothed;
     }
-
-    // ramping up
-    if (duty > last_duty) {
-      // out of bounds (higher) safeguard
-      uint8_t smoothed = last_duty > max_speed - max_jump_up
-        ? max_speed
-        : last_duty + max_jump_up;
-
-      if (smoothed < duty) {
-        next_duty = smoothed;
-      }
-    }
-
-    return next_duty;
   }
-#endif
+
+  // ramping up
+  if (duty > last_duty) {
+    // out of bounds (higher) safeguard
+    uint8_t smoothed = last_duty > max_speed - max_jump_up
+      ? max_speed
+      : last_duty + max_jump_up;
+
+    if (smoothed < duty) {
+      next_duty = smoothed;
+    }
+  }
+
+  return next_duty;
+}

--- a/src/board/system76/common/fan.c
+++ b/src/board/system76/common/fan.c
@@ -82,7 +82,7 @@ void fan_duty_set(uint8_t peci_fan_duty, uint8_t dgpu_fan_duty) __reentrant {
   if (peci_fan_duty != DCR2) {
       DEBUG("PECI fan_duty_raw=%d\n", peci_fan_duty);
       last_duty_peci = peci_fan_duty = fan_smooth(last_duty_peci, peci_fan_duty);
-      DCR2 = peci_fan_duty;
+      DCR2 = fan_max ? max_speed : peci_fan_duty;
       DEBUG("PECI fan_duty_smoothed=%d\n", peci_fan_duty);
   }
 
@@ -90,7 +90,7 @@ void fan_duty_set(uint8_t peci_fan_duty, uint8_t dgpu_fan_duty) __reentrant {
   if (dgpu_fan_duty != DCR4) {
       DEBUG("DGPU fan_duty_raw=%d\n", dgpu_fan_duty);
       last_duty_dgpu = dgpu_fan_duty = fan_smooth(last_duty_dgpu, dgpu_fan_duty);
-      DCR4 = dgpu_fan_duty;
+      DCR4 = fan_max ? max_speed : dgpu_fan_duty;
       DEBUG("DGPU fan_duty_smoothed=%d\n", dgpu_fan_duty);
   }
 }

--- a/src/board/system76/common/fan.c
+++ b/src/board/system76/common/fan.c
@@ -80,16 +80,18 @@ void fan_duty_set(uint8_t peci_fan_duty, uint8_t dgpu_fan_duty) __reentrant {
 
   // set PECI fan duty
   if (peci_fan_duty != DCR2) {
+      DEBUG("PECI fan_duty_raw=%d\n", peci_fan_duty);
       last_duty_peci = peci_fan_duty = fan_smooth(last_duty_peci, peci_fan_duty);
       DCR2 = peci_fan_duty;
-      DEBUG("PECI fan_duty=%d\n", peci_fan_duty);
+      DEBUG("PECI fan_duty_smoothed=%d\n", peci_fan_duty);
   }
 
   // set dGPU fan duty
   if (dgpu_fan_duty != DCR4) {
+      DEBUG("DGPU fan_duty_raw=%d\n", dgpu_fan_duty);
       last_duty_dgpu = dgpu_fan_duty = fan_smooth(last_duty_dgpu, dgpu_fan_duty);
       DCR4 = dgpu_fan_duty;
-      DEBUG("DGPU fan_duty=%d\n", dgpu_fan_duty);
+      DEBUG("DGPU fan_duty_smoothed=%d\n", dgpu_fan_duty);
   }
 }
 

--- a/src/board/system76/common/include/board/dgpu.h
+++ b/src/board/system76/common/include/board/dgpu.h
@@ -14,6 +14,6 @@
 #endif // HAVE_DGPU
 
 void dgpu_init(void);
-void dgpu_event(void);
+uint8_t dgpu_get_fan_duty(void);
 
 #endif // _BOARD_DGPU_H

--- a/src/board/system76/common/include/board/fan.h
+++ b/src/board/system76/common/include/board/fan.h
@@ -30,5 +30,6 @@ void fan_reset(void);
 uint8_t fan_duty(const struct Fan * fan, int16_t temp) __reentrant;
 uint8_t fan_heatup(const struct Fan * fan, uint8_t duty) __reentrant;
 uint8_t fan_cooldown(const struct Fan * fan, uint8_t duty) __reentrant;
+uint8_t fan_smooth(uint8_t last_duty, uint8_t duty) __reentrant;
 
 #endif // _BOARD_FAN_H

--- a/src/board/system76/common/include/board/fan.h
+++ b/src/board/system76/common/include/board/fan.h
@@ -28,6 +28,7 @@ extern bool fan_max;
 void fan_reset(void);
 
 uint8_t fan_duty(const struct Fan * fan, int16_t temp) __reentrant;
+void fan_duty_set(uint8_t peci_fan_duty, uint8_t dgpu_fan_duty) __reentrant;
 uint8_t fan_heatup(const struct Fan * fan, uint8_t duty) __reentrant;
 uint8_t fan_cooldown(const struct Fan * fan, uint8_t duty) __reentrant;
 uint8_t fan_smooth(uint8_t last_duty, uint8_t duty) __reentrant;

--- a/src/board/system76/common/include/board/peci.h
+++ b/src/board/system76/common/include/board/peci.h
@@ -9,6 +9,6 @@ extern int16_t peci_temp;
 
 void peci_init(void);
 int peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data);
-void peci_event(void);
+uint8_t peci_get_fan_duty(void);
 
 #endif // _BOARD_PECI_H

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -10,6 +10,7 @@
 #include <board/board.h>
 #include <board/dgpu.h>
 #include <board/ecpm.h>
+#include <board/fan.h>
 #include <board/gpio.h>
 #include <board/gctrl.h>
 #include <board/kbc.h>
@@ -126,13 +127,8 @@ void main(void) {
             if (last_time_fan > time || (time - last_time_fan) >= fan_interval) {
                 last_time_fan = time;
 
-                // Updates fan status and temps
-                peci_event();
-
-#if HAVE_DGPU && (!defined(SYNC_FANS) || !SYNC_FANS)
-                // Updates discrete GPU fan status and temps
-                dgpu_event();
-#endif
+                // Update fan speeds
+                fan_duty_set(peci_get_fan_duty(), dgpu_get_fan_duty());
             }
 
             // Only run the following once per interval

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -43,7 +43,7 @@ void timer_2(void) __interrupt(5) {}
 
 uint8_t main_cycle = 0;
 const uint16_t battery_interval = 1000;
-#ifdef FAN_SMOOTHING
+#if defined(FAN_SMOOTHING) || defined(FAN_SMOOTHING_UP) || defined(FAN_SMOOTHING_DOWN)
   const uint16_t fan_interval = 250; // event loop is longer than 100ms and maybe even longer than 250
 #else
   const uint16_t fan_interval = 1000;

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -29,7 +29,7 @@ static uint8_t FAN_COOLDOWN[BOARD_COOLDOWN] = { 0 };
 
 int16_t peci_temp = 0;
 
-#define PECI_TEMP(X) (((int16_t)(X)) << 6)
+#define PECI_TEMP(X) ((int16_t)(X))
 
 #define FAN_POINT(T, D) { .temp = PECI_TEMP(T), .duty = PWM_DUTY(D) }
 
@@ -158,10 +158,11 @@ uint8_t peci_get_fan_duty(void) {
             // Use result if finished successfully
             uint8_t low = HORDDR;
             uint8_t high = HORDDR;
-            uint16_t peci_offset = ((int16_t)high << 8) | (int16_t)low;
+            uint16_t peci_offset = (((int16_t)high << 8) | (int16_t)low) >> 6;
 
             peci_temp = PECI_TEMP(T_JUNCTION) + peci_offset;
             duty = fan_duty(&FAN, peci_temp);
+            DEBUG("PECI offset=%d temp=%d duty=%d\n", peci_offset, peci_temp, duty);
         } else {
             // Default to 50% if there is an error
             peci_temp = 0;

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -182,6 +182,6 @@ uint8_t peci_get_fan_duty(void) {
         duty = fan_cooldown(&FAN, duty);
     }
 
-    DEBUG("PECI temp=%d = %d\n", peci_temp);
+    DEBUG("PECI temp=%d\n", peci_temp);
     return duty;
 }

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -54,7 +54,7 @@ static struct Fan __code FAN = {
     .heatup_size = ARRAY_SIZE(FAN_HEATUP),
     .cooldown = FAN_COOLDOWN,
     .cooldown_size = ARRAY_SIZE(FAN_COOLDOWN),
-    #ifdef FAN_SMOOTHING
+    #if defined(FAN_SMOOTHING) || defined(FAN_SMOOTHING_UP) || defined(FAN_SMOOTHING_DOWN)
       .interpolate = true,
     #else
       .interpolate = false,
@@ -181,7 +181,7 @@ void peci_event(void) {
         // Apply heatup and cooldown filters to duty
         duty = fan_heatup(&FAN, duty);
         duty = fan_cooldown(&FAN, duty);
-        #ifdef FAN_SMOOTHING
+        #if defined(FAN_SMOOTHING) || defined(FAN_SMOOTHING_UP) || defined(FAN_SMOOTHING_DOWN)
           duty = fan_smooth(last_duty_cpu, duty);
           last_duty_cpu = duty;
         #endif

--- a/src/board/system76/common/pwm.c
+++ b/src/board/system76/common/pwm.c
@@ -22,7 +22,7 @@ void pwm_init(void) {
     // Set cycle time to 255 + 1
     CTR0 = 255;
 
-    // Turn off CPU fan (temperature control in peci_event)
+    // Turn off CPU fan (temperature control in peci_get_fan_duty)
     DCR2 = 0;
 
     // Enable PWM

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -43,7 +43,8 @@ CFLAGS+=\
 # sync GPU fan speed to CPU fan speed (great for galp5 w/o dGPU)
 CFLAGS+=-DSYNC_FANS=1
 # smooth the fan speed updates such that 0 to full speed happens over this period (divide by 4 for seconds)
-CFLAGS+=-DFAN_SMOOTHING=50
+CFLAGS+=-DFAN_SMOOTHING_UP=45
+CFLAGS+=-DFAN_SMOOTHING_DOWN=100
 
 # Custom fan curve
 CFLAGS+=-DBOARD_HEATUP=5

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -40,6 +40,11 @@ CFLAGS+=\
 	-DPOWER_LIMIT_AC=65 \
 	-DPOWER_LIMIT_DC=28
 
+# sync GPU fan speed to CPU fan speed (great for galp5 w/o dGPU)
+CFLAGS+=-DSYNC_FANS=1
+# smooth the fan speed updates such that 0 to full speed happens over this period (divide by 4 for seconds)
+CFLAGS+=-DFAN_SMOOTHING=50
+
 # Custom fan curve
 CFLAGS+=-DBOARD_HEATUP=5
 CFLAGS+=-DBOARD_COOLDOWN=20


### PR DESCRIPTION
## NOTES
- I'm a C newb and very interested in how this could be refactored for elegance, accuracy, etc.
- First PR on this repo. I developed this off the commit for my current firmware (galp5 2020-12-15_79d6fa7) and later rebased to master. Please advise improvements to the PR itself.

## CHANGES
I wrote this for my new galp5 to address a common complaint of the fans jumping from 0 to 100 and back abruptly. This PR adds support for new build flags:
- `SYNC_FANS` will read target fan speeds from both CPU and GPU fan curves, take the max and set both fans to this speed.
- `FAN_SMOOTHING` sets the number of fan speed event loops that a 0 - 100 speed ramp should be smoothed across. Effectively, this determines the maximum fan speed adjustment for each event loop to prevent audible stepping. A high number yields a slower and smoother ramp while a low number yields a fast response.
- `FAN_SMOOTHING_UP` sets the fan smoothing (as described above) for the fan speed increases
- `FAN_SMOOTHING_DOWN` sets the fan smoothing (as described above) for the fan speed decreases

See updated galp5 board config for an example of these new values: https://github.com/system76/ec/pull/139/files#diff-198f0231dadddcc1692e1557f98782a282a0e540eb1664fd95402cb0574caab8R43

Attempts to fix https://github.com/system76/firmware-open/issues/149 and https://github.com/system76/firmware-open/issues/148