### PR TITLE
Sync dGPU and PECI fans (at highest requested duty)

### DIFF
--- a/src/board/system76/common/dgpu.c
+++ b/src/board/system76/common/dgpu.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/dgpu.h>
+#include <board/fan.h>
 
 #if HAVE_DGPU
 
@@ -61,7 +62,7 @@ void dgpu_init(void) {
     i2c_reset(&I2C_DGPU, true);
 }
 
-void dgpu_event(void) {
+uint8_t dgpu_get_fan_duty(void) {
     uint8_t duty;
     if (power_state == POWER_STATE_S0 && gpio_get(&DGPU_PWR_EN) && !gpio_get(&GC6_FB_EN)) {
         // Use I2CS if in S0 state
@@ -91,16 +92,16 @@ void dgpu_event(void) {
         duty = fan_cooldown(&FAN, duty);
     }
 
-    if (duty != DCR4) {
-        DCR4 = duty;
-        DEBUG("DGPU temp=%d = %d\n", dgpu_temp, duty);
-    }
+    DEBUG("DGPU temp=%d\n", dgpu_temp);
+    return duty;
 }
 
 #else
 
 void dgpu_init(void) {}
 
-void dgpu_event(void) {}
+uint8_t dgpu_get_fan_duty(void) {
+  return PWM_DUTY(0);
+}
 
 #endif // HAVE_DGPU

--- a/src/board/system76/common/fan.c
+++ b/src/board/system76/common/fan.c
@@ -9,6 +9,10 @@ bool fan_max = false;
 #define max_speed PWM_DUTY(100)
 #define min_speed PWM_DUTY(0)
 
+#ifndef SYNC_FANS
+  #define SYNC_FANS 1
+#endif
+
 void fan_reset(void) {
     // Do not manually set fans to maximum speed
     fan_max = false;
@@ -52,7 +56,7 @@ uint8_t fan_duty(const struct Fan * fan, int16_t temp) __reentrant {
 }
 
 void fan_duty_set(uint8_t peci_fan_duty, uint8_t dgpu_fan_duty) __reentrant {
-  #ifdef SYNC_FANS
+  #if SYNC_FANS != 0
     peci_fan_duty = peci_fan_duty > dgpu_fan_duty ? peci_fan_duty : dgpu_fan_duty;
     dgpu_fan_duty = peci_fan_duty > dgpu_fan_duty ? peci_fan_duty : dgpu_fan_duty;
   #endif

--- a/src/board/system76/common/include/board/dgpu.h
+++ b/src/board/system76/common/include/board/dgpu.h
@@ -14,6 +14,6 @@
 #endif // HAVE_DGPU
 
 void dgpu_init(void);
-void dgpu_event(void);
+uint8_t dgpu_get_fan_duty(void);
 
 #endif // _BOARD_DGPU_H

--- a/src/board/system76/common/include/board/fan.h
+++ b/src/board/system76/common/include/board/fan.h
@@ -28,6 +28,7 @@ extern bool fan_max;
 void fan_reset(void);
 
 uint8_t fan_duty(const struct Fan * fan, int16_t temp) __reentrant;
+void fan_duty_set(uint8_t peci_fan_duty, uint8_t dgpu_fan_duty) __reentrant;
 uint8_t fan_heatup(const struct Fan * fan, uint8_t duty) __reentrant;
 uint8_t fan_cooldown(const struct Fan * fan, uint8_t duty) __reentrant;
 

--- a/src/board/system76/common/include/board/peci.h
+++ b/src/board/system76/common/include/board/peci.h
@@ -10,6 +10,6 @@ extern int16_t peci_temp;
 
 void peci_init(void);
 int peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data);
-void peci_event(void);
+uint8_t peci_get_fan_duty(void);
 
 #endif // _BOARD_PECI_H

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -10,6 +10,7 @@
 #include <board/board.h>
 #include <board/dgpu.h>
 #include <board/ecpm.h>
+#include <board/fan.h>
 #include <board/gpio.h>
 #include <board/gctrl.h>
 #include <board/kbc.h>
@@ -118,13 +119,8 @@ void main(void) {
             if (last_time > time || (time - last_time) >= 1000) {
                 last_time = time;
 
-                // Updates fan status and temps
-                peci_event();
-
-#if HAVE_DGPU
-                // Updates discrete GPU fan status and temps
-                dgpu_event();
-#endif
+                // Update fan speeds
+                fan_duty_set(peci_get_fan_duty(), dgpu_get_fan_duty());
 
                 // Updates battery status
                 battery_event();

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -119,7 +119,7 @@ int peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
 }
 
 // PECI information can be found here: https://www.intel.com/content/dam/www/public/us/en/documents/design-guides/core-i7-lga-2011-guide.pdf
-void peci_event(void) {
+uint8_t peci_get_fan_duty(void) {
     uint8_t duty;
 
 #if EC_ESPI
@@ -180,8 +180,6 @@ void peci_event(void) {
         duty = fan_cooldown(&FAN, duty);
     }
 
-    if (duty != DCR2) {
-        DCR2 = duty;
-        DEBUG("PECI temp=%d = %d\n", peci_temp, duty);
-    }
+    DEBUG("PECI temp=%d\n", peci_temp);
+    return duty;
 }

--- a/src/board/system76/common/pwm.c
+++ b/src/board/system76/common/pwm.c
@@ -22,7 +22,7 @@ void pwm_init(void) {
     // Set cycle time to 255 + 1
     CTR0 = 255;
 
-    // Turn off CPU fan (temperature control in peci_event)
+    // Turn off CPU fan (temperature control in peci_get_fan_duty)
     DCR2 = 0;
 
     // Enable PWM

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -40,9 +40,6 @@ CFLAGS+=\
 	-DPOWER_LIMIT_AC=65 \
 	-DPOWER_LIMIT_DC=28
 
-# sync GPU fan speed to CPU fan speed (great for galp5 w/o dGPU)
-CFLAGS+=-DSYNC_FANS=1
-
 # Custom fan curve
 CFLAGS+=-DBOARD_HEATUP=5
 CFLAGS+=-DBOARD_COOLDOWN=20

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -40,6 +40,9 @@ CFLAGS+=\
 	-DPOWER_LIMIT_AC=65 \
 	-DPOWER_LIMIT_DC=28
 
+# sync GPU fan speed to CPU fan speed (great for galp5 w/o dGPU)
+CFLAGS+=-DSYNC_FANS=1
+
 # Custom fan curve
 CFLAGS+=-DBOARD_HEATUP=5
 CFLAGS+=-DBOARD_COOLDOWN=20


### PR DESCRIPTION
Fix for https://github.com/system76/firmware-open/issues/148

## CHANGES
This PR adds support for new build flags:
- `SYNC_FANS` will read target fan speeds from both CPU and GPU fan curves, take the max and set both fans to this speed.
