### PR TITLE
fan: Replace 'static const' with defines

### DIFF
--- a/src/board/system76/common/fan.c
+++ b/src/board/system76/common/fan.c
@@ -5,14 +5,14 @@
 #include <ec/pwm.h>
 
 #if SMOOTH_FANS != 0
-    static const uint8_t max_jump_up = (MAX_FAN_SPEED - MIN_FAN_SPEED) / (uint8_t) SMOOTH_FANS_UP;
-    static const uint8_t max_jump_down = (MAX_FAN_SPEED - MIN_FAN_SPEED) / (uint8_t) SMOOTH_FANS_DOWN;
+#define MAX_JUMP_UP ((MAX_FAN_SPEED - MIN_FAN_SPEED) / (uint8_t)SMOOTH_FANS_UP)
+#define MAX_JUMP_DOWN ((MAX_FAN_SPEED - MIN_FAN_SPEED) / (uint8_t)SMOOTH_FANS_DOWN)
 #else
-    static const uint8_t max_jump_up = MAX_FAN_SPEED - MIN_FAN_SPEED;
-    static const uint8_t max_jump_down = MAX_FAN_SPEED - MIN_FAN_SPEED;
+#define MAX_JUMP_UP (MAX_FAN_SPEED - MIN_FAN_SPEED)
+#define MAX_JUMP_DOWN (MAX_FAN_SPEED - MIN_FAN_SPEED)
 #endif
 
-static const uint8_t min_speed_to_smooth = PWM_DUTY(SMOOTH_FANS_MIN);
+#define MIN_SPEED_TO_SMOOTH PWM_DUTY(SMOOTH_FANS_MIN)
 
 bool fan_max = false;
 uint8_t last_duty_dgpu = 0;
