### PR TITLE
kbc: Reduce timeout from 10ms to 1ms

### DIFF
--- a/src/board/system76/common/kbc.c
+++ b/src/board/system76/common/kbc.c
@@ -22,7 +22,7 @@ void kbc_init(void) {
     *(KBC.status) = BIT(4);
 }
 
-#define KBC_TIMEOUT 10000
+#define KBC_TIMEOUT 1000
 
 // Enable first port - TODO
 static bool kbc_first = false;


### PR DESCRIPTION
Fix ACPI timeout and delay on S3 resume when holding a key.

```
[ 3368.051132] ACPI: Waking up from system sleep state S3
[ 3369.136271] ACPI: EC: interrupt unblocked
[ 3370.249561] ACPI: EC: event unblocked
```

Tested on: oryp5, oryp6

While a timeout of 5ms was sufficient to fix the ACPI error, a value greater than 1ms (tested with 1.5ms and 2ms) still results in the excessive delay (~10s).

Resolves: #187

May also address system76/firmware-open#156