### PR TITLE
gaze16: set PCH_DPWROK_EC low on EC boot to ensure PCH is off

### DIFF
--- a/src/board/system76/gaze16-3050/gpio.c
+++ b/src/board/system76/gaze16-3050/gpio.c
@@ -55,8 +55,8 @@ void gpio_init() {
     // PWR_BTN#, SMI#, SCI#
     GPDRD = BIT(5) | BIT(4) | BIT(3);
     GPDRE = 0;
-    // CC_EN, PCH_DPWROK_EC
-    GPDRF = BIT(7) | BIT(3);
+    // CC_EN
+    GPDRF = BIT(7);
     // H_PROCHOT_EC, WLAN_EN
     GPDRG = BIT(6) | BIT(1);
     // AIRPLAN_LED#

--- a/src/board/system76/gaze16-3060/gpio.c
+++ b/src/board/system76/gaze16-3060/gpio.c
@@ -56,8 +56,7 @@ void gpio_init() {
     // PWR_BTN#, SMI#, SCI#
     GPDRD = BIT(5) | BIT(4) | BIT(3);
     GPDRE = 0;
-    // PCH_DPWROK_EC
-    GPDRF = BIT(7);
+    GPDRF = 0;
     // H_PROCHOT#_EC, WLAN_EN
     GPDRG = BIT(6) | BIT(1);
     // AIRPLAN_LED#


### PR DESCRIPTION
This should make the gaze16 not require the AC adapter to be removed after flashing the EC.