### PR TITLE
board/system76/common: use SLP_S0# pin for modern standby detection

### DIFF
--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -123,8 +123,8 @@ uint8_t peci_get_fan_duty(void) {
     uint8_t duty;
 
 #if EC_ESPI
-    // Use PECI if CPU is not in C10 state
-    peci_on = gpio_get(&CPU_C10_GATE_N);
+    // Use PECI if platform is not in CS
+    peci_on = gpio_get(&SLP_S0_N);
 #else // EC_ESPI
     // Use PECI if in S0 state
     peci_on = power_state == POWER_STATE_S0;

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -303,7 +303,7 @@ void power_set_limit(void) {
     static bool last_power_limit_ac = true;
     // We don't use power_state because the latency needs to be low
 #if EC_ESPI
-    if (gpio_get(&CPU_C10_GATE_N)) {
+    if (gpio_get(&SLP_S0_N)) {
 #else
     if (gpio_get(&BUF_PLT_RST_N)) {
 #endif
@@ -537,7 +537,7 @@ void power_event(void) {
     uint32_t time = time_get();
     if (power_state == POWER_STATE_S0) {
 #if EC_ESPI
-        if (!gpio_get(&CPU_C10_GATE_N)) {
+        if (!gpio_get(&SLP_S0_N)) {
             // Modern suspend, flashing green light
             if ((time - last_time) >= 1000) {
                 gpio_set(&LED_PWR, !gpio_get(&LED_PWR));


### PR DESCRIPTION
Previously, CPU_C10_GATE# was used for detecting entry into s0ix /
Modern Standby.

Intel documentation says that SLP_S0# should be used for s0ix detection
instead, and CPU_C10_GATE# is intended for VCCSTG power gating, so
switch the pin to improve s0ix detection reliability.

Fixes https://github.com/system76/firmware-open/issues/199

Tested on Clevo NS51MU, firmware built for `system76/darp7`.

References:

- Intel docs #575570 rev 0.5, #607872 rev 2.2
- Chromium EC: https://chromium.googlesource.com/chromiumos/platform/ec/+/master/power/intel_x86.c#41

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>