### PR TITLE
Add target to generate LVFS MetaInfo and cab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,5 @@ trim_trailing_whitespace = false
 [{Makefile,*.mk}]
 indent_style = tab
 
-[*.yml]
+[*.{xml,xml.in,yml}]
 indent_size = 2

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,24 @@ INCLUDE+=$(wildcard $(ARCH_DIR)/include/arch/*.h) $(ARCH_DIR)/arch.mk
 CFLAGS+=-I$(ARCH_DIR)/include -D__ARCH__=$(ARCH)
 include $(ARCH_DIR)/arch.mk
 
+.PHONY: $(BUILD)/firmware.metainfo.xml
+$(BUILD)/firmware.metainfo.xml: firmware.metainfo.xml.in
+	LVFS_VENDOR_NAME=$(LVFS_VENDOR_NAME) \
+	LVFS_VENDOR_HOMEPAGE=$(LVFS_VENDOR_HOMEPAGE) \
+	LVFS_DEVICE_ID=$(LVFS_DEVICE_ID) \
+	LVFS_DEVICE_NAME=$(LVFS_DEVICE_NAME) \
+	LVFS_DEVICE_UUID=$(LVFS_DEVICE_UUID) \
+	LVFS_RELEASE_VERSION=$(VERSION) \
+	LVFS_RELEASE_DATE=$(DATE) \
+	./scripts/lvfs.sh $< > $@
+
+.PHONY: $(BUILD)/firmware.cab
+$(BUILD)/firmware.cab: $(BUILD)/ec.rom $(BUILD)/firmware.metainfo.xml
+	gcab --verbose --create --nopath $@ $^
+
+.PHONY: lvfs
+lvfs: $(BUILD)/firmware.cab
+
 # The architecture defines build targets, no more is required
 endif
 

--- a/firmware.metainfo.xml.in
+++ b/firmware.metainfo.xml.in
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="firmware">
+  <id>${LVFS_DEVICE_ID}</id>
+  <name>${LVFS_DEVICE_NAME}</name>
+  <summary>${LVFS_VENDOR_NAME} ${LVFS_DEVICE_NAME} Embedded Controller Firmware</summary>
+  <description>
+    <p>Embedded controller firmware for the ${LVFS_DEVICE_NAME}.</p>
+  </description>
+  <provides>
+    <firmware type="flashed">${LVFS_DEVICE_UUID}</firmware>
+  </provides>
+  <url type="homepage">${LVFS_VENDOR_HOMEPAGE}</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+
+  <releases>
+    <release version="${LVFS_RELEASE_VERSION}" date="${LVFS_RELEASE_DATE}">
+      <checksum filename="ec.rom" target="content" />
+      <url type="source">${LVFS_RELEASE_SOURCE_URL}</url>
+      <description>
+        ${LVFS_RELEASE_DESCRIPTION}
+      </description>
+    </release>
+  </releases>
+
+  <requires>
+    <id compare="ge" version="1.6.2">org.freedesktop.fwupd</id>
+  </requires>
+  <categories>
+    <category>X-EmbeddedController</category>
+  </categories>
+  <custom>
+    <value key="LVFS::UpdateProtocol">org.uefi.capsule</value>
+    <value key="LVFS::VersionFormat">plain</value>
+  </custom>
+</component>

--- a/scripts/lvfs.sh
+++ b/scripts/lvfs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Generate LVFS MetaInfo from a template file.
+
+warn() {
+    echo -e "\x1B[33m$*\x1B[0m" >&2
+}
+
+error() {
+    echo -e "\x1B[31m$*\x1B[0m" >&2
+}
+
+TEMPLATE=$1
+if [[ -z "$TEMPLATE" ]]; then
+    echo "$0: <template>" >&2
+    exit 1
+fi
+
+export LVFS_VENDOR_NAME="${LVFS_VENDOR_NAME:-System76}"
+export LVFS_VENDOR_HOMEPAGE="${LVFS_VENDOR_HOMEPAGE:-https://system76.com/}"
+
+invalid=0
+if [[ -z "$LVFS_DEVICE_ID" ]]; then
+    warn "LVFS_DEVICE_ID is not set"
+    invalid=1
+fi
+if [[ -z "$LVFS_DEVICE_NAME" ]]; then
+    warn "LVFS_DEVICE_NAME is not set"
+    invalid=1
+fi
+if [[ -z "$LVFS_DEVICE_UUID" ]]; then
+    warn "LVFS_DEVICE_UUID is not set"
+    invalid=1
+fi
+
+GIT_COMMIT_HASH=$(git describe --always --abbrev=12 --exclude='*')
+GIT_COMMIT_URL="https://github.com/system76/ec/tree/${GIT_COMMIT_HASH}"
+
+GIT_COMMIT_RELEASE=$(git describe --always --dirty --abbrev=7 --exclude='*')
+GIT_COMMIT_DATE=$(git show --format="%cd" --date="format:%Y-%m-%d" --no-patch)
+EC_VERSION="${GIT_COMMIT_DATE}_${GIT_COMMIT_RELEASE}"
+
+export LVFS_RELEASE_VERSION="${LVFS_RELEASE_VERSION:-${EC_VERSION}}"
+export LVFS_RELEASE_DATE="${LVFS_RELEASE_DATE:-${GIT_COMMIT_DATE}}"
+export LVFS_RELEASE_SOURCE_URL="${LVFS_RELEASE_SOURCE_URL:-${GIT_COMMIT_URL}}"
+
+if [[ -z "$LVFS_RELEASE_DESCRIPTION" ]]; then
+    warn "LVFS_RELEASE_DESCRIPTION is not set"
+    invalid=1
+fi
+
+if [[ "$invalid" = "1" ]]; then
+    error "Errors detected, not generating MetaInfo"
+    exit 1
+fi
+
+envsubst < "$TEMPLATE"

--- a/src/board/system76/addw1/board.mk
+++ b/src/board/system76/addw1/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.addw1.ec.firmware
+LVFS_DEVICE_NAME = "Adder Workstation 1"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it8587e
 

--- a/src/board/system76/addw2/board.mk
+++ b/src/board/system76/addw2/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.addw2.ec.firmware
+LVFS_DEVICE_NAME = "Adder Workstation 2"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/bonw14/board.mk
+++ b/src/board/system76/bonw14/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.bonw14.ec.firmware
+LVFS_DEVICE_NAME = "Bonobo Workstation 14"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_VENDOR_NAME = System76
+LVFS_VENDOR_HOMEPAGE = https://system76.com/
+
 # Set log level
 # 0 - NONE
 # 1 - ERROR

--- a/src/board/system76/darp5/board.mk
+++ b/src/board/system76/darp5/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.darp5.ec.firmware
+LVFS_DEVICE_NAME = "Darter Pro 5"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it8587e
 

--- a/src/board/system76/darp7/board.mk
+++ b/src/board/system76/darp7/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.darp7.ec.firmware
+LVFS_DEVICE_NAME = "Darter Pro 7"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/darp8/board.mk
+++ b/src/board/system76/darp8/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.darp8.ec.firmware
+LVFS_DEVICE_NAME = "Darter Pro 8"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/galp3-c/board.mk
+++ b/src/board/system76/galp3-c/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.galp3-c.ec.firmware
+LVFS_DEVICE_NAME = "Galago Pro 3"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it8587e
 

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.galp5.ec.firmware
+LVFS_DEVICE_NAME = "Galago Pro 5"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/gaze15/board.mk
+++ b/src/board/system76/gaze15/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.gaze15.ec.firmware
+LVFS_DEVICE_NAME = "Gazelle 15"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/gaze16-3050/board.mk
+++ b/src/board/system76/gaze16-3050/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.gaze16-3050.ec.firmware
+LVFS_DEVICE_NAME = "Gazelle 16"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/gaze16-3060/board.mk
+++ b/src/board/system76/gaze16-3060/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.gaze16-3060.ec.firmware
+LVFS_DEVICE_NAME = "Gazelle 16"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/gaze17-3050/board.mk
+++ b/src/board/system76/gaze17-3050/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.gaze17-3050.ec.firmware
+LVFS_DEVICE_NAME = "Gazelle 17"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/gaze17-3060/board.mk
+++ b/src/board/system76/gaze17-3060/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.gaze17-3060.ec.firmware
+LVFS_DEVICE_NAME = "Gazelle 17"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/lemp10/board.mk
+++ b/src/board/system76/lemp10/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.lemp10.ec.firmware
+LVFS_DEVICE_NAME = "Lemur Pro 10"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/lemp11/board.mk
+++ b/src/board/system76/lemp11/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.lemp11.ec.firmware
+LVFS_DEVICE_NAME = "Lemur Pro 11"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/lemp9/board.mk
+++ b/src/board/system76/lemp9/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.lemp9.ec.firmware
+LVFS_DEVICE_NAME = "Lemur Pro 9"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/oryp5/board.mk
+++ b/src/board/system76/oryp5/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.oryp5.ec.firmware
+LVFS_DEVICE_NAME = "Oryx Pro 5"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it8587e
 

--- a/src/board/system76/oryp6/board.mk
+++ b/src/board/system76/oryp6/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.oryp6.ec.firmware
+LVFS_DEVICE_NAME = "Oryx Pro 6"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/oryp7/board.mk
+++ b/src/board/system76/oryp7/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.oryp7.ec.firmware
+LVFS_DEVICE_NAME = "Oryx Pro 7"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/oryp8/board.mk
+++ b/src/board/system76/oryp8/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.oryp8.ec.firmware
+LVFS_DEVICE_NAME = "Oryx Pro 8"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 

--- a/src/board/system76/oryp9/board.mk
+++ b/src/board/system76/oryp9/board.mk
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+LVFS_DEVICE_ID = com.system76.oryp9.ec.firmware
+LVFS_DEVICE_NAME = "Oryx Pro 9"
+# TODO
+LVFS_DEVICE_UUID = "00000000-0000-0000-0000-000000000000"
+
 EC=ite
 EC_VARIANT=it5570e
 


### PR DESCRIPTION
Add a new target to generate LVFS MetaInfo and a Microsoft cabinet.

Not actually usable, since we currently ship EC updates as part of a monolithic system update, have no ESRT to advertise the device, have no FMP driver to handle UEFI capsule updates, and probably need to modify fwupd regardless.

Ref: system76/firmware-open#225

### TODO

- [ ] Generate/get UUID for all devices
- [ ] Handle the models that use symlinks (darp6, galp4, gaze16-3060-b)