### PR TITLE
Fix OZ26786 AdapterCurrent() values

### DIFF
--- a/doc/adding-a-new-board.md
+++ b/doc/adding-a-new-board.md
@@ -2,33 +2,40 @@
 
 ## Charger parameters
 
-- `CHARGER_CHARGE_CURRENT`: Currently the same for all boards (1536).
+- `CHARGER_CHARGE_CURRENT`: Currently the same for all boards (3A).
 - `CHARGER_CHARGE_VOLTAGE`: On the battery, look for 充电限制电压 (charge limit
   voltage). Convert this from volts to millivolts.
 - `CHARGER_INPUT_CURRENT`: On the charger, look for DC output. Convert the
   current from amps to milliamps.
 
+These values need to be adjusted based on the values of the sense resistors
+(PRS1, PRS2) and how the charger interprets the value.
+
 #### Example
 
-The gaze15 battery has
+The gaze15 battery has:
 
 ```
 充电限制电压: 16.8Vdc
 ```
 
-and its charger has
+Its charger has:
 
 ```
 DC OUTPUT (输出/輸出): 19.5V⎓9.23A 180W
 ```
 
-This gives
+The schematics show it uses a 0.005 ohm sense resistor for both PRS1 and PRS2.
+This means that the charge current and input current must be divided by 2 when
+configuring the smart charger.
+
+This gives:
 
 ```
 CFLAGS+=\
-	-DCHARGER_CHARGE_CURRENT=1536 \
+	-DCHARGER_CHARGE_CURRENT=0x600 \
 	-DCHARGER_CHARGE_VOLTAGE=16800 \
-	-DCHARGER_INPUT_CURRENT=9230
+	-DCHARGER_INPUT_CURRENT=0x1200
 ```
 
 ## GPIOs

--- a/src/board/system76/common/charger/oz26786.c
+++ b/src/board/system76/common/charger/oz26786.c
@@ -17,6 +17,9 @@
     #define CHARGE_OPTION_2_PSYS_EN BIT(11)
 #define REG_ADAPTER_CURRENT 0x3F
 
+// Bits 0-6 are ignored. Bits 12-15 must be 0.
+#define INPUT_CURRENT (CHARGER_INPUT_CURRENT & 0x0FFF)
+
 // XXX: Assumption: ac_last is initialized high.
 static bool charger_enabled = false;
 
