### PR TITLE
Update keyboard customization instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ Install dependencies using the provided script:
 ```
 ./scripts/deps.sh
 ```
+
+The dependencies include `rustup` - if it wasn't installed on your system before and you plan to flash the firmware within the same shell session, you should additionally source the environment variables for cargo to avoid build failures:
+
+```
+source $HOME/.cargo/env
+```

--- a/doc/keyboard-layout-customization.md
+++ b/doc/keyboard-layout-customization.md
@@ -41,6 +41,7 @@ KEYMAP?=jeremy
 ```
 
 ## Test build your EC
+* Make sure all dependencies are installed (see above).
 * From the `ec` directory, run `make` to make sure it builds correctly.
 
 ## Flash your EC


### PR DESCRIPTION
I overlooked the first paragraph in the keyboard customization readme and jumped directly to the build steps so that I missed to install the build dependencies. Additionally, as `rustup` wasn't installed on my machine, I had to `source $HOME/.cargo/env` because I didn't restart the shell between `./scripts/dev.sh` and `make flash_internal`.

This PR updates the installation instructions.