### PR TITLE
Add missing SPDX identifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
 
 jobs:
+  spdx:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check SPDX identifiers
+        run: ./scripts/spdx.sh
+
   build:
     runs-on: ubuntu-20.04
     strategy:

--- a/scripts/ectool.sh
+++ b/scripts/ectool.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
 
 set -e
 cargo build --release --manifest-path tool/Cargo.toml

--- a/scripts/power.sh
+++ b/scripts/power.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
 
 set -e
 

--- a/scripts/spdx.sh
+++ b/scripts/spdx.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+# Check that all files have a SPDX license identifier
+
+set -e
+
+# File patterns to check
+FILE_TYPES=(
+    '*.c'
+    '*.h'
+    '*.mk'
+    '*.rs'
+    '*.sh'
+    'Makefile'
+)
+
+ret=0
+
+for ft in "${FILE_TYPES[@]}"; do
+    files=$(git ls-files "$ft")
+    for f in ${files}; do
+        # Skip empty files
+        if [[ "$(wc -l < "$f")" = "0" ]]; then
+            continue
+        fi
+
+        # SPDX must appear at head of file
+        if ! head "$f" | grep -q 'SPDX-License-Identifier:'; then
+            echo "$f: Missing SPDX identifier"
+            ret=1
+        fi
+    done
+done
+
+exit ${ret}

--- a/src/board/system76/common/keymap.c
+++ b/src/board/system76/common/keymap.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #include <board/flash.h>
 #include <board/keymap.h>
 

--- a/tool/src/access/hid.rs
+++ b/tool/src/access/hid.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use hidapi::HidDevice;
 
 use crate::{

--- a/tool/src/access/lpc/direct.rs
+++ b/tool/src/access/lpc/direct.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use hwio::{Io, Pio};
 
 use crate::{

--- a/tool/src/access/lpc/linux.rs
+++ b/tool/src/access/lpc/linux.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     fs,
     io::{

--- a/tool/src/access/lpc/mod.rs
+++ b/tool/src/access/lpc/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 const SMFI_CMD_BASE: u16 = 0xE00;
 const SMFI_CMD_SIZE: usize = 0x100;
 

--- a/tool/src/access/lpc/sim.rs
+++ b/tool/src/access/lpc/sim.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use std::{
     io,
     net::UdpSocket,
@@ -40,7 +42,7 @@ impl AccessLpcSim {
                 "Socket request incorrect size"
             ));
         }
-    
+
         let mut response = [0];
         if self.socket.recv(&mut response)? != response.len() {
             return Err(io::Error::new(
@@ -48,14 +50,14 @@ impl AccessLpcSim {
                 "Socket response incorrect size"
             ));
         }
-    
+
         Ok(response[0])
     }
-    
+
     pub fn inb(&mut self, addr: u16) -> Result<u8, Error> {
         Ok(self.transaction(0x01, addr, 0)?)
     }
-    
+
     pub fn outb(&mut self, addr: u16, value: u8) -> Result<(), Error> {
         self.transaction(0x02, addr, value)?;
         Ok(())

--- a/tool/src/access/mod.rs
+++ b/tool/src/access/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::Error;
 use downcast_rs::Downcast;
 

--- a/tool/src/ec.rs
+++ b/tool/src/ec.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[cfg(not(feature = "std"))]
 use alloc::{
     boxed::Box,

--- a/tool/src/error.rs
+++ b/tool/src/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 /// Errors returned by operations
 #[derive(Debug)]
 pub enum Error {

--- a/tool/src/firmware.rs
+++ b/tool/src/firmware.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 /// Parses firmware information from a firmware ROM
 pub struct Firmware<'a> {
     pub board: &'a [u8],

--- a/tool/src/legacy.rs
+++ b/tool/src/legacy.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     Error,
     Pmc,

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 //! Library for accessing System76 ECs
 //! First, construct an access method, using an object implementing the `Access` trait. Next, an Ec
 //! object can be contructed, which exposes the command interface.

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use clap::{Arg, App, AppSettings, SubCommand};
 use ectool::{
     Access,

--- a/tool/src/pmc.rs
+++ b/tool/src/pmc.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use hwio::{Io, Pio};
 
 use crate::{

--- a/tool/src/spi.rs
+++ b/tool/src/spi.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use crate::{
     Error,
     Timeout,

--- a/tool/src/super_io.rs
+++ b/tool/src/super_io.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use hwio::{Io, Pio};
 
 /// Super I/O interface provided by LPC ECs

--- a/tool/src/timeout.rs
+++ b/tool/src/timeout.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #[cfg(feature = "std")]
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
- Add missing SPDX identifiers to source files
- Add a simple script to check for missing identifiers
- Add a CI job to check for missing identifiers