### PR TITLE
Move POST code logic from boards to EC

### DIFF
--- a/src/board/system76/addw2/board.c
+++ b/src/board/system76/addw2/board.c
@@ -10,6 +10,7 @@
 #include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
+#include <ec/ec.h>
 
 extern uint8_t main_cycle;
 
@@ -69,14 +70,7 @@ void board_event(void) {
         last_power_limit_ac = true;
     }
 
-    // Read POST codes
-    while (P80H81HS & 1) {
-        uint8_t p80h = P80HD;
-        uint8_t p81h = P81HD;
-        P80H81HS |= 1;
-
-        DEBUG("POST %02X%02X\n", p81h, p80h);
-    }
+    ec_read_post_codes();
 
     if (main_cycle == 0) {
         // Set keyboard LEDs

--- a/src/board/system76/addw2/board.c
+++ b/src/board/system76/addw2/board.c
@@ -26,9 +26,6 @@ void board_init(void) {
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
-
-    // Enable POST codes
-    SPCTRL1 |= 0xC8;
 }
 
 // Set PL4 using PECI

--- a/src/board/system76/bonw14/board.c
+++ b/src/board/system76/bonw14/board.c
@@ -31,9 +31,6 @@ void board_init(void) {
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
-
-    // Enable POST codes
-    SPCTRL1 |= 0xC8;
 }
 
 // Set PL4 using PECI

--- a/src/board/system76/bonw14/board.c
+++ b/src/board/system76/bonw14/board.c
@@ -10,6 +10,7 @@
 #include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
+#include <ec/ec.h>
 
 extern uint8_t main_cycle;
 
@@ -74,12 +75,5 @@ void board_event(void) {
         last_power_limit_ac = true;
     }
 
-    // Read POST codes
-    while (P80H81HS & 1) {
-        uint8_t p80h = P80HD;
-        uint8_t p81h = P81HD;
-        P80H81HS |= 1;
-
-        DEBUG("POST %02X%02X\n", p81h, p80h);
-    }
+    ec_read_post_codes();
 }

--- a/src/board/system76/common/gctrl.c
+++ b/src/board/system76/common/gctrl.c
@@ -3,6 +3,8 @@
 #include <board/gctrl.h>
 
 void gctrl_init(void) {
-    SPCTRL1 = 0x03;
+    // Set I2EC as R/W
+    SPCTRL1 |= 0x03;
+    // Set PNPCFG base address
     BADRSEL = 0;
 }

--- a/src/board/system76/darp7/board.c
+++ b/src/board/system76/darp7/board.c
@@ -27,9 +27,6 @@ void board_init(void) {
     // Assert SMI# and SWI#
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
-
-    // Enable POST codes
-    SPCTRL1 |= 0xC8;
 }
 
 void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }

--- a/src/board/system76/darp7/board.c
+++ b/src/board/system76/darp7/board.c
@@ -6,6 +6,7 @@
 #include <board/gpio.h>
 #include <board/power.h>
 #include <common/debug.h>
+#include <ec/ec.h>
 
 extern uint8_t main_cycle;
 
@@ -36,12 +37,5 @@ void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }
 void board_event(void) {
     espi_event();
 
-    // Read POST codes
-    while (P80H81HS & 1) {
-        uint8_t p80h = P80HD;
-        uint8_t p81h = P81HD;
-        P80H81HS |= 1;
-
-        DEBUG("POST %02X%02X\n", p81h, p80h);
-    }
+    ec_read_post_codes();
 }

--- a/src/board/system76/galp5/board.c
+++ b/src/board/system76/galp5/board.c
@@ -9,6 +9,7 @@
 #include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
+#include <ec/ec.h>
 
 extern uint8_t main_cycle;
 
@@ -84,12 +85,5 @@ void board_event(void) {
 
     espi_event();
 
-    // Read POST codes
-    while (P80H81HS & 1) {
-        uint8_t p80h = P80HD;
-        uint8_t p81h = P81HD;
-        P80H81HS |= 1;
-
-        DEBUG("POST %02X%02X\n", p81h, p80h);
-    }
+    ec_read_post_codes();
 }

--- a/src/board/system76/galp5/board.c
+++ b/src/board/system76/galp5/board.c
@@ -34,9 +34,6 @@ void board_init(void) {
     // Assert SMI# and SWI#
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
-
-    // Enable POST codes
-    SPCTRL1 |= 0xC8;
 }
 
 #if HAVE_DGPU

--- a/src/board/system76/gaze15/board.c
+++ b/src/board/system76/gaze15/board.c
@@ -27,9 +27,6 @@ void board_init(void) {
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
-
-    // Enable POST codes
-    SPCTRL1 |= 0xC8;
 }
 
 // Set PL4 using PECI

--- a/src/board/system76/gaze15/board.c
+++ b/src/board/system76/gaze15/board.c
@@ -10,6 +10,7 @@
 #include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
+#include <ec/ec.h>
 
 extern uint8_t main_cycle;
 
