### PR TITLE
docs: Explicitly mention to use a USB cable

### DIFF
--- a/doc/flashing.md
+++ b/doc/flashing.md
@@ -15,18 +15,25 @@ make BOARD=<vendor>/<model> flash_internal
 
 Use this method for first-time flashing or flashing a bricked controller.
 
-[A Mega 2560 is required for flashing.](./mega2560.md)
+This requires:
+
+- [A configured Mega 2560](./mega2560.md): For programming the EC itself
+- A USB cable: For creating a common ground and providing power
+    - USB-C is recommended, but USB-A will work as well
+- A second computer: For building and flashing the firmware
 
 **The system must not have any power!**
 
-1. Turn off the computer
+1. Turn off the laptop
 2. Unplug the AC adapter
 3. Remove the bottom panel
 4. Disconnect the battery
-5. Ground the laptop to the programmer
-6. Disconnect the keyboard from its port
-7. Attach the programmer to the keyboard port
-8. Flash the firmware
+5. Disconnect the keyboard from its port
+6. Replace the bottom panel and flip the laptop back over
+7. Connect the USB cable from the laptop to the host machine
+8. Connect the Mega 2560 to the host machine
+9. Attach the programmer to the keyboard port
+10. Flash the firmware
 
 ```
 make BOARD=<vendor>/<model> flash_external


### PR DESCRIPTION
Replace the vague step about grounding with one that says to connect a USB cable and explain its purpose.