@@ -53,7 +56,7 @@ int16_t battery_charger_disable(void) {
 
     // Set input current in mA
     //TODO: needed when charging disabled?
-    res = smbus_write(CHARGER_ADDRESS, REG_ADAPTER_CURRENT, CHARGER_INPUT_CURRENT);
+    res = smbus_write(CHARGER_ADDRESS, REG_ADAPTER_CURRENT, INPUT_CURRENT);
     if (res < 0) return res;
 
     DEBUG("Charger disabled\n");
@@ -94,7 +97,7 @@ int16_t battery_charger_enable(void) {
     if (res < 0) return res;
 
     // Set input current in mA
-    res = smbus_write(CHARGER_ADDRESS, REG_ADAPTER_CURRENT, CHARGER_INPUT_CURRENT);
+    res = smbus_write(CHARGER_ADDRESS, REG_ADAPTER_CURRENT, INPUT_CURRENT);
     if (res < 0) return res;
 
     DEBUG("Charger enabled\n");

--- a/src/board/system76/darp7/board.mk
+++ b/src/board/system76/darp7/board.mk
@@ -18,11 +18,12 @@ CFLAGS+=-DI2C_SMBUS=I2C_4
 CFLAGS+=-DPS2_TOUCHPAD=PS2_3
 
 # Set smart charger parameters
-#TODO: Find out why input current must by divided by two
+# Adapter input current = 3.42A
+# PRS1 = 0.005 ohm. Divide input current by 2.
 CFLAGS+=\
 	-DCHARGER_CHARGE_CURRENT=1536 \
 	-DCHARGER_CHARGE_VOLTAGE=8800 \
-	-DCHARGER_INPUT_CURRENT=1600
+	-DCHARGER_INPUT_CURRENT=0x680
 
 # Add system76 common code
 include src/board/system76/common/common.mk

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -22,12 +22,13 @@ CFLAGS+=-DI2C_SMBUS=I2C_4
 CFLAGS+=-DPS2_TOUCHPAD=PS2_3
 
 # Set smart charger parameters
-#TODO: Find out why input current must by divided by two
+# Adapter input current = 3.42A (Intel variant)
+# PRS1 = 0.010 ohm. Divide input current by 2.
 CHARGER=oz26786
 CFLAGS+=\
 	-DCHARGER_CHARGE_CURRENT=1536 \
 	-DCHARGER_CHARGE_VOLTAGE=17400 \
-	-DCHARGER_INPUT_CURRENT=1600
+	-DCHARGER_INPUT_CURRENT=0x680
 
 # Set CPU power limits in watts
 CFLAGS+=\

--- a/src/board/system76/gaze16-3050/board.mk
+++ b/src/board/system76/gaze16-3050/board.mk
@@ -21,11 +21,13 @@ CFLAGS+=-DI2C_SMBUS=I2C_4
 CFLAGS+=-DPS2_TOUCHPAD=PS2_3
 
 # Set smart charger parameters
+# Adapter input current = 7.7A
+# PRS1 = 0.005 ohm. Divide input current by 4.
 CHARGER=oz26786
 CFLAGS+=\
 	-DCHARGER_CHARGE_CURRENT=1536 \
 	-DCHARGER_CHARGE_VOLTAGE=16800 \
-	-DCHARGER_INPUT_CURRENT=7700
+	-DCHARGER_INPUT_CURRENT=0x780
 
 # Set CPU power limits in watts
 CFLAGS+=\

--- a/src/board/system76/gaze16-3060/board.mk
+++ b/src/board/system76/gaze16-3060/board.mk
@@ -21,11 +21,13 @@ CFLAGS+=-DI2C_SMBUS=I2C_4
 CFLAGS+=-DPS2_TOUCHPAD=PS2_3
 
 # Set smart charger parameters
+# Adapter input current = 9.23A
+# PRS1 = 0.005 ohm. Divide input current by 4.
 CHARGER=oz26786
 CFLAGS+=\
 	-DCHARGER_CHARGE_CURRENT=1536 \
 	-DCHARGER_CHARGE_VOLTAGE=16800 \
-	-DCHARGER_INPUT_CURRENT=9230
+	-DCHARGER_INPUT_CURRENT=0x900
 
 # Set CPU power limits in watts
 CFLAGS+=\

--- a/src/board/system76/lemp10/board.mk
+++ b/src/board/system76/lemp10/board.mk
@@ -19,11 +19,12 @@ CFLAGS+=-DI2C_SMBUS=I2C_4
 CFLAGS+=-DPS2_TOUCHPAD=PS2_3
 
 # Set smart charger parameters
-#TODO: Find out why input current must by divided by two
+# Adapter input current = 3.42A
+# PRS1 = 0.005 ohm. Divide input current by 2.
 CFLAGS+=\
 	-DCHARGER_CHARGE_CURRENT=1536 \
 	-DCHARGER_CHARGE_VOLTAGE=8800 \
-	-DCHARGER_INPUT_CURRENT=1600
+	-DCHARGER_INPUT_CURRENT=0x680
 
 # Add system76 common code
 include src/board/system76/common/common.mk

--- a/src/board/system76/lemp9/board.mk
+++ b/src/board/system76/lemp9/board.mk
@@ -16,11 +16,12 @@ CFLAGS+=-DI2C_SMBUS=I2C_4
 CFLAGS+=-DPS2_TOUCHPAD=PS2_3
 
 # Set smart charger parameters
-#TODO: Find out why input current must by divided by two
+# Adapter input current = 3.42A
+# PRS1 = 0.005 ohm. Divide input current by 2.
 CFLAGS+=\
 	-DCHARGER_CHARGE_CURRENT=1536 \
 	-DCHARGER_CHARGE_VOLTAGE=8800 \
-	-DCHARGER_INPUT_CURRENT=1600
+	-DCHARGER_INPUT_CURRENT=0x680
 
 # Add system76 common code
 include src/board/system76/common/common.mk


### PR DESCRIPTION
The value passed to `AdapterCurrent()` must be adjusted based on the sense resistor used.

- 0.020 ohm sense resistor: Use actual input current
- 0.010 ohm sense resistor: Divide input current by 2
- 0.005 ohm sense resistor: Divide input current by 4

See section "Setting Adapter Current" in the datasheet.

Ref: OZ26786-DS v1.0

---

~I don't know if this is correct for gaze16, since it uses both a 5mΩ (PSR1) and 10mΩ (PRS2) sense resistor in the schematics, and we can never be sure that the schematics are correct.~

PRS1 is for `AdapterCurrent()` and PRS2 is for `ChargeCurrent()`, so this should be correct.

However, if the intention was to allow charging at 3A and not 1.5A, the value for `ChargeCurrent()` will need to be changed as well.