### PR TITLE
arch/8051: Use Timer 2 for global tick

### DIFF
--- a/src/arch/8051/time.c
+++ b/src/arch/8051/time.c
@@ -1,41 +1,41 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-// Uses timer 0 to keep track of global time
-
-#include <8051.h>
+// Use Timer 2 to keep track of global time.
 
 #include <arch/time.h>
 
+#include <8052.h>
+
+// Pre-calculated value for a ~1ms interrupt using a 9.2 MHz crystal.
+//   0x10000 - (INTERVAL * ((OSC_FREQ / 1000) / OSC_DIVISOR))
+#define TIMER2_RELOAD 0xFD01
+
 static volatile uint32_t time_overflows = 0;
 
-void timer_0(void) __interrupt(1) {
-    // Stop timer
-    TR0 = 0;
+void timer_2(void) __interrupt(5) {
+    // Hardware automatically reloads the RCAP2 value.
+    // Software must explicitly clear the interrupt.
+    TF2 = 0;
 
     time_overflows++;
-
-    // Start timer
-    TH0 = 0xFD;
-    TL0 = 0x01;
-    TR0 = 1;
 }
 
 void time_init(void) __critical {
-    // Stop the timer
-    TR0 = 0;
-    TF0 = 0;
-
     time_overflows = 0;
 
-    // Enable timer interrupts
-    ET0 = 1;
+    // Timer 2 defaults to 16-bit auto-reload
 
-    // Start timer in mode 1
-    // (65536 - 64769) / (9.2 MHz / 12) = ~1 ms interval
-    TMOD = (TMOD & 0xF0) | 0x01;
-    TH0 = 0xFD;
-    TL0 = 0x01;
-    TR0 = 1;
+    // Set the initial values
+    TH2 = TIMER2_RELOAD >> 8;
+    TL2 = TIMER2_RELOAD & 0xFF;
+    // Set the values to reload on overflow
+    RCAP2H = TIMER2_RELOAD >> 8;
+    RCAP2L = TIMER2_RELOAD & 0xFF;
+
+    // Enable timer interrupts
+    ET2 = 1;
+    // Start the timer
+    TR2 = 1;
 }
 
 uint32_t time_get(void) __critical {

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -35,12 +35,12 @@
 #endif // PARALLEL_DEBUG
 
 void external_0(void) __interrupt(0) {}
-// timer_0 is in time.c
-void timer_0(void) __interrupt(1);
+void timer_0(void) __interrupt(1) {}
 void external_1(void) __interrupt(2) {}
 void timer_1(void) __interrupt(3) {}
 void serial(void) __interrupt(4) {}
-void timer_2(void) __interrupt(5) {}
+// timer_2 is in time.c
+void timer_2(void) __interrupt(5);
 
 uint8_t main_cycle = 0;
 const uint16_t battery_interval = 1000;


### PR DESCRIPTION
The ECs support Timer 2 from the 8052, which has a 16-bit auto-reload
mode. Use it to offload resetting the timer to hardware instead of doing
it in the interrupt.
