### PR TITLE
tool: Make `Access` require `Send` and `'static` 

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -13,6 +13,7 @@ source /etc/os-release
 
 msg "Installing system build dependencies"
 if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
+    sudo apt-get update
     sudo apt-get install \
         --no-install-recommends \
         --yes \

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -87,7 +87,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "system76_ectool"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap 2.33.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "downcast-rs 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76_ectool"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2018"
 description = "System76 EC tool"
 license = "MIT"

--- a/tool/src/access/lpc/direct.rs
+++ b/tool/src/access/lpc/direct.rs
@@ -13,13 +13,13 @@ use crate::{
 use super::*;
 
 /// Use direct hardware access. Unsafe due to not having mutual exclusion
-pub struct AccessLpcDirect<T: Timeout + 'static> {
+pub struct AccessLpcDirect<T: Timeout + Send + 'static> {
     cmd: u16,
     dbg: u16,
     timeout: T,
 }
 
-impl<T: Timeout> AccessLpcDirect<T> {
+impl<T: Timeout + Send> AccessLpcDirect<T> {
     /// Checks that Super I/O ID matches and then returns access object
     pub unsafe fn new(timeout: T) -> Result<Self, Error> {
         // Make sure EC ID matches
@@ -71,7 +71,7 @@ impl<T: Timeout> AccessLpcDirect<T> {
     }
 }
 
-impl<T: Timeout> Access for AccessLpcDirect<T> {
+impl<T: Timeout + Send> Access for AccessLpcDirect<T> {
     unsafe fn command(&mut self, cmd: u8, data: &mut [u8]) -> Result<u8, Error> {
         // Test data length
         if data.len() > self.data_size() {

--- a/tool/src/access/mod.rs
+++ b/tool/src/access/mod.rs
@@ -23,7 +23,7 @@ pub use self::lpc::*;
 mod lpc;
 
 /// Access method for running an EC command
-pub trait Access: Downcast {
+pub trait Access: Downcast + Send + 'static {
     /// Sends a command using the access method. Only internal use is recommended
     unsafe fn command(&mut self, cmd: u8, data: &mut [u8]) -> Result<u8, Error>;
 


### PR DESCRIPTION
This allows the Configurator to send a `Ec<Box<dyn Access>>` through a channel to a background thread. This could be done differently, but presumably there's no reason to have an `Access` implementation this oesn't apply to.