### PR TITLE
Add hidapi deps

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -20,9 +20,12 @@ if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
         avr-libc \
         avrdude \
         curl \
+        gcc \
         gcc-avr \
+        libc-dev \
         libudev-dev \
         make \
+        pkgconf \
         sdcc \
         xxd
 elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
@@ -32,6 +35,7 @@ elif [[ "${ID}" =~ "fedora" ]] || [[ "${ID_LIKE}" =~ "fedora" ]]; then
         avr-libc \
         avrdude \
         curl \
+        gcc \
         make \
         sdcc \
         systemd-devel \
@@ -43,7 +47,9 @@ elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
         avr-libc \
         avrdude \
         curl \
+        gcc \
         make \
+        pkgconf \
         sdcc \
         systemd-libs \
         vim


### PR DESCRIPTION
ectool uses hidapi, which requires `cc` and `pkg-config` to be available.

This fixes building ectool on a minimal install system.

```
cargo build --manifest-path ecflash/Cargo.toml --example isp --release
```

Tested on:
- Ubuntu Server 20.04
- Fedora Server 34 ("Minimal Install" environment)
- Arch Linux