### PR TITLE
battery: Fix value to start/stop charging at

### DIFF
--- a/src/board/system76/common/battery.c
+++ b/src/board/system76/common/battery.c
@@ -58,7 +58,7 @@ int16_t battery_charger_configure(void) {
         // Stop threshold not configured: Always charge on AC.
         should_charge = true;
     }
-    else if (battery_info.charge >= battery_get_end_threshold()) {
+    else if (battery_info.charge > battery_get_end_threshold()) {
         // Stop threshold configured: Stop charging at threshold.
         should_charge = false;
     }
@@ -66,7 +66,7 @@ int16_t battery_charger_configure(void) {
         // Start threshold not configured: Always charge up to stop threshold.
         should_charge = true;
     }
-    else if (battery_info.charge <= battery_get_start_threshold()) {
+    else if (battery_info.charge < battery_get_start_threshold()) {
         // Start threshold configured: Start charging at threshold.
         should_charge = true;
     }


### PR DESCRIPTION
Change the condition, which is currently a level *at* which charging
will start/stop.

Per [sysfs](https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-power), these values are a level:

- *below* which charging will begin
- *above* which charging will stop

### Test

1. Set stop threshold
2. Drain battery ~5% below that value
3. Charge the battery

- Check: Battery shows the user specified value, not 1 below it