### PR TITLE
Move power limit functions to common board code

### DIFF
--- a/src/board/system76/addw1/board.c
+++ b/src/board/system76/addw1/board.c
@@ -7,7 +7,6 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/kbc.h>
-#include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
 
@@ -32,44 +31,8 @@ void board_init(void) {
     gpio_set(&SWI_N, true);
 }
 
-// Set PL4 using PECI
-static int set_power_limit(uint8_t watts) {
-    return peci_wr_pkg_config(
-        60, // index
-        0, // param
-        ((uint32_t)watts) * 8
-    );
-}
-
-void board_on_ac(bool ac) {
-    uint8_t power_limit = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
-    // Retry, timeout errors happen occasionally
-    for (int i = 0; i < 16; i++) {
-        int res = set_power_limit(power_limit);
-        DEBUG("set_power_limit %d = %d\n", power_limit, res);
-        if (res == 0x40) {
-            break;
-        } else if (res < 0) {
-            ERROR("set_power_limit failed: 0x%02X\n", -res);
-        } else {
-            ERROR("set_power_limit unknown response: 0x%02X\n", res);
-        }
-    }
-}
-
 void board_event(void) {
-    bool ac = !gpio_get(&ACIN_N);
-
-    static bool last_power_limit_ac = true;
-    // We don't use power_state because the latency needs to be low
-    if (gpio_get(&BUF_PLT_RST_N)) {
-        if (last_power_limit_ac != ac) {
-            board_on_ac(ac);
-            last_power_limit_ac = ac;
-        }
-    } else {
-        last_power_limit_ac = true;
-    }
+    power_set_limit();
 
     if (main_cycle == 0) {
         // Set keyboard LEDs

--- a/src/board/system76/addw2/board.c
+++ b/src/board/system76/addw2/board.c
@@ -30,44 +30,8 @@ void board_init(void) {
     SPCTRL1 |= 0xC8;
 }
 
-// Set PL4 using PECI
-static int set_power_limit(uint8_t watts) {
-    return peci_wr_pkg_config(
-        60, // index
-        0, // param
-        ((uint32_t)watts) * 8
-    );
-}
-
-void board_on_ac(bool ac) {
-    uint8_t power_limit = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
-    // Retry, timeout errors happen occasionally
-    for (int i = 0; i < 16; i++) {
-        int res = set_power_limit(power_limit);
-        DEBUG("set_power_limit %d = %d\n", power_limit, res);
-        if (res == 0x40) {
-            break;
-        } else if (res < 0) {
-            ERROR("set_power_limit failed: 0x%02X\n", -res);
-        } else {
-            ERROR("set_power_limit unknown response: 0x%02X\n", res);
-        }
-    }
-}
-
 void board_event(void) {
-    bool ac = !gpio_get(&ACIN_N);
-
-    static bool last_power_limit_ac = true;
-    // We don't use power_state because the latency needs to be low
-    if (gpio_get(&BUF_PLT_RST_N)) {
-        if (last_power_limit_ac != ac) {
-            board_on_ac(ac);
-            last_power_limit_ac = ac;
-        }
-    } else {
-        last_power_limit_ac = true;
-    }
+    power_set_limit();
 
     // Read POST codes
     while (P80H81HS & 1) {

--- a/src/board/system76/bonw14/board.c
+++ b/src/board/system76/bonw14/board.c
@@ -7,7 +7,6 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/kbc.h>
-#include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
 
@@ -35,44 +34,8 @@ void board_init(void) {
     SPCTRL1 |= 0xC8;
 }
 
-// Set PL4 using PECI
-static int set_power_limit(uint8_t watts) {
-    return peci_wr_pkg_config(
-        60, // index
-        0, // param
-        ((uint32_t)watts) * 8
-    );
-}
-
-void board_on_ac(bool ac) {
-    uint8_t power_limit = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
-    // Retry, timeout errors happen occasionally
-    for (int i = 0; i < 16; i++) {
-        int res = set_power_limit(power_limit);
-        DEBUG("set_power_limit %d = %d\n", power_limit, res);
-        if (res == 0x40) {
-            break;
-        } else if (res < 0) {
-            ERROR("set_power_limit failed: 0x%02X\n", -res);
-        } else {
-            ERROR("set_power_limit unknown response: 0x%02X\n", res);
-        }
-    }
-}
-
 void board_event(void) {
-    bool ac = !gpio_get(&ACIN_N);
-
-    static bool last_power_limit_ac = true;
-    // We don't use power_state because the latency needs to be low
-    if (gpio_get(&BUF_PLT_RST_N)) {
-        if (last_power_limit_ac != ac) {
-            board_on_ac(ac);
-            last_power_limit_ac = ac;
-        }
-    } else {
-        last_power_limit_ac = true;
-    }
+    power_set_limit();
 
     // Read POST codes
     while (P80H81HS & 1) {

--- a/src/board/system76/common/include/board/board.h
+++ b/src/board/system76/common/include/board/board.h
@@ -7,6 +7,5 @@
 
 void board_init(void);
 void board_event(void);
-void board_on_ac(bool ac);
 
 #endif // _BOARD_BOARD_H

--- a/src/board/system76/common/include/board/power.h
+++ b/src/board/system76/common/include/board/power.h
@@ -17,6 +17,7 @@ extern enum PowerState power_state;
 void power_on_ds5(void);
 void power_on_s5(void);
 void power_off_s5(void);
+void power_set_limit(void);
 void power_cpu_reset(void);
 
 void power_event(void);

--- a/src/board/system76/darp5/board.c
+++ b/src/board/system76/darp5/board.c
@@ -25,6 +25,4 @@ void board_init(void) {
     gpio_set(&SWI_N, true);
 }
 
-void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }
-
 void board_event(void) {}

--- a/src/board/system76/darp7/board.c
+++ b/src/board/system76/darp7/board.c
@@ -31,8 +31,6 @@ void board_init(void) {
     SPCTRL1 |= 0xC8;
 }
 
-void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }
-
 void board_event(void) {
     espi_event();
 

--- a/src/board/system76/galp3-c/board.c
+++ b/src/board/system76/galp3-c/board.c
@@ -25,6 +25,4 @@ void board_init(void) {
     gpio_set(&SWI_N, true);
 }
 
-void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }
-
 void board_event(void) {}

--- a/src/board/system76/galp5/board.c
+++ b/src/board/system76/galp5/board.c
@@ -6,7 +6,6 @@
 #include <board/espi.h>
 #include <board/gctrl.h>
 #include <board/gpio.h>
-#include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
 
@@ -38,48 +37,9 @@ void board_init(void) {
     SPCTRL1 |= 0xC8;
 }
 
-#if HAVE_DGPU
-// Set PL4 using PECI
-static int set_power_limit(uint8_t watts) {
-    return peci_wr_pkg_config(
-        60, // index
-        0, // param
-        ((uint32_t)watts) * 8
-    );
-}
-
-void board_on_ac(bool ac) {
-    uint8_t power_limit = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
-    // Retry, timeout errors happen occasionally
-    for (int i = 0; i < 16; i++) {
-        int res = set_power_limit(power_limit);
-        DEBUG("set_power_limit %d = %d\n", power_limit, res);
-        if (res == 0x40) {
-            break;
-        } else if (res < 0) {
-            ERROR("set_power_limit failed: 0x%02X\n", -res);
-        } else {
-            ERROR("set_power_limit unknown response: 0x%02X\n", res);
-        }
-    }
-}
-#else // HAVE_DGPU
-void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }
-#endif // HAVE_DGPU
-
 void board_event(void) {
 #if HAVE_DGPU
-    static bool last_power_limit_ac = true;
-    // We don't use power_state because the latency needs to be low
-    if (gpio_get(&CPU_C10_GATE_N)) {
-        bool ac = !gpio_get(&ACIN_N);
-        if (last_power_limit_ac != ac) {
-            board_on_ac(ac);
-            last_power_limit_ac = ac;
-        }
-    } else {
-        last_power_limit_ac = true;
-    }
+    power_set_limit();
 #endif // HAVE_DGPU
 
     espi_event();

--- a/src/board/system76/gaze15/board.c
+++ b/src/board/system76/gaze15/board.c
@@ -7,7 +7,6 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/kbc.h>
-#include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
 
@@ -31,44 +30,8 @@ void board_init(void) {
     SPCTRL1 |= 0xC8;
 }
 
-// Set PL4 using PECI
-static int set_power_limit(uint8_t watts) {
-    return peci_wr_pkg_config(
-        60, // index
-        0, // param
-        ((uint32_t)watts) * 8
-    );
-}
-
-void board_on_ac(bool ac) {
-    uint8_t power_limit = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
-    // Retry, timeout errors happen occasionally
-    for (int i = 0; i < 16; i++) {
-        int res = set_power_limit(power_limit);
-        DEBUG("set_power_limit %d = %d\n", power_limit, res);
-        if (res == 0x40) {
-            break;
-        } else if (res < 0) {
-            ERROR("set_power_limit failed: 0x%02X\n", -res);
-        } else {
-            ERROR("set_power_limit unknown response: 0x%02X\n", res);
-        }
-    }
-}
-
 void board_event(void) {
-    bool ac = !gpio_get(&ACIN_N);
-
-    static bool last_power_limit_ac = true;
-    // We don't use power_state because the latency needs to be low
-    if (gpio_get(&BUF_PLT_RST_N)) {
-        if (last_power_limit_ac != ac) {
-            board_on_ac(ac);
-            last_power_limit_ac = ac;
-        }
-    } else {
-        last_power_limit_ac = true;
-    }
+    power_set_limit();
 
     // Read POST codes
     while (P80H81HS & 1) {

--- a/src/board/system76/lemp10/board.c
+++ b/src/board/system76/lemp10/board.c
@@ -33,8 +33,6 @@ void board_init(void) {
     SPCTRL1 |= 0xC8;
 }
 
-void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }
-
 void board_event(void) {
     espi_event();
 

--- a/src/board/system76/lemp9/board.c
+++ b/src/board/system76/lemp9/board.c
@@ -25,8 +25,6 @@ void board_init(void) {
     gpio_set(&SWI_N, true);
 }
 
-void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }
-
 void board_event(void) {
     if (main_cycle == 0) {
         if (power_state == POWER_STATE_S0 || power_state == POWER_STATE_S3 || power_state == POWER_STATE_DS3) {

--- a/src/board/system76/oryp5/board.c
+++ b/src/board/system76/oryp5/board.c
@@ -7,7 +7,6 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/kbc.h>
-#include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
 
@@ -32,42 +31,6 @@ void board_init(void) {
     gpio_set(&SWI_N, true);
 }
 
-// Set PL4 using PECI
-static int set_power_limit(uint8_t watts) {
-    return peci_wr_pkg_config(
-        60, // index
-        0, // param
-        ((uint32_t)watts) * 8
-    );
-}
-
-void board_on_ac(bool ac) {
-    uint8_t power_limit = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
-    // Retry, timeout errors happen occasionally
-    for (int i = 0; i < 16; i++) {
-        int res = set_power_limit(power_limit);
-        DEBUG("set_power_limit %d = %d\n", power_limit, res);
-        if (res == 0x40) {
-            break;
-        } else if (res < 0) {
-            ERROR("set_power_limit failed: 0x%02X\n", -res);
-        } else {
-            ERROR("set_power_limit unknown response: 0x%02X\n", res);
-        }
-    }
-}
-
 void board_event(void) {
-    bool ac = !gpio_get(&ACIN_N);
-
-    static bool last_power_limit_ac = true;
-    // We don't use power_state because the latency needs to be low
-    if (gpio_get(&BUF_PLT_RST_N)) {
-        if (last_power_limit_ac != ac) {
-            board_on_ac(ac);
-            last_power_limit_ac = ac;
-        }
-    } else {
-        last_power_limit_ac = true;
-    }
+    power_set_limit();
 }

--- a/src/board/system76/oryp6/board.c
+++ b/src/board/system76/oryp6/board.c
@@ -7,7 +7,6 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/kbc.h>
-#include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
 
@@ -35,44 +34,8 @@ void board_init(void) {
     SPCTRL1 |= 0xC8;
 }
 
-// Set PL4 using PECI
-static int set_power_limit(uint8_t watts) {
-    return peci_wr_pkg_config(
-        60, // index
-        0, // param
-        ((uint32_t)watts) * 8
-    );
-}
-
-void board_on_ac(bool ac) {
-    uint8_t power_limit = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
-    // Retry, timeout errors happen occasionally
-    for (int i = 0; i < 16; i++) {
-        int res = set_power_limit(power_limit);
-        DEBUG("set_power_limit %d = %d\n", power_limit, res);
-        if (res == 0x40) {
-            break;
-        } else if (res < 0) {
-            ERROR("set_power_limit failed: 0x%02X\n", -res);
-        } else {
-            ERROR("set_power_limit unknown response: 0x%02X\n", res);
-        }
-    }
-}
-
 void board_event(void) {
-    bool ac = !gpio_get(&ACIN_N);
-
-    static bool last_power_limit_ac = true;
-    // We don't use power_state because the latency needs to be low
-    if (gpio_get(&BUF_PLT_RST_N)) {
-        if (last_power_limit_ac != ac) {
-            board_on_ac(ac);
-            last_power_limit_ac = ac;
-        }
-    } else {
-        last_power_limit_ac = true;
-    }
+    power_set_limit();
 
     // Read POST codes
     while (P80H81HS & 1) {

--- a/src/board/system76/oryp7/board.c
+++ b/src/board/system76/oryp7/board.c
@@ -7,7 +7,6 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/kbc.h>
-#include <board/peci.h>
 #include <board/power.h>
 #include <common/debug.h>
 
@@ -34,44 +33,8 @@ void board_init(void) {
     SPCTRL1 |= 0xC8;
 }
 
-// Set PL4 using PECI
-static int set_power_limit(uint8_t watts) {
-    return peci_wr_pkg_config(
-        60, // index
-        0, // param
-        ((uint32_t)watts) * 8
-    );
-}
-
-void board_on_ac(bool ac) {
-    uint8_t power_limit = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
-    // Retry, timeout errors happen occasionally
-    for (int i = 0; i < 16; i++) {
-        int res = set_power_limit(power_limit);
-        DEBUG("set_power_limit %d = %d\n", power_limit, res);
-        if (res == 0x40) {
-            break;
-        } else if (res < 0) {
-            ERROR("set_power_limit failed: 0x%02X\n", -res);
-        } else {
-            ERROR("set_power_limit unknown response: 0x%02X\n", res);
-        }
-    }
-}
-
 void board_event(void) {
-    bool ac = !gpio_get(&ACIN_N);
-
-    static bool last_power_limit_ac = true;
-    // We don't use power_state because the latency needs to be low
-    if (gpio_get(&BUF_PLT_RST_N)) {
-        if (last_power_limit_ac != ac) {
-            board_on_ac(ac);
-            last_power_limit_ac = ac;
-        }
-    } else {
-        last_power_limit_ac = true;
-    }
+    power_set_limit();
 
     // Read POST codes
     while (P80H81HS & 1) {


### PR DESCRIPTION
Logic for changing power limit is the same for all boards with GPUs. It is still called from `board_event()` instead of in `power_event()` to maintain the current behavior of checking every main cycle.