### PR TITLE
Add FnLock key

### DIFF
--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -5,6 +5,7 @@
 #include <board/acpi.h>
 #include <board/fan.h>
 #include <board/gpio.h>
+#include <board/keymap.h>
 #include <board/kbc.h>
 #include <board/kbled.h>
 #include <board/kbscan.h>
@@ -202,6 +203,12 @@ bool kbscan_press(uint16_t key, bool pressed, uint8_t *layer) {
         pmc_swi();
     }
 
+    if (key == K_FNLOCK && pressed) {
+        DEBUG("Toggling FnLock\n");
+        keymap_fnlock ^= 1;
+        return true;
+    }
+
     switch (key & KT_MASK) {
     case (KT_NORMAL):
         if (kbscan_enabled) {
@@ -298,6 +305,7 @@ static inline bool key_should_repeat(uint16_t key) {
     case K_CAMERA_TOGGLE:
     case K_DISPLAY_TOGGLE:
     case K_FAN_TOGGLE:
+    case K_FNLOCK:
     case K_KBD_BKL:
     case K_KBD_COLOR:
     case K_KBD_TOGGLE:

--- a/src/board/system76/common/keymap.c
+++ b/src/board/system76/common/keymap.c
@@ -3,6 +3,8 @@
 #include <board/flash.h>
 #include <board/keymap.h>
 
+bool keymap_fnlock = false;
+
 uint16_t __xdata DYNAMIC_KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Config is in the last sector of flash
@@ -69,6 +71,8 @@ bool keymap_save_config(void) {
 
 bool keymap_get(uint8_t layer, uint8_t output, uint8_t input, uint16_t *value) {
     if (layer < KM_LAY && output < KM_OUT && input < KM_IN) {
+        if (keymap_fnlock && keymap_is_f_key(output, input))
+            layer ^= 1;
         *value = DYNAMIC_KEYMAP[layer][output][input];
         return true;
     } else {

--- a/src/common/include/common/keymap.h
+++ b/src/common/include/common/keymap.h
@@ -16,6 +16,9 @@ extern uint16_t __xdata DYNAMIC_KEYMAP[KM_LAY][KM_OUT][KM_IN];
 #endif
 
 #if HAVE_KEYMAP
+// FnLock config
+extern bool keymap_fnlock;
+
 // Initialize the dynamic keymap
 void keymap_init(void);
 // Set the dynamic keymap to the default keymap
@@ -277,5 +280,10 @@ uint16_t keymap_translate(uint16_t key);
 
 #define K_INT_1 (0x61)
 #define K_INT_2 (0x5D)
+
+// XXX: Custom keys
+
+#define KF_CUSTOM (0x0200)
+#define K_FNLOCK (KF_CUSTOM | 0x01)
 
 #endif // _COMMON_KEYMAP_H

--- a/src/keyboard/system76/14in_83/include/board/keymap.h
+++ b/src/keyboard/system76/14in_83/include/board/keymap.h
@@ -79,4 +79,25 @@
 #define MATRIX_FN_INPUT 0
 #define MATRIX_FN_OUTPUT 6
 
+static inline bool keymap_is_f_key(uint8_t row, uint8_t col) {
+    switch (row) {
+    case 8:
+        return col == 6 || col == 7;
+    case 9:
+        return col == 6 || col == 7;
+    case 10:
+        return col == 6 || col == 7;
+    case 11:
+        return col == 6 || col == 7;
+    case 12:
+        return col == 6 || col == 7;
+    case 13:
+        return col == 7;
+    case 15:
+        return col == 5;
+    default:
+        return false;
+    }
+}
+
 #endif // _BOARD_KEYMAP_H

--- a/src/keyboard/system76/14in_86/include/board/keymap.h
+++ b/src/keyboard/system76/14in_86/include/board/keymap.h
@@ -50,4 +50,25 @@
 #define MATRIX_FN_INPUT 0
 #define MATRIX_FN_OUTPUT 6
 
+static inline bool keymap_is_f_key(uint8_t row, uint8_t col) {
+    switch (row) {
+    case 8:
+        return col == 6 || col == 7;
+    case 9:
+        return col == 6 || col == 7;
+    case 10:
+        return col == 6 || col == 7;
+    case 11:
+        return col == 6 || col == 7;
+    case 12:
+        return col == 6 || col == 7;
+    case 13:
+        return col == 7;
+    case 15:
+        return col == 5;
+    default:
+        return false;
+    }
+}
+
 #endif // _BOARD_KEYMAP_H

--- a/src/keyboard/system76/15in_102/include/board/keymap.h
+++ b/src/keyboard/system76/15in_102/include/board/keymap.h
@@ -60,4 +60,25 @@
 #define MATRIX_FN_INPUT 3
 #define MATRIX_FN_OUTPUT 17
 
+static inline bool keymap_is_f_key(uint8_t row, uint8_t col) {
+    switch (row) {
+    case 8:
+        return col == 5 || col == 7;
+    case 9:
+        return col == 3;
+    case 10:
+        return col == 5 || col == 6;
+    case 12:
+        return col == 5;
+    case 13:
+        return col == 3 || col == 7;
+    case 14:
+        return col == 1 || col == 3;
+    case 16:
+        return col == 6 || col == 7;
+    default:
+        return false;
+    }
+}
+
 #endif // _BOARD_KEYMAP_H

--- a/src/keyboard/system76/15in_102_nkey/include/board/keymap.h
+++ b/src/keyboard/system76/15in_102_nkey/include/board/keymap.h
@@ -54,4 +54,29 @@
 #define MATRIX_FN_INPUT 0
 #define MATRIX_FN_OUTPUT 4
 
+static inline bool keymap_is_f_key(uint8_t row, uint8_t col) {
+    switch (row) {
+    case 1:
+        return col == 1;
+    case 4:
+        return col == 2;
+    case 6:
+        return col == 2 || col == 3 || col == 4;
+    case 7:
+        return col == 1;
+    case 10:
+        return col == 2;
+    case 11:
+        return col == 2 || col == 3;
+    case 12:
+        return col == 0;
+    case 13:
+        return col == 3;
+    case 15:
+        return col == 1;
+    default:
+        return false;
+    }
+}
+
 #endif // _BOARD_KEYMAP_H

--- a/src/keyboard/system76/18H9LHA04/include/board/keymap.h
+++ b/src/keyboard/system76/18H9LHA04/include/board/keymap.h
@@ -60,4 +60,25 @@
 #define MATRIX_FN_INPUT 3
 #define MATRIX_FN_OUTPUT 17
 
+static inline bool keymap_is_f_key(uint8_t row, uint8_t col) {
+    switch (row) {
+    case 8:
+        return col == 5 || col == 7;
+    case 9:
+        return col == 3;
+    case 10:
+        return col == 5 || col == 6;
+    case 12:
+        return col == 5;
+    case 13:
+        return col == 3 || col == 7;
+    case 14:
+        return col == 1 || col == 3;
+    case 16:
+        return col == 6 || col == 7;
+    default:
+        return false;
+    }
+}
+
 #endif // _BOARD_KEYMAP_H

--- a/src/keyboard/system76/18H9LHA05/include/board/keymap.h
+++ b/src/keyboard/system76/18H9LHA05/include/board/keymap.h
@@ -60,4 +60,25 @@
 #define MATRIX_FN_INPUT 3
 #define MATRIX_FN_OUTPUT 17
 
+static inline bool keymap_is_f_key(uint8_t row, uint8_t col) {
+    switch (row) {
+    case 8:
+        return col == 5 || col == 7;
+    case 9:
+        return col == 3;
+    case 10:
+        return col == 5 || col == 6;
+    case 12:
+        return col == 5;
+    case 13:
+        return col == 3 || col == 7;
+    case 14:
+        return col == 1 || col == 3;
+    case 16:
+        return col == 6 || col == 7;
+    default:
+        return false;
+    }
+}
+
 #endif // _BOARD_KEYMAP_H


### PR DESCRIPTION
Implement a FnLock toggle and a custom key for it.

- When disabled, `F1`-`F12` behave normally
- When enabled, `F1`-`F12` behave as the alternate function

Set it to `Fn+Esc` by default.

NOTE: Holding `Fn+Esc` at power on (S5 to S0) is used for resetting the EC configs. After S0, `Fn+Esc` will only act as FnLock.

NOTE: System76 laptops do not have an indicator for FnLock state.

Resolves: system76/firmware-open#78
