### PR TITLE
Power on from `PWR_SW#` interrupt

### DIFF
--- a/src/arch/8051/arch.c
+++ b/src/arch/8051/arch.c
@@ -11,6 +11,9 @@ void arch_init(void) {
 
     time_init();
 
+    // Enable external interrupts for INTC
+    EX1 = 1;
+
     // Enable interrupts
     EA = 1;
 }

--- a/src/board/system76/addw1/interrupts.c
+++ b/src/board/system76/addw1/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/addw2/interrupts.c
+++ b/src/board/system76/addw2/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/bonw14/interrupts.c
+++ b/src/board/system76/bonw14/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/common/include/board/interrupts.h
+++ b/src/board/system76/common/include/board/interrupts.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#ifndef _BOARD_INTERRUPTS_H
+#define _BOARD_INTERRUPTS_H
+
+void interrupts_init(void);
+
+#endif // _BOARD_INTERRUPTS_H

--- a/src/board/system76/common/include/board/power.h
+++ b/src/board/system76/common/include/board/power.h
@@ -21,4 +21,6 @@ void power_cpu_reset(void);
 
 void power_event(void);
 
+void power_handle_pwr_sw(void);
+
 #endif // _BOARD_POWER_H

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -11,8 +11,9 @@
 #include <board/dgpu.h>
 #include <board/ecpm.h>
 #include <board/fan.h>
-#include <board/gpio.h>
 #include <board/gctrl.h>
+#include <board/gpio.h>
+#include <board/interrupts.h>
 #include <board/kbc.h>
 #include <board/kbled.h>
 #include <board/kbscan.h>
@@ -37,7 +38,8 @@
 void external_0(void) __interrupt(0) {}
 // timer_0 is in time.c
 void timer_0(void) __interrupt(1);
-void external_1(void) __interrupt(2) {}
+// external_1 is board-specific
+void external_1(void) __interrupt(2);
 void timer_1(void) __interrupt(3) {}
 void serial(void) __interrupt(4) {}
 void timer_2(void) __interrupt(5) {}
