### PR TITLE
Always notify OS of SCI when pmc_sci is called

### DIFF
--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -275,6 +275,7 @@ static inline bool key_should_repeat(uint16_t key) {
     case K_AIRPLANE_MODE:
     case K_CAMERA_TOGGLE:
     case K_DISPLAY_TOGGLE:
+    case K_FAN_TOGGLE:
     case K_SUSPEND:
     case K_KBD_BKL:
     case K_KBD_COLOR:

--- a/src/board/system76/common/pmc.c
+++ b/src/board/system76/common/pmc.c
@@ -53,16 +53,15 @@ static void pmc_sci_interrupt(void) {
 }
 
 bool pmc_sci(struct Pmc * pmc, uint8_t sci) {
-    // Set SCI queue if possible
+    // Set SCI pending bit
+    pmc_set_status(pmc, pmc_status(pmc) | (1 << 5));
+
+    // Send SCI
+    pmc_sci_interrupt();
+
+    // Set SCI queue if not already set
     if (pmc_sci_queue == 0) {
         pmc_sci_queue = sci;
-
-        // Set SCI pending bit
-        pmc_set_status(pmc, pmc_status(pmc) | (1 << 5));
-
-        // Send SCI
-        pmc_sci_interrupt();
-
         return true;
     } else {
         return false;


### PR DESCRIPTION
This might fix issues with the oryp7 missing SCI events. It will need testing on multiple models and inspection of the kernel logs for errors. I threw in a change to not repeat K_FAN_TOGGLE, which I found while testing this.