@@ -70,12 +71,5 @@ void board_event(void) {
         last_power_limit_ac = true;
     }
 
-    // Read POST codes
-    while (P80H81HS & 1) {
-        uint8_t p80h = P80HD;
-        uint8_t p81h = P81HD;
-        P80H81HS |= 1;
-
-        DEBUG("POST %02X%02X\n", p81h, p80h);
-    }
+    ec_read_post_codes();
 }

--- a/src/board/system76/lemp10/board.c
+++ b/src/board/system76/lemp10/board.c
@@ -29,9 +29,6 @@ void board_init(void) {
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
-
-    // Enable POST codes
-    SPCTRL1 |= 0xC8;
 }
 
 void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }

--- a/src/board/system76/lemp10/board.c
+++ b/src/board/system76/lemp10/board.c
@@ -6,6 +6,7 @@
 #include <board/gpio.h>
 #include <board/power.h>
 #include <common/debug.h>
+#include <ec/ec.h>
 
 extern uint8_t main_cycle;
 
@@ -38,12 +39,5 @@ void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }
 void board_event(void) {
     espi_event();
 
-    // Read POST codes
-    while (P80H81HS & 1) {
-        uint8_t p80h = P80HD;
-        uint8_t p81h = P81HD;
-        P80H81HS |= 1;
-
-        DEBUG("POST %02X%02X\n", p81h, p80h);
-    }
+    ec_read_post_codes();
 }

--- a/src/board/system76/oryp6/board.c
+++ b/src/board/system76/oryp6/board.c
@@ -31,9 +31,6 @@ void board_init(void) {
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
-
-    // Enable POST codes
-    SPCTRL1 |= 0xC8;
 }
 
 // Set PL4 using PECI

--- a/src/board/system76/oryp6/board.c
+++ b/src/board/system76/oryp6/board.c
@@ -10,6 +10,7 @@
 #include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
+#include <ec/ec.h>
 
 extern uint8_t main_cycle;
 
@@ -74,12 +75,5 @@ void board_event(void) {
         last_power_limit_ac = true;
     }
 
-    // Read POST codes
-    while (P80H81HS & 1) {
-        uint8_t p80h = P80HD;
-        uint8_t p81h = P81HD;
-        P80H81HS |= 1;
-
-        DEBUG("POST %02X%02X\n", p81h, p80h);
-    }
+    ec_read_post_codes();
 }

--- a/src/board/system76/oryp7/board.c
+++ b/src/board/system76/oryp7/board.c
@@ -10,6 +10,7 @@
 #include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
+#include <ec/ec.h>
 
 extern uint8_t main_cycle;
 
@@ -73,12 +74,5 @@ void board_event(void) {
         last_power_limit_ac = true;
     }
 
-    // Read POST codes
-    while (P80H81HS & 1) {
-        uint8_t p80h = P80HD;
-        uint8_t p81h = P81HD;
-        P80H81HS |= 1;
-
-        DEBUG("POST %02X%02X\n", p81h, p80h);
-    }
+    ec_read_post_codes();
 }

--- a/src/board/system76/oryp7/board.c
+++ b/src/board/system76/oryp7/board.c
@@ -30,9 +30,6 @@ void board_init(void) {
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
-
-    // Enable POST codes
-    SPCTRL1 |= 0xC8;
 }
 
 // Set PL4 using PECI

--- a/src/ec/it5570e/ec.c
+++ b/src/ec/it5570e/ec.c
@@ -2,7 +2,18 @@
 
 #include <ec/ec.h>
 #include <ec/gctrl.h>
+#include <common/debug.h>
 
 void ec_init(void) {
     RSTS = 0x44;
+}
+
+void ec_read_post_codes(void) {
+    while (P80H81HS & 1) {
+        uint8_t p80h = P80HD;
+        uint8_t p81h = P81HD;
+        P80H81HS |= 1;
+
+        DEBUG("POST %02X%02X\n", p81h, p80h);
+    }
 }

--- a/src/ec/it5570e/ec.c
+++ b/src/ec/it5570e/ec.c
@@ -3,9 +3,13 @@
 #include <ec/ec.h>
 #include <ec/gctrl.h>
 #include <common/debug.h>
+#include <common/macro.h>
 
 void ec_init(void) {
     RSTS = 0x44;
+
+    // Enable POST codes
+    SPCTRL1 |= BIT(7) | BIT(6) | BIT(3);
 }
 
 void ec_read_post_codes(void) {

--- a/src/ec/it5570e/include/ec/ec.h
+++ b/src/ec/it5570e/include/ec/ec.h
@@ -4,5 +4,6 @@
 #define _EC_EC_H
 
 void ec_init(void);
+void ec_read_post_codes(void);
 
 #endif // _EC_EC_H


### PR DESCRIPTION
Logic for reading port 0x80/0x81 is common to the IT5570E. Define a EC function for reading POST codes and have the boards call that.