@@ -75,6 +77,7 @@ void init(void) {
     smfi_init();
 
     //TODO: INTC
+    interrupts_init();
 
     // Must happen last
     board_init();

--- a/src/board/system76/darp5/interrupts.c
+++ b/src/board/system76/darp5/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/darp7/interrupts.c
+++ b/src/board/system76/darp7/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/galp3-c/interrupts.c
+++ b/src/board/system76/galp3-c/interrupts.c
@@ -1,11 +1,28 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/interrupts.h>
+#include <board/gpio.h>
+#include <board/power.h>
+#include <common/macro.h>
 #include <ec/intc.h>
 #include <ec/wuc.h>
 
 void interrupts_init(void) {
+    GCR14 = BIT(3);
+    GCR16 = 2; // 64ms debounce for PWR_SW#
+
+    // INT1: PWR_SW#
+    WUEMR2 = BIT(0); // Falling-edge
+    WUESR2 = BIT(0);
+    ISR0 = BIT(1);
+    IER0 = BIT(1);
 }
 
 void external_1(void) __interrupt(2) {
+    if (ISR0 & BIT(1)) {
+        // INT1: PWR_SW#
+        power_handle_pwr_sw();
+        ISR0 = BIT(1);
+        WUESR2 = BIT(0);
+    }
 }

--- a/src/board/system76/galp3-c/interrupts.c
+++ b/src/board/system76/galp3-c/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/galp5/interrupts.c
+++ b/src/board/system76/galp5/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/gaze15/interrupts.c
+++ b/src/board/system76/gaze15/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/gaze15/interrupts.c
+++ b/src/board/system76/gaze15/interrupts.c
@@ -1,11 +1,26 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/interrupts.h>
+#include <board/power.h>
+#include <common/macro.h>
 #include <ec/intc.h>
 #include <ec/wuc.h>
 
 void interrupts_init(void) {
+    // XXX: Can't set debounce for PWR_SW# on IT5570E?
+
+    // INT108: PWR_SW#
+    WUEMR10 = BIT(7); // Either-edge
+    WUESR10 = BIT(7);
+    ISR13 = BIT(4);
+    IER13 = BIT(4);
 }
 
 void external_1(void) __interrupt(2) {
+    if (ISR13 & BIT(4)) {
+        // INT108: PWR_SW#
+        power_handle_pwr_sw();
+        ISR13 = BIT(4);
+        WUESR10 = BIT(7);
+    }
 }

--- a/src/board/system76/lemp10/interrupts.c
+++ b/src/board/system76/lemp10/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/lemp9/interrupts.c
+++ b/src/board/system76/lemp9/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/oryp5/interrupts.c
+++ b/src/board/system76/oryp5/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/oryp6/interrupts.c
+++ b/src/board/system76/oryp6/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/board/system76/oryp7/interrupts.c
+++ b/src/board/system76/oryp7/interrupts.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/interrupts.h>
+#include <ec/intc.h>
+#include <ec/wuc.h>
+
+void interrupts_init(void) {
+}
+
+void external_1(void) __interrupt(2) {
+}

--- a/src/ec/it5570e/include/ec/intc.h
+++ b/src/ec/it5570e/include/ec/intc.h
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Interrupt Controller (INTC)
+
+#ifndef _EC_INTC_H
+#define _EC_INTC_H
+
+#include <stdint.h>
+
+volatile uint8_t __xdata __at(0x1100) ISR0;
+volatile uint8_t __xdata __at(0x1104) IER0;
+volatile uint8_t __xdata __at(0x1108) IELMR0;
+volatile uint8_t __xdata __at(0x110C) IPOLR0;
+
+volatile uint8_t __xdata __at(0x1101) ISR1;
+volatile uint8_t __xdata __at(0x1105) IER1;
+volatile uint8_t __xdata __at(0x1109) IELMR1;
+volatile uint8_t __xdata __at(0x110D) IPOLR1;
+
+volatile uint8_t __xdata __at(0x1102) ISR2;
+volatile uint8_t __xdata __at(0x1106) IER2;
+volatile uint8_t __xdata __at(0x110A) IELMR2;
+volatile uint8_t __xdata __at(0x110E) IPOLR2;
+
+volatile uint8_t __xdata __at(0x1103) ISR3;
+volatile uint8_t __xdata __at(0x1107) IER3;
+volatile uint8_t __xdata __at(0x110B) IELMR3;
+volatile uint8_t __xdata __at(0x110F) IPOLR3;
+
+volatile uint8_t __xdata __at(0x1114) ISR4;
+volatile uint8_t __xdata __at(0x1115) IER4;
+volatile uint8_t __xdata __at(0x1116) IELMR4;
+volatile uint8_t __xdata __at(0x1117) IPOLR4;
+
+volatile uint8_t __xdata __at(0x1118) ISR5;
+volatile uint8_t __xdata __at(0x1119) IER5;
+volatile uint8_t __xdata __at(0x111A) IELMR5;
+volatile uint8_t __xdata __at(0x111B) IPOLR5;
+
+volatile uint8_t __xdata __at(0x111C) ISR6;
+volatile uint8_t __xdata __at(0x111D) IER6;
+volatile uint8_t __xdata __at(0x111E) IELMR6;
+volatile uint8_t __xdata __at(0x111F) IPOLR6;
+
+volatile uint8_t __xdata __at(0x1120) ISR7;
+volatile uint8_t __xdata __at(0x1121) IER7;
+volatile uint8_t __xdata __at(0x1122) IELMR7;
+volatile uint8_t __xdata __at(0x1123) IPOLR7;
+
+volatile uint8_t __xdata __at(0x1124) ISR8;
+volatile uint8_t __xdata __at(0x1125) IER8;
+volatile uint8_t __xdata __at(0x1126) IELMR8;
+volatile uint8_t __xdata __at(0x1127) IPOLR8;
+
+volatile uint8_t __xdata __at(0x1128) ISR9;
+volatile uint8_t __xdata __at(0x1129) IER9;
+volatile uint8_t __xdata __at(0x112A) IELMR9;
+volatile uint8_t __xdata __at(0x112B) IPOLR9;
+
+volatile uint8_t __xdata __at(0x112C) ISR10;
+volatile uint8_t __xdata __at(0x112D) IER10;
+volatile uint8_t __xdata __at(0x112E) IELMR10;
+volatile uint8_t __xdata __at(0x112F) IPOLR10;
+
+volatile uint8_t __xdata __at(0x1130) ISR11;
+volatile uint8_t __xdata __at(0x1131) IER11;
+volatile uint8_t __xdata __at(0x1132) IELMR11;
+volatile uint8_t __xdata __at(0x1133) IPOLR11;
+
+volatile uint8_t __xdata __at(0x1134) ISR12;
+volatile uint8_t __xdata __at(0x1135) IER12;
+volatile uint8_t __xdata __at(0x1136) IELMR12;
+volatile uint8_t __xdata __at(0x1137) IPOLR12;
+
+volatile uint8_t __xdata __at(0x1138) ISR13;
+volatile uint8_t __xdata __at(0x1139) IER13;
+volatile uint8_t __xdata __at(0x113A) IELMR13;
+volatile uint8_t __xdata __at(0x113B) IPOLR13;
+
+volatile uint8_t __xdata __at(0x113C) ISR14;
+volatile uint8_t __xdata __at(0x113D) IER14;
+volatile uint8_t __xdata __at(0x113E) IELMR14;
+volatile uint8_t __xdata __at(0x113F) IPOLR14;
+
+volatile uint8_t __xdata __at(0x1140) ISR15;
+volatile uint8_t __xdata __at(0x1141) IER15;
+volatile uint8_t __xdata __at(0x1142) IELMR15;
+volatile uint8_t __xdata __at(0x1143) IPOLR15;
+
+volatile uint8_t __xdata __at(0x1144) ISR16;
+volatile uint8_t __xdata __at(0x1145) IER16;
+volatile uint8_t __xdata __at(0x1146) IELMR16;
+volatile uint8_t __xdata __at(0x1147) IPOLR16;
+
+volatile uint8_t __xdata __at(0x1148) ISR17;
+volatile uint8_t __xdata __at(0x1149) IER17;
+volatile uint8_t __xdata __at(0x114A) IELMR17;
+volatile uint8_t __xdata __at(0x114B) IPOLR17;
+
+volatile uint8_t __xdata __at(0x114C) ISR18;
+volatile uint8_t __xdata __at(0x114D) IER18;
+volatile uint8_t __xdata __at(0x114E) IELMR18;
+volatile uint8_t __xdata __at(0x114F) IPOLR18;
+
+volatile uint8_t __xdata __at(0x1150) ISR19;
+volatile uint8_t __xdata __at(0x1151) IER19;
+volatile uint8_t __xdata __at(0x1152) IELMR19;
+volatile uint8_t __xdata __at(0x1153) IPOLR19;
+
+volatile uint8_t __xdata __at(0x1154) ISR20;
+volatile uint8_t __xdata __at(0x1155) IER20;
+volatile uint8_t __xdata __at(0x1156) IELMR20;
+volatile uint8_t __xdata __at(0x1157) IPOLR20;
+
+volatile uint8_t __xdata __at(0x1158) ISR21;
+volatile uint8_t __xdata __at(0x1159) IER21;
+volatile uint8_t __xdata __at(0x115A) IELMR21;
+volatile uint8_t __xdata __at(0x115B) IPOLR21;
+
+volatile uint8_t __xdata __at(0x1110) IVCT;
+
+#endif // _EC_INTC_H

--- a/src/ec/it5570e/include/ec/wuc.h
+++ b/src/ec/it5570e/include/ec/wuc.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Wake-Up Control (WUC)
+
+#ifndef _EC_WUC_H
+#define _EC_WUC_H
+
+#include <stdint.h>
+
+volatile uint8_t __xdata __at(0x1B00) WUEMR1;
+volatile uint8_t __xdata __at(0x1B04) WUESR1;
+volatile uint8_t __xdata __at(0x1B08) WUENR1;
+
+volatile uint8_t __xdata __at(0x1B01) WUEMR2;
+volatile uint8_t __xdata __at(0x1B05) WUESR2;
+
+volatile uint8_t __xdata __at(0x1B02) WUEMR3;
+volatile uint8_t __xdata __at(0x1B06) WUESR3;
+volatile uint8_t __xdata __at(0x1B0A) WUENR3;
+
+volatile uint8_t __xdata __at(0x1B03) WUEMR4;
+volatile uint8_t __xdata __at(0x1B07) WUESR4;
+volatile uint8_t __xdata __at(0x1B0B) WUENR4;
+
+// There is no group 5
+
+volatile uint8_t __xdata __at(0x1B10) WUEMR6;
+volatile uint8_t __xdata __at(0x1B11) WUESR6;
+
+volatile uint8_t __xdata __at(0x1B14) WUEMR7;
+volatile uint8_t __xdata __at(0x1B15) WUESR7;
+
+volatile uint8_t __xdata __at(0x1B18) WUEMR8;
+volatile uint8_t __xdata __at(0x1B19) WUESR8;
+
+volatile uint8_t __xdata __at(0x1B1C) WUEMR9;
+volatile uint8_t __xdata __at(0x1B1D) WUESR9;
+
+volatile uint8_t __xdata __at(0x1B20) WUEMR10;
+volatile uint8_t __xdata __at(0x1B21) WUESR10;
+
+volatile uint8_t __xdata __at(0x1B24) WUEMR11;
+volatile uint8_t __xdata __at(0x1B25) WUESR11;
+
+volatile uint8_t __xdata __at(0x1B28) WUEMR12;
+volatile uint8_t __xdata __at(0x1B29) WUESR12;
+
+volatile uint8_t __xdata __at(0x1B2C) WUEMR13;
+volatile uint8_t __xdata __at(0x1B2D) WUESR13;
+
+volatile uint8_t __xdata __at(0x1B30) WUEMR14;
+volatile uint8_t __xdata __at(0x1B31) WUESR14;
+
+#endif // _EC_WUC_H

--- a/src/ec/it8587e/include/ec/intc.h
+++ b/src/ec/it8587e/include/ec/intc.h
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Interrupt Controller (INTC)
+
+#ifndef _EC_INTC_H
+#define _EC_INTC_H
+
+#include <stdint.h>
+
+volatile uint8_t __xdata __at(0x1100) ISR0;
+volatile uint8_t __xdata __at(0x1104) IER0;
+volatile uint8_t __xdata __at(0x1108) IELMR0;
+volatile uint8_t __xdata __at(0x110C) IPOLR0;
+
+volatile uint8_t __xdata __at(0x1101) ISR1;
+volatile uint8_t __xdata __at(0x1105) IER1;
+volatile uint8_t __xdata __at(0x1109) IELMR1;
+volatile uint8_t __xdata __at(0x110D) IPOLR1;
+
+volatile uint8_t __xdata __at(0x1102) ISR2;
+volatile uint8_t __xdata __at(0x1106) IER2;
+volatile uint8_t __xdata __at(0x110A) IELMR2;
+volatile uint8_t __xdata __at(0x110E) IPOLR2;
+
+volatile uint8_t __xdata __at(0x1103) ISR3;
+volatile uint8_t __xdata __at(0x1107) IER3;
+volatile uint8_t __xdata __at(0x110B) IELMR3;
+volatile uint8_t __xdata __at(0x110F) IPOLR3;
+
+volatile uint8_t __xdata __at(0x1114) ISR4;
+volatile uint8_t __xdata __at(0x1115) IER4;
+volatile uint8_t __xdata __at(0x1116) IELMR4;
+volatile uint8_t __xdata __at(0x1117) IPOLR4;
+
+volatile uint8_t __xdata __at(0x1118) ISR5;
+volatile uint8_t __xdata __at(0x1119) IER5;
+volatile uint8_t __xdata __at(0x111A) IELMR5;
+volatile uint8_t __xdata __at(0x111B) IPOLR5;
+
+volatile uint8_t __xdata __at(0x111C) ISR6;
+volatile uint8_t __xdata __at(0x111D) IER6;
+volatile uint8_t __xdata __at(0x111E) IELMR6;
+volatile uint8_t __xdata __at(0x111F) IPOLR6;
+
+volatile uint8_t __xdata __at(0x1120) ISR7;
+volatile uint8_t __xdata __at(0x1121) IER7;
+volatile uint8_t __xdata __at(0x1122) IELMR7;
+volatile uint8_t __xdata __at(0x1123) IPOLR7;
+
+volatile uint8_t __xdata __at(0x1124) ISR8;
+volatile uint8_t __xdata __at(0x1125) IER8;
+volatile uint8_t __xdata __at(0x1126) IELMR8;
+volatile uint8_t __xdata __at(0x1127) IPOLR8;
+
+volatile uint8_t __xdata __at(0x1128) ISR9;
+volatile uint8_t __xdata __at(0x1129) IER9;
+volatile uint8_t __xdata __at(0x112A) IELMR9;
+volatile uint8_t __xdata __at(0x112B) IPOLR9;
+
+volatile uint8_t __xdata __at(0x112C) ISR10;
+volatile uint8_t __xdata __at(0x112D) IER10;
+volatile uint8_t __xdata __at(0x112E) IELMR10;
+volatile uint8_t __xdata __at(0x112F) IPOLR10;
+
+volatile uint8_t __xdata __at(0x1130) ISR11;
+volatile uint8_t __xdata __at(0x1131) IER11;
+volatile uint8_t __xdata __at(0x1132) IELMR11;
+volatile uint8_t __xdata __at(0x1133) IPOLR11;
+
+volatile uint8_t __xdata __at(0x1134) ISR12;
+volatile uint8_t __xdata __at(0x1135) IER12;
+volatile uint8_t __xdata __at(0x1136) IELMR12;
+volatile uint8_t __xdata __at(0x1137) IPOLR12;
+
+volatile uint8_t __xdata __at(0x1138) ISR13;
+volatile uint8_t __xdata __at(0x1139) IER13;
+volatile uint8_t __xdata __at(0x113A) IELMR13;
+volatile uint8_t __xdata __at(0x113B) IPOLR13;
+
+volatile uint8_t __xdata __at(0x113C) ISR14;
+volatile uint8_t __xdata __at(0x113D) IER14;
+volatile uint8_t __xdata __at(0x113E) IELMR14;
+volatile uint8_t __xdata __at(0x113F) IPOLR14;
+
+volatile uint8_t __xdata __at(0x1140) ISR15;
+volatile uint8_t __xdata __at(0x1141) IER15;
+volatile uint8_t __xdata __at(0x1142) IELMR15;
+volatile uint8_t __xdata __at(0x1143) IPOLR15;
+
+volatile uint8_t __xdata __at(0x1144) ISR16;
+volatile uint8_t __xdata __at(0x1145) IER16;
+volatile uint8_t __xdata __at(0x1146) IELMR16;
+volatile uint8_t __xdata __at(0x1147) IPOLR16;
+
+volatile uint8_t __xdata __at(0x1148) ISR17;
+volatile uint8_t __xdata __at(0x1149) IER17;
+volatile uint8_t __xdata __at(0x114A) IELMR17;
+volatile uint8_t __xdata __at(0x114B) IPOLR17;
+
+volatile uint8_t __xdata __at(0x114C) ISR18;
+volatile uint8_t __xdata __at(0x114D) IER18;
+volatile uint8_t __xdata __at(0x114E) IELMR18;
+volatile uint8_t __xdata __at(0x114F) IPOLR18;
+
+volatile uint8_t __xdata __at(0x1110) IVCT;
+
+#endif // _EC_INTC_H

--- a/src/ec/it8587e/include/ec/wuc.h
+++ b/src/ec/it8587e/include/ec/wuc.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Wake-Up Control (WUC)
+
+#ifndef _EC_WUC_H
+#define _EC_WUC_H
+
+#include <stdint.h>
+
+volatile uint8_t __xdata __at(0x1B00) WUEMR1;
+volatile uint8_t __xdata __at(0x1B04) WUESR1;
+volatile uint8_t __xdata __at(0x1B08) WUENR1;
+
+volatile uint8_t __xdata __at(0x1B01) WUEMR2;
+volatile uint8_t __xdata __at(0x1B05) WUESR2;
+
+volatile uint8_t __xdata __at(0x1B02) WUEMR3;
+volatile uint8_t __xdata __at(0x1B06) WUESR3;
+volatile uint8_t __xdata __at(0x1B0A) WUENR3;
+
+volatile uint8_t __xdata __at(0x1B03) WUEMR4;
+volatile uint8_t __xdata __at(0x1B07) WUESR4;
+volatile uint8_t __xdata __at(0x1B0B) WUENR4;
+
+// There is no group 5
+
+volatile uint8_t __xdata __at(0x1B10) WUEMR6;
+volatile uint8_t __xdata __at(0x1B11) WUESR6;
+
+volatile uint8_t __xdata __at(0x1B14) WUEMR7;
+volatile uint8_t __xdata __at(0x1B15) WUESR7;
+
+volatile uint8_t __xdata __at(0x1B18) WUEMR8;
+volatile uint8_t __xdata __at(0x1B19) WUESR8;
+
+volatile uint8_t __xdata __at(0x1B1C) WUEMR9;
+volatile uint8_t __xdata __at(0x1B1D) WUESR9;
+
+volatile uint8_t __xdata __at(0x1B20) WUEMR10;
+volatile uint8_t __xdata __at(0x1B21) WUESR10;
+
+volatile uint8_t __xdata __at(0x1B24) WUEMR11;
+volatile uint8_t __xdata __at(0x1B25) WUESR11;
+
+volatile uint8_t __xdata __at(0x1B28) WUEMR12;
+volatile uint8_t __xdata __at(0x1B29) WUESR12;
+
+volatile uint8_t __xdata __at(0x1B2C) WUEMR13;
+volatile uint8_t __xdata __at(0x1B2D) WUESR13;
+
+volatile uint8_t __xdata __at(0x1B30) WUEMR14;
+volatile uint8_t __xdata __at(0x1B31) WUESR14;
+
+#endif // _EC_WUC_H


### PR DESCRIPTION
Replace polling logic for power switch with an ISR for `PWR_SW#`. The "spurious press" logic is removed: If pressing the power button results in an interrupt then it will power on.

IT8587E:

- Only detects switch press, not release
- Requires debounce enabled to work correctly

IT5570E:

- Detects both switch press and release
- Debounce for interrupt source not available