@@ -121,12 +121,12 @@ uint8_t fan_smooth(uint8_t last_duty, uint8_t duty) __reentrant {
     // ramping down
     if (duty < last_duty) {
         // out of bounds (lower) safeguard
-        uint8_t smoothed = last_duty < MIN_FAN_SPEED + max_jump_down
+        uint8_t smoothed = last_duty < MIN_FAN_SPEED + MAX_JUMP_DOWN
             ? MIN_FAN_SPEED
-            : last_duty - max_jump_down;
+            : last_duty - MAX_JUMP_DOWN;
 
         // use smoothed value if above min and if smoothed is closer than raw
-        if (last_duty > min_speed_to_smooth && smoothed > duty) {
+        if (last_duty > MIN_SPEED_TO_SMOOTH && smoothed > duty) {
             next_duty = smoothed;
         }
     }
@@ -134,12 +134,12 @@ uint8_t fan_smooth(uint8_t last_duty, uint8_t duty) __reentrant {
     // ramping up
     if (duty > last_duty) {
         // out of bounds (higher) safeguard
-        uint8_t smoothed = last_duty > MAX_FAN_SPEED - max_jump_up
+        uint8_t smoothed = last_duty > MAX_FAN_SPEED - MAX_JUMP_UP
             ? MAX_FAN_SPEED
-            : last_duty + max_jump_up;
+            : last_duty + MAX_JUMP_UP;
 
         // use smoothed value if above min and if smoothed is closer than raw
-        if (duty > min_speed_to_smooth && smoothed < duty) {
+        if (duty > MIN_SPEED_TO_SMOOTH && smoothed < duty) {
             next_duty = smoothed;
         }
     }


### PR DESCRIPTION
SDCC is not able to optimize statics [\[1\]](https://sourceforge.net/p/sdcc/feature-requests/414/). Replace their use with defines so significantly better code is generated.

```diff
--- build/system76/oryp6/0/board/system76/common/fan.asm	2021-12-16 16:32:53.743631152 -0700
+++ build/system76/oryp6/1/board/system76/common/fan.asm	2021-12-16 16:43:13.537870374 -0700
@@ -1284,42 +1284,20 @@
 	mov	a,r6
 	subb	a,r7
 	jnc	00105$
-;	src/board/system76/common/fan.c:124: uint8_t smoothed = last_duty < MIN_FAN_SPEED + max_jump_down
-	push	ar6
-	mov	dptr,#_max_jump_down
-	clr	a
-	movc	a,@a+dptr
-	mov	r5,a
-	mov	r3,a
-	mov	r4,#0x00
-	mov	ar2,r7
-	mov	r6,#0x00
-	clr	c
-	mov	a,r2
-	subb	a,r3
-	mov	a,r6
-	xrl	a,#0x80
-	mov	b,r4
-	xrl	b,#0x80
-	subb	a,b
-	pop	ar6
+;	src/board/system76/common/fan.c:124: uint8_t smoothed = last_duty < MIN_FAN_SPEED + MAX_JUMP_DOWN
+	cjne	r7,#0x02,00150$
+00150$:
 	jnc	00113$
-	mov	r4,#0x00
+	mov	r5,#0x00
 	sjmp	00114$
 00113$:
 	mov	a,r7
-	clr	c
-	subb	a,r5
-	mov	r4,a
+	add	a,#0xfe
+	mov	r5,a
 00114$:
-	mov	ar5,r4
-;	src/board/system76/common/fan.c:129: if (last_duty > min_speed_to_smooth && smoothed > duty) {
-	mov	dptr,#_min_speed_to_smooth
-	clr	a
-	movc	a,@a+dptr
-	mov	r4,a
-	clr	c
-	subb	a,r7
+;	src/board/system76/common/fan.c:129: if (last_duty > MIN_SPEED_TO_SMOOTH && smoothed > duty) {
+	mov	a,r7
+	add	a,#0xff - 0x40
 	jnc	00105$
 	clr	c
 	mov	a,r6
@@ -1336,52 +1314,24 @@
 	mov	a,r7
 	subb	a,@r0
 	jnc	00110$
-;	src/board/system76/common/fan.c:137: uint8_t smoothed = last_duty > MAX_FAN_SPEED - max_jump_up
-	push	ar6
-	mov	dptr,#_max_jump_up
-	clr	a
-	movc	a,@a+dptr
-	mov	r5,a
-	mov	r3,a
-	mov	r4,#0x00
-	mov	a,#0xff
-	clr	c
-	subb	a,r3
-	mov	r3,a
-	clr	a
-	subb	a,r4
-	mov	r4,a
-	mov	ar2,r7
-	mov	r6,#0x00
-	clr	c
-	mov	a,r3
-	subb	a,r2
-	mov	a,r4
-	xrl	a,#0x80
-	mov	b,r6
-	xrl	b,#0x80
-	subb	a,b
-	pop	ar6
+;	src/board/system76/common/fan.c:137: uint8_t smoothed = last_duty > MAX_FAN_SPEED - MAX_JUMP_UP
+	mov	a,r7
+	add	a,#0xff - 0xfa
 	jnc	00115$
-	mov	r4,#0xff
+	mov	r5,#0xff
 	sjmp	00116$
 00115$:
-	mov	a,r5
+	mov	a,#0x05
 	add	a,r7
-	mov	r4,a
-00116$:
-	mov	ar7,r4
-;	src/board/system76/common/fan.c:142: if (duty > min_speed_to_smooth && smoothed < duty) {
-	mov	dptr,#_min_speed_to_smooth
-	clr	a
-	movc	a,@a+dptr
 	mov	r5,a
+00116$:
+	mov	ar7,r5
+;	src/board/system76/common/fan.c:142: if (duty > MIN_SPEED_TO_SMOOTH && smoothed < duty) {
 	mov	a,_bp
 	add	a,#0xfd
 	mov	r0,a
-	clr	c
-	mov	a,r5
-	subb	a,@r0
+	mov	a,@r0
+	add	a,#0xff - 0x40
 	jnc	00110$
 	mov	a,_bp
 	add	a,#0xfd
@@ -1400,12 +1350,6 @@
 	ret
 	.area CSEG    (CODE)
 	.area CONST   (CODE)
-_max_jump_up:
-	.db #0x05	; 5
-_max_jump_down:
-	.db #0x02	; 2
-_min_speed_to_smooth:
-	.db #0x40	; 64
 	.area XINIT   (CODE)
 __xinit__fan_max:
 	.db #0x00	;  0
````