### PR TITLE
Remove SCI#/SMI#/SWI# on boards using eSPI

### DIFF
--- a/src/board/system76/darp7/board.c
+++ b/src/board/system76/darp7/board.c
@@ -23,9 +23,6 @@ void board_init(void) {
     gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
-    // Assert SMI# and SWI#
-    gpio_set(&SMI_N, true);
-    gpio_set(&SWI_N, true);
 
     // Enable POST codes
     SPCTRL1 |= 0xC8;

--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -29,10 +29,8 @@ struct Gpio __code PWR_SW_N =       GPIO(B, 3);
 struct Gpio __code SB_KBCRST_N =    GPIO(E, 6);
 struct Gpio __code SLP_S0_N =       GPIO(J, 3);
 struct Gpio __code SLP_SUS_N =      GPIO(J, 7);
-struct Gpio __code SMI_N =          GPIO(D, 4);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
-struct Gpio __code SWI_N =          GPIO(B, 5);
 struct Gpio __code USB_PWR_EN_N =   GPIO(E, 3);
 struct Gpio __code VA_EC_EN =       GPIO(J, 4);
 struct Gpio __code WLAN_EN =        GPIO(G, 1);
@@ -56,8 +54,8 @@ void gpio_init() {
     // XLP_OUT, PWR_SW#, PCH_DPWROK_EC
     GPDRB = BIT(4) | BIT(3) | BIT(2);
     GPDRC = 0;
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
+    // PWR_BTN#
+    GPDRD = BIT(5);
     // USB_PWR_EN#
     GPDRE = BIT(3);
     // H_PECI
@@ -98,7 +96,7 @@ void gpio_init() {
     // XLP_OUT
     GPCRB4 = GPIO_OUT;
     // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
+    GPCRB5 = GPIO_IN;
     // SUSBC_EN
     GPCRB6 = GPIO_OUT | GPIO_UP;
     // Does not exist

--- a/src/board/system76/darp7/include/board/gpio.h
+++ b/src/board/system76/darp7/include/board/gpio.h
@@ -33,15 +33,12 @@ extern struct Gpio __code PM_PWROK;
 extern struct Gpio __code PWR_BTN_N;
 extern struct Gpio __code PWR_SW_N;
 extern struct Gpio __code SB_KBCRST_N;
-extern struct Gpio __code SCI_N;
 extern struct Gpio __code SLP_S0_N;
 extern struct Gpio __code SLP_SUS_N;
-extern struct Gpio __code SMI_N;
 extern struct Gpio __code SUSB_N_PCH;
 extern struct Gpio __code SUSC_N_PCH;
 #define HAVE_SUSWARN_N 0
 #define HAVE_SUS_PWR_ACK 0
-extern struct Gpio __code SWI_N;
 extern struct Gpio __code USB_PWR_EN_N;
 extern struct Gpio __code VA_EC_EN;
 extern struct Gpio __code VR_ON;

--- a/src/board/system76/galp5/board.c
+++ b/src/board/system76/galp5/board.c
@@ -30,9 +30,6 @@ void board_init(void) {
     gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
-    // Assert SMI# and SWI#
-    gpio_set(&SMI_N, true);
-    gpio_set(&SWI_N, true);
 
     // Enable POST codes
     SPCTRL1 |= 0xC8;

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -32,10 +32,8 @@ struct Gpio __code PWR_SW_N =       GPIO(B, 3);
 struct Gpio __code SB_KBCRST_N =    GPIO(E, 6);
 struct Gpio __code SLP_S0_N =       GPIO(A, 5);
 struct Gpio __code SLP_SUS_N =      GPIO(J, 7);
-struct Gpio __code SMI_N =          GPIO(D, 4);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
-struct Gpio __code SWI_N =          GPIO(B, 5);
 struct Gpio __code USB_PWR_EN_N =   GPIO(E, 3);
 struct Gpio __code VA_EC_EN =       GPIO(J, 4);
 struct Gpio __code WLAN_EN =        GPIO(G, 1);
@@ -60,8 +58,8 @@ void gpio_init() {
     GPDRB = BIT(4) | BIT(3);
     // PCH_DPWROK_EC
     GPDRC = BIT(5);
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
+    // PWR_BTN#
+    GPDRD = BIT(5);
     GPDRE = 0;
     // H_PECI
     GPDRF = BIT(6);
@@ -101,7 +99,7 @@ void gpio_init() {
     // XLP_OUT
     GPCRB4 = GPIO_OUT;
     // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
+    GPCRB5 = GPIO_IN;
     // SUSBC_EC
     GPCRB6 = GPIO_OUT | GPIO_UP;
     // N/A

--- a/src/board/system76/galp5/include/board/gpio.h
+++ b/src/board/system76/galp5/include/board/gpio.h
@@ -35,15 +35,12 @@ extern struct Gpio __code PM_PWROK;
 extern struct Gpio __code PWR_BTN_N;
 extern struct Gpio __code PWR_SW_N;
 extern struct Gpio __code SB_KBCRST_N;
-#define HAVE_SCI_N 0
 extern struct Gpio __code SLP_S0_N;
 extern struct Gpio __code SLP_SUS_N;
-extern struct Gpio __code SMI_N;
 extern struct Gpio __code SUSB_N_PCH;
 extern struct Gpio __code SUSC_N_PCH;
 #define HAVE_SUSWARN_N 0
 #define HAVE_SUS_PWR_ACK 0
-extern struct Gpio __code SWI_N;
 extern struct Gpio __code USB_PWR_EN_N;
 extern struct Gpio __code VA_EC_EN;
 extern struct Gpio __code WLAN_EN;

--- a/src/board/system76/lemp10/board.c
+++ b/src/board/system76/lemp10/board.c
@@ -24,10 +24,6 @@ void board_init(void) {
     gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
-    // Assert SMI#, SCI#, and SWI#
-    gpio_set(&SCI_N, true);
-    gpio_set(&SMI_N, true);
-    gpio_set(&SWI_N, true);
 
     // Enable POST codes
     SPCTRL1 |= 0xC8;

--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -25,13 +25,10 @@ struct Gpio __code PM_PWROK =       GPIO(C, 6);
 struct Gpio __code PWR_BTN_N =      GPIO(D, 5);
 struct Gpio __code PWR_SW_N =       GPIO(B, 3);
 struct Gpio __code SB_KBCRST_N =    GPIO(E, 6);
-struct Gpio __code SCI_N =          GPIO(D, 3);
 struct Gpio __code SLP_S0_N =       GPIO(J, 0);
 struct Gpio __code SLP_SUS_N =      GPIO(J, 3);
-struct Gpio __code SMI_N =          GPIO(D, 4);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
-struct Gpio __code SWI_N =          GPIO(B, 5);
 struct Gpio __code USB_PWR_EN_N =   GPIO(E, 3);
 struct Gpio __code VA_EC_EN =       GPIO(J, 4);
 struct Gpio __code VR_ON =          GPIO(H, 4);
@@ -56,8 +53,8 @@ void gpio_init() {
     // XLP_OUT, PWR_SW#
     GPDRB = BIT(4) | BIT(3);
     GPDRC = 0;
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
+    // PWR_BTN#
+    GPDRD = BIT(5);
     // USB_PWR_EN#
     GPDRE = BIT(3);
     // H_PECI
@@ -97,7 +94,7 @@ void gpio_init() {
     // XLP_OUT
     GPCRB4 = GPIO_OUT;
     // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
+    GPCRB5 = GPIO_IN;
     // EC_FORCE_POWER
     GPCRB6 = GPIO_IN;
     // NC
@@ -127,7 +124,7 @@ void gpio_init() {
     // SCI#
     GPCRD3 = GPIO_IN;
     // SMI#
-    GPCRD4 = GPIO_IN | GPIO_UP;
+    GPCRD4 = GPIO_IN;
     // PWR_BTN#
     GPCRD5 = GPIO_OUT | GPIO_UP;
     // CPU_FANSEN

--- a/src/board/system76/lemp10/include/board/gpio.h
+++ b/src/board/system76/lemp10/include/board/gpio.h
@@ -33,15 +33,12 @@ extern struct Gpio __code PM_PWROK;
 extern struct Gpio __code PWR_BTN_N;
 extern struct Gpio __code PWR_SW_N;
 extern struct Gpio __code SB_KBCRST_N;
-extern struct Gpio __code SCI_N;
 extern struct Gpio __code SLP_S0_N;
 extern struct Gpio __code SLP_SUS_N;
-extern struct Gpio __code SMI_N;
 extern struct Gpio __code SUSB_N_PCH;
 extern struct Gpio __code SUSC_N_PCH;
 #define HAVE_SUSWARN_N 0
 #define HAVE_SUS_PWR_ACK 0
-extern struct Gpio __code SWI_N;
 extern struct Gpio __code USB_PWR_EN_N;
 extern struct Gpio __code VA_EC_EN;
 extern struct Gpio __code VR_ON;


### PR DESCRIPTION
IIUC, these pins have been replaced with eSPI Virtual Wire events and are unused. Do not bother setting their data, and leave them as inputs. Per the specs, remove the pull up as it increases power consumption.

Will this leak; should they be pulled down?

Section "Power Consumption Consideration" says:

> - Each input pin should be driven or pulled
>   Input floating causes leakage current and should be prevented.