### PR TITLE
Remove overflow check for unsigned diffs

### DIFF
--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -122,7 +122,7 @@ void main(void) {
         if (main_cycle == 0) {
             uint32_t time = time_get();
             // Only run the following once per interval
-            if (last_time_fan > time || (time - last_time_fan) >= fan_interval) {
+            if ((time - last_time_fan) >= fan_interval) {
                 last_time_fan = time;
 
                 // Update fan speeds
@@ -130,7 +130,7 @@ void main(void) {
             }
 
             // Only run the following once per interval
-            if (last_time_battery > time || (time - last_time_battery) >= battery_interval) {
+            if ((time - last_time_battery) >= battery_interval) {
                 last_time_battery = time;
 
                 // Updates battery status

--- a/src/board/system76/common/parallel.c
+++ b/src/board/system76/common/parallel.c
@@ -34,7 +34,7 @@ bool parallel_debug = false;
 static bool parallel_wait_peripheral(uint8_t mask, uint8_t value) {
     uint32_t start = time_get();
 
-    while (time_get() < start + PARALLEL_TIMEOUT) {
+    while ((time_get() - start) < PARALLEL_TIMEOUT) {
         if ((KSOHGDMRR & mask) == value) {
             return true;
         }

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -618,11 +618,7 @@ void power_event(void) {
 #if EC_ESPI
         if (!gpio_get(&CPU_C10_GATE_N)) {
             // Modern suspend, flashing green light
-            if (
-                (time < last_time) // overflow
-                ||
-                (time >= (last_time + 1000)) // timeout
-            ) {
+            if ((time - last_time) >= 1000) {
                 gpio_set(&LED_PWR, !gpio_get(&LED_PWR));
                 last_time = time;
             }
@@ -636,11 +632,7 @@ void power_event(void) {
         }
     } else if (power_state == POWER_STATE_S3 || power_state == POWER_STATE_DS3) {
         // Suspended, flashing green light
-        if (
-            (time < last_time) // overflow
-            ||
-            (time >= (last_time + 1000)) // timeout
-        ) {
+        if ((time - last_time) >= 1000) {
             gpio_set(&LED_PWR, !gpio_get(&LED_PWR));
             last_time = time;
         }
@@ -652,11 +644,7 @@ void power_event(void) {
     } else {
         // CPU off and AC adapter unplugged, flashing orange light
         gpio_set(&LED_PWR, false);
-        if (
-            (time < last_time) // overflow
-            ||
-            (time >= (last_time + 1000)) // timeout
-        ) {
+        if ((time - last_time) >= 1000) {
             gpio_set(&LED_ACIN, !gpio_get(&LED_ACIN));
             last_time = time;
         }


### PR DESCRIPTION
Calculating diffs with *unsigned* integers will always produce the correct result, as long as the diff is less than the type max.

For example, suppose we read 254 and 2 for an 8 bit value:

    2 - 254 = 4

Using this property, simplify diffs on `time_get()` comparisons.