### PR TITLE
tool: Add a system76_ec command to disable input events

### DIFF
--- a/src/common/include/common/command.h
+++ b/src/common/include/common/command.h
@@ -44,6 +44,8 @@ enum Command {
     CMD_MATRIX_GET = 17,
     // Save LED settings to ROM
     CMD_LED_SAVE = 18,
+    // Enable/disable no input mode
+    CMD_SET_NO_INPUT = 19,
     //TODO
 };
 

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "system76_ectool"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "downcast-rs",

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system76_ectool"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2018"
 description = "System76 EC tool"
 license = "MIT"

--- a/tool/src/ec.rs
+++ b/tool/src/ec.rs
@@ -35,6 +35,7 @@ enum Cmd {
     LedSetMode = 16,
     MatrixGet = 17,
     LedSave = 18,
+    SetNoInput = 19,
 }
 
 const CMD_SPI_FLAG_READ: u8 = 1 << 0;
@@ -277,6 +278,10 @@ impl<A: Access> Ec<A> {
 
     pub unsafe fn matrix_get(&mut self, matrix: &mut [u8]) -> Result<(), Error> {
         self.command(Cmd::MatrixGet, matrix)
+    }
+
+    pub unsafe fn set_no_input(&mut self, no_input: bool) -> Result<(), Error> {
+        self.command(Cmd::SetNoInput, &mut [no_input as u8])
     }
 
     pub fn into_dyn(self) -> Ec<Box<dyn Access>>

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -377,6 +377,12 @@ fn main() {
                 .multiple(true)
             )
         )
+        .subcommand(SubCommand::with_name("set_no_input")
+            .arg(Arg::with_name("value")
+                .possible_values(&["true", "false"])
+                .required(true)
+            )
+        )
         .get_matches();
 
     let get_ec = || -> Result<_, Error> {
@@ -596,6 +602,16 @@ fn main() {
                 },
             }
         },
+        ("set_no_input", Some(sub_m)) => {
+            let no_input = sub_m.value_of("value").unwrap().parse::<bool>().unwrap();
+            match unsafe { ec.set_no_input(no_input) } {
+                Ok(()) => (),
+                Err(err) => {
+                    eprintln!("failed to set no_input mode: {:X?}", err);
+                    process::exit(1);
+                }
+            }
+        }
         _ => unreachable!()
     }
 }


### PR DESCRIPTION
For testing Launch keyboards.

Could easily support in EC firmware as well if we had a use for that, but not adding that for now.

Requires https://github.com/system76/qmk_firmware/pull/20.