### PR TITLE
Use unsigned, shorter data types

### DIFF
--- a/src/arch/avr/i2c.c
+++ b/src/arch/avr/i2c.c
@@ -46,8 +46,8 @@ void i2c_stop(struct I2C * i2c) {
     TWCR = BIT(TWINT) | BIT(TWEN) | BIT(TWSTO);
 }
 
-int16_t i2c_write(struct I2C * i2c, uint8_t * data, int16_t length) {
-    int16_t i;
+int16_t i2c_write(struct I2C * i2c, uint8_t * data, uint16_t length) {
+    uint16_t i;
     for (i = 0; i < length; i++) {
         // load data into data register
         TWDR = data[i];
@@ -65,8 +65,8 @@ int16_t i2c_write(struct I2C * i2c, uint8_t * data, int16_t length) {
     return i;
 }
 
-int16_t i2c_read(struct I2C * i2c, uint8_t * data, int16_t length) {
-    int16_t i;
+int16_t i2c_read(struct I2C * i2c, uint8_t * data, uint16_t length) {
+    uint16_t i;
     for (i = 0; i < length; i++) {
         if ((i + 1) < length) {
             // start TWI module and acknowledge data after reception

--- a/src/board/system76/common/fan.c
+++ b/src/board/system76/common/fan.c
@@ -26,7 +26,7 @@ void fan_reset(void) {
 // Get duty cycle based on temperature, adapted from
 // https://github.com/pop-os/system76-power/blob/master/src/fan.rs
 uint8_t fan_duty(const struct Fan * fan, int16_t temp) __reentrant {
-    for (int16_t i = 0; i < fan->points_size; i++) {
+    for (uint8_t i = 0; i < fan->points_size; i++) {
         const struct FanPoint * cur = &fan->points[i];
 
         // If exactly the current temp, return the current duty
@@ -86,7 +86,7 @@ void fan_duty_set(uint8_t peci_fan_duty, uint8_t dgpu_fan_duty) __reentrant {
 uint8_t fan_heatup(const struct Fan * fan, uint8_t duty) __reentrant {
     uint8_t lowest = duty;
 
-    int16_t i;
+    uint8_t i;
     for (i = 0; (i + 1) < fan->heatup_size; i++) {
         uint8_t value = fan->heatup[i + 1];
         if (value < lowest) {
@@ -102,7 +102,7 @@ uint8_t fan_heatup(const struct Fan * fan, uint8_t duty) __reentrant {
 uint8_t fan_cooldown(const struct Fan * fan, uint8_t duty) __reentrant {
     uint8_t highest = duty;
 
-    int16_t i;
+    uint8_t i;
     for (i = 0; (i + 1) < fan->cooldown_size; i++) {
         uint8_t value = fan->cooldown[i + 1];
         if (value > highest) {

--- a/src/board/system76/common/include/board/parallel.h
+++ b/src/board/system76/common/include/board/parallel.h
@@ -8,6 +8,6 @@
 
 extern bool parallel_debug;
 bool parallel_init(void);
-int16_t parallel_write(uint8_t * data, int16_t length);
+int16_t parallel_write(uint8_t * data, uint16_t length);
 
 #endif // _BOARD_PARALLEL_H

--- a/src/board/system76/common/kbled.c
+++ b/src/board/system76/common/kbled.c
@@ -3,7 +3,7 @@
 #include <board/kbled.h>
 #include <common/macro.h>
 
-static int16_t LEVEL_I = 1;
+static uint8_t LEVEL_I = 1;
 static const uint8_t __code LEVELS[] = {
     48,
     72,
@@ -13,7 +13,7 @@ static const uint8_t __code LEVELS[] = {
     255
 };
 
-static int16_t COLOR_I = 0;
+static uint8_t COLOR_I = 0;
 static const uint32_t __code COLORS[] = {
     0xFFFFFF,
     0x0000FF,

--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -30,11 +30,11 @@ uint8_t kbscan_matrix[KM_OUT] = { 0 };
 
 uint8_t sci_extra = 0;
 
-static inline bool matrix_position_is_esc(int16_t row, int16_t col) {
+static inline bool matrix_position_is_esc(uint8_t row, uint8_t col) {
     return (row == MATRIX_ESC_OUTPUT) && (col == MATRIX_ESC_INPUT);
 }
 
-static inline bool matrix_position_is_fn(int16_t row, int16_t col) {
+static inline bool matrix_position_is_fn(uint8_t row, uint8_t col) {
     return (row == MATRIX_FN_OUTPUT) && (col == MATRIX_FN_INPUT);
 }
 
@@ -60,7 +60,7 @@ void kbscan_init(void) {
 // Debounce time in milliseconds
 #define DEBOUNCE_DELAY 15
 
-static uint8_t kbscan_get_row(int16_t i) {
+static uint8_t kbscan_get_row(uint8_t i) {
     // Report all keys as released when lid is closed
     if (!lid_state) {
         return 0;
@@ -118,7 +118,7 @@ static uint8_t kbscan_get_row(int16_t i) {
 }
 
 #if KM_NKEY
-static bool kbscan_has_ghost_in_row(int16_t row, uint8_t rowdata) {
+static bool kbscan_has_ghost_in_row(uint8_t row, uint8_t rowdata) {
     // Use arguments
     row = row;
     rowdata = rowdata;
@@ -129,21 +129,21 @@ static inline bool popcount_more_than_one(uint8_t rowdata) {
     return rowdata & (rowdata - 1);
 }
 
-static uint8_t kbscan_get_real_keys(int16_t row, uint8_t rowdata) {
+static uint8_t kbscan_get_real_keys(uint8_t row, uint8_t rowdata) {
     // Remove any "active" blanks from the matrix.
     uint8_t realdata = 0;
     for (uint8_t col = 0; col < KM_IN; col++) {
         // This tests the default keymap intentionally, to avoid blanks in the
         // dynamic keymap
         if (KEYMAP[0][row][col] && (rowdata & BIT(col))) {
-            realdata |=  BIT(col);
+            realdata |= BIT(col);
         }
     }
 
     return realdata;
 }
 
-static bool kbscan_has_ghost_in_row(int16_t row, uint8_t rowdata) {
+static bool kbscan_has_ghost_in_row(uint8_t row, uint8_t rowdata) {
     rowdata = kbscan_get_real_keys(row, rowdata);
 
     // No ghosts exist when  less than 2 keys in the row are active.
@@ -152,7 +152,7 @@ static bool kbscan_has_ghost_in_row(int16_t row, uint8_t rowdata) {
     }
 
     // Check against other rows to see if more than one column matches.
-    for (int16_t i = 0; i < KM_OUT; i++) {
+    for (uint8_t i = 0; i < KM_OUT; i++) {
         uint8_t otherrow = kbscan_get_real_keys(i, kbscan_get_row(i));
         if (i != row && popcount_more_than_one(otherrow & rowdata)) {
             return true;
@@ -315,8 +315,7 @@ void kbscan_event(void) {
         }
     }
 
-    int16_t i;
-    for (i = 0; i < KM_OUT; i++) {
+    for (uint8_t i = 0; i < KM_OUT; i++) {
         uint8_t new = kbscan_get_row(i);
         uint8_t last = kbscan_matrix[i];
         if (new != last) {
@@ -331,8 +330,7 @@ void kbscan_event(void) {
             }
 
             // A key was pressed or released
-            int16_t j;
-            for (j = 0; j < KM_IN; j++) {
+            for (uint8_t j = 0; j < KM_IN; j++) {
                 bool new_b = new & BIT(j);
                 bool last_b = last & BIT(j);
                 if (new_b != last_b) {

--- a/src/board/system76/common/keymap.c
+++ b/src/board/system76/common/keymap.c
@@ -17,9 +17,9 @@ void keymap_init(void) {
 }
 
 void keymap_load_default(void) {
-    for (int16_t layer = 0; layer < KM_LAY; layer++) {
-        for (int16_t output = 0; output < KM_OUT; output++) {
-            for (int16_t input = 0; input < KM_IN; input++) {
+    for (uint8_t layer = 0; layer < KM_LAY; layer++) {
+        for (uint8_t output = 0; output < KM_OUT; output++) {
+            for (uint8_t input = 0; input < KM_IN; input++) {
                 DYNAMIC_KEYMAP[layer][output][input] = KEYMAP[layer][output][input];
             }
         }
@@ -57,7 +57,7 @@ bool keymap_save_config(void) {
     return flash_read_u16(CONFIG_ADDR) == CONFIG_SIGNATURE;
 }
 
-bool keymap_get(int16_t layer, int16_t output, int16_t input, uint16_t * value) {
+bool keymap_get(uint8_t layer, uint8_t output, uint8_t input, uint16_t * value) {
     if (layer < KM_LAY && output < KM_OUT && input < KM_IN) {
         *value = DYNAMIC_KEYMAP[layer][output][input];
         return true;
@@ -66,7 +66,7 @@ bool keymap_get(int16_t layer, int16_t output, int16_t input, uint16_t * value) 
     }
 }
 
-bool keymap_set(int16_t layer, int16_t output, int16_t input, uint16_t value) {
+bool keymap_set(uint8_t layer, uint8_t output, uint8_t input, uint16_t value) {
     if (layer < KM_LAY && output < KM_OUT && input < KM_IN) {
         DYNAMIC_KEYMAP[layer][output][input] = value;
         return true;

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -99,7 +99,7 @@ void main(void) {
     uint32_t last_time_fan = 0;
 
     for(main_cycle = 0; ; main_cycle++) {
-        switch (main_cycle % 3) {
+        switch (main_cycle % 3U) {
             case 0:
                 // Handle power states
                 power_event();

--- a/src/board/system76/common/parallel.c
+++ b/src/board/system76/common/parallel.c
@@ -82,14 +82,14 @@ bool parallel_init(void) {
     return parallel_wait_peripheral(STS_WAIT, 0);
 }
 
-int16_t parallel_write(uint8_t * data, int16_t length) {
+int16_t parallel_write(uint8_t * data, uint16_t length) {
     // Assert nWRITE
     KSIGDAT &= ~CTL_WRITE;
 
     // Set data lines as outputs
     KSOLGOEN = 0xFF;
 
-    int16_t i;
+    uint16_t i;
     for (i = 0; i < length; i++) {
         // Wait for peripheral to indicate it's ready for next cycle
         if (!parallel_wait_peripheral(STS_WAIT, 0)) {

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -294,7 +294,7 @@ void power_on_s5(void) {
     // Wait for SUSPWRDNACK validity
     tPLT01;
 
-    for (int16_t i = 0; i < 5000; i++) {
+    for (uint16_t i = 5000; i != 0; i--) {
         // If we reached S0, exit this loop
         update_power_state();
         if (power_state == POWER_STATE_S0) {
@@ -361,7 +361,7 @@ void power_off_s5(void) {
 static void power_peci_limit(bool ac) {
     uint8_t watts = ac ? POWER_LIMIT_AC : POWER_LIMIT_DC;
     // Retry, timeout errors happen occasionally
-    for (int16_t i = 0; i < 16; i++) {
+    for (uint8_t i = 16; i != 0; i--) {
         // Set PL4 using PECI
         int16_t res = peci_wr_pkg_config(60, 0, ((uint32_t)watts) * 8);
         DEBUG("power_peci_limit %d = %d\n", watts, res);
@@ -466,7 +466,7 @@ void power_event(void) {
     bool ps_new = gpio_get(&PWR_SW_N);
     if (!ps_new && ps_last) {
         // Ensure press is not spurious
-        for (int16_t i = 0; i < 100; i++) {
+        for (uint8_t i = 100; i != 0; i--) {
             delay_ms(1);
             if (gpio_get(&PWR_SW_N) != ps_new) {
                 DEBUG("%02X: Spurious press\n", main_cycle);

--- a/src/common/i2c.c
+++ b/src/common/i2c.c
@@ -2,7 +2,7 @@
 
 #include <common/i2c.h>
 
-int16_t i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, int16_t length) __reentrant {
+int16_t i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, uint16_t length) __reentrant {
     int16_t res = 0;
 
     res = i2c_start(i2c, addr, true);
@@ -16,7 +16,7 @@ int16_t i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, int16_t length) 
     return res;
 }
 
-int16_t i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, int16_t length) __reentrant {
+int16_t i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, uint16_t length) __reentrant {
     int16_t res = 0;
 
     res = i2c_start(i2c, addr, false);
@@ -30,7 +30,7 @@ int16_t i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, int16_t length) 
     return res;
 }
 
-int16_t i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int16_t length) __reentrant {
+int16_t i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, uint16_t length) __reentrant {
     int16_t res = 0;
 
     res = i2c_start(i2c, addr, false);
@@ -42,7 +42,7 @@ int16_t i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int1
     return i2c_recv(i2c, addr, data, length);
 }
 
-int16_t i2c_set(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int16_t length) __reentrant {
+int16_t i2c_set(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, uint16_t length) __reentrant {
     int16_t res = 0;
 
     res = i2c_start(i2c, addr, false);

--- a/src/common/include/common/i2c.h
+++ b/src/common/include/common/i2c.h
@@ -24,22 +24,22 @@ void i2c_stop(struct I2C * i2c) __reentrant;
 
 // Send a byte on i2c bus
 // Must be defined by arch, board, or ec
-int16_t i2c_write(struct I2C * i2c, uint8_t * data, int16_t length) __reentrant;
+int16_t i2c_write(struct I2C * i2c, uint8_t * data, uint16_t length) __reentrant;
 
 // Read bytes from bus
 // Must be defined by arch, board, or ec
-int16_t i2c_read(struct I2C * i2c, uint8_t * data, int16_t length) __reentrant;
+int16_t i2c_read(struct I2C * i2c, uint8_t * data, uint16_t length) __reentrant;
 
 // Read multiple bytes from address in one transaction
-int16_t i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, int16_t length) __reentrant;
+int16_t i2c_recv(struct I2C * i2c, uint8_t addr, uint8_t* data, uint16_t length) __reentrant;
 
 // Write multiple bytes to address in one transaction
-int16_t i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, int16_t length) __reentrant;
+int16_t i2c_send(struct I2C * i2c, uint8_t addr, uint8_t* data, uint16_t length) __reentrant;
 
 // Read multiple bytes from a register in one transaction
-int16_t i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int16_t length) __reentrant;
+int16_t i2c_get(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, uint16_t length) __reentrant;
 
 // Write multiple bytes to a register in one transaction
-int16_t i2c_set(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, int16_t length) __reentrant;
+int16_t i2c_set(struct I2C * i2c, uint8_t addr, uint8_t reg, uint8_t* data, uint16_t length) __reentrant;
 
 #endif // _COMMON_I2C_H

--- a/src/common/include/common/keymap.h
+++ b/src/common/include/common/keymap.h
@@ -27,9 +27,9 @@
     // Save dynamic keymap to flash
     bool keymap_save_config(void);
     // Get a keycode from the dynamic keymap
-    bool keymap_get(int16_t layer, int16_t output, int16_t input, uint16_t * value);
+    bool keymap_get(uint8_t layer, uint8_t output, uint8_t input, uint16_t * value);
     // Set a keycode in the dynamic keymap
-    bool keymap_set(int16_t layer, int16_t output, int16_t input, uint16_t value);
+    bool keymap_set(uint8_t layer, uint8_t output, uint8_t input, uint16_t value);
 #endif
 
 // Translate a keycode from PS/2 set 2 to PS/2 set 1

--- a/src/ec/ite/i2c.c
+++ b/src/ec/ite/i2c.c
@@ -94,8 +94,8 @@ void i2c_stop(struct I2C * i2c) {
     i2c_reset(i2c, false);
 }
 
-static int16_t i2c_transaction(struct I2C * i2c, uint8_t * data, int16_t length, bool read) {
-    int16_t i;
+static int16_t i2c_transaction(struct I2C * i2c, uint8_t * data, uint16_t length, bool read) {
+    uint16_t i;
     for (i = 0; i < length; i++) {
         if (read) {
             // If last byte
@@ -153,10 +153,10 @@ static int16_t i2c_transaction(struct I2C * i2c, uint8_t * data, int16_t length,
     return i;
 }
 
-int16_t i2c_read(struct I2C * i2c, uint8_t * data, int16_t length) __reentrant {
+int16_t i2c_read(struct I2C * i2c, uint8_t * data, uint16_t length) __reentrant {
     return i2c_transaction(i2c, data, length, true);
 }
 
-int16_t i2c_write(struct I2C * i2c, uint8_t * data, int16_t length) __reentrant {
+int16_t i2c_write(struct I2C * i2c, uint8_t * data, uint16_t length) __reentrant {
     return i2c_transaction(i2c, data, length, false);
 }

--- a/src/ec/ite/include/ec/kbc.h
+++ b/src/ec/ite/include/ec/kbc.h
@@ -33,8 +33,8 @@ extern struct Kbc __code KBC;
 
 uint8_t kbc_status(struct Kbc * kbc);
 uint8_t kbc_read(struct Kbc * kbc);
-bool kbc_keyboard(struct Kbc * kbc, uint8_t data, int16_t timeout);
-bool kbc_mouse(struct Kbc * kbc, uint8_t data, int16_t timeout);
+bool kbc_keyboard(struct Kbc * kbc, uint8_t data, uint16_t timeout);
+bool kbc_mouse(struct Kbc * kbc, uint8_t data, uint16_t timeout);
 
 volatile uint8_t __xdata __at(0x1300) KBHICR;
 volatile uint8_t __xdata __at(0x1302) KBIRQR;

--- a/src/ec/ite/kbc.c
+++ b/src/ec/ite/kbc.c
@@ -20,7 +20,7 @@ uint8_t kbc_read(struct Kbc * kbc) {
     return *(kbc->data_in);
 }
 
-static bool kbc_wait(struct Kbc * kbc, int16_t timeout) {
+static bool kbc_wait(struct Kbc * kbc, uint16_t timeout) {
     while (*(kbc->status) & KBC_STS_OBF) {
         if (timeout == 0) return false;
         timeout -= 1;
@@ -29,14 +29,14 @@ static bool kbc_wait(struct Kbc * kbc, int16_t timeout) {
     return true;
 }
 
-bool kbc_keyboard(struct Kbc * kbc, uint8_t data, int16_t timeout) {
+bool kbc_keyboard(struct Kbc * kbc, uint8_t data, uint16_t timeout) {
     if (!kbc_wait(kbc, timeout)) return false;
     *(kbc->status) &= ~0x20;
     *(kbc->keyboard_out) = data;
     return true;
 }
 
-bool kbc_mouse(struct Kbc * kbc, uint8_t data, int16_t timeout) {
+bool kbc_mouse(struct Kbc * kbc, uint8_t data, uint16_t timeout) {
     if (!kbc_wait(kbc, timeout)) return false;
     *(kbc->status) |= 0x20;
     *(kbc->mouse_out) = data;


### PR DESCRIPTION
Ref: #222

```diff
--- build/system76/gaze15/2021-08-02_99af8a3/ec.mem     2021-08-02 12:14:45.885302912 -0600
+++ build/system76/gaze15/2021-08-02_6eff43f/ec.mem     2021-08-02 12:15:02.065163105 -0600
@@ -1,12 +1,12 @@
 Internal RAM layout:
       0 1 2 3 4 5 6 7 8 9 A B C D E F
 0x00:|0|0|0|0|0|0|0|0|a|a|a|a|a|a|b|b|
-0x10:|b|b|b|b|b|b|b|b|b|b|b|b|b|c|c|c|
-0x20:|c|c|c|c|c|c|c|d|e|e|e|e|e|e|e|e|
-0x30:|f|f|g|g|g|g|g|g|g|g|g|g|g|g|g|g|
-0x40:|g|g|g|g|g|g|g|g|g|g|g|g|g|g|g|g|
-0x50:|g|h|i|i|i|i|i|i|i|i|i|i|Q|Q|Q|Q|
-0x60:|Q|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
+0x10:|b|b|b|b|b|b|b|b|b|b|b|b|c|c|c|c|
+0x20:|d|e|e|e|e|e|e|e|e|f|f|f|f|f|f|f|
+0x30:|f|f|f|f|f|f|f|f|f|f|f|f|f|f|f|f|
+0x40:|f|f|f|f|f|f|f|f|g|h|h|h|h|h|h|h|
+0x50:|h|h|h|Q|Q|Q|Q|Q|S|S|S|S|S|S|S|S|
+0x60:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
 0x70:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
 0x80:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
 0x90:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
@@ -18,12 +18,12 @@
 0xf0:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
 0-3:Reg Banks, T:Bit regs, a-z:Data, B:Bits, Q:Overlay, I:iData, S:Stack, A:Absolute
 
-Stack starts at: 0x61 (sp set to 0x60) with 159 bytes available.
+Stack starts at: 0x58 (sp set to 0x57) with 168 bytes available.
 No spare internal RAM space left.
 
 Other memory:
    Name             Start    End      Size     Max     
    ---------------- -------- -------- -------- --------
    PAGED EXT. RAM                         0      256   
-   EXTERNAL RAM     0x0001   0x0526    1318     2048   
-   ROM/EPROM/FLASH  0x0000   0x8a8b   34449    65536   
+   EXTERNAL RAM     0x0001   0x0511    1297     2048   
+   ROM/EPROM/FLASH  0x0000   0x86fb   33537    65536
```

Resulting ROM for gaze15 is 912 bytes smaller.