### PR TITLE
readme: Add datasheet info

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,9 @@ Public License, version 3. See [LICENSE](./LICENSE) for details.
 - ecsim: MIT
 - ectool: MIT
 
-Datasheets for ITE embedded controllers cannot be shared outside of System76.
+Datasheets for the ITE embedded controllers used in System76 laptops cannot be
+shared outside of company. (However, the IT81202E datasheet is [publicly
+available][it81202e]. While it uses a different core, a significant portion of
+the register information is the same as IT85878E/IT5570E.)
+
+[it81202e]: https://www.ite.com.tw/en/product/view?mid=149


### PR DESCRIPTION
The IT81202E, despite using a different core, contains sufficiently
equivalent documentation to IT8587E and IT5570E for most tasks except
interrupt management. Provide it as a reference since we cannot share
the datasheets for the models we use.