### PR TITLE
lemp10: Set DPWROK low on EC reset to ensure PCH reset

### DIFF
--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -52,8 +52,7 @@ void gpio_init() {
     GCR21 = BIT(2);
 
     // Set GPIO data
-    // PCH_DPWROK_EC, NC
-    GPDRA = BIT(7) | BIT(5);
+    GPDRA = 0;
     // XLP_OUT, PWR_SW#
     GPDRB = BIT(4) | BIT(3);
     GPDRC = 0;


### PR DESCRIPTION
I've flashed this using a USB stick many times and have seen the behavior I expect