### PR TITLE
galp6: Fix USB power

### DIFF
--- a/src/board/system76/galp6/board.c
+++ b/src/board/system76/galp6/board.c
@@ -16,8 +16,6 @@ void board_init(void) {
     // Enable wireless
     gpio_set(&WLAN_EN, true);
     gpio_set(&WLAN_PWR_EN, true);
-    // Enable USB power
-    gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI# and SWI#
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);

--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -72,8 +72,8 @@ void gpio_init(void) {
     GPDRD = BIT(5) | BIT(4);
     // USB_PWR_EN
     GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
+    // H_PECI, PD_EN
+    GPDRF = BIT(6) | BIT(3);
     // H_PROCHOT_EC
     GPDRG = BIT(6);
     GPDRH = 0;
@@ -156,7 +156,7 @@ void gpio_init(void) {
     // USB_PWR_EN# (Actually active high)
     GPCRE3 = GPIO_OUT;
     // DD_ON
-    GPCRE4 = GPIO_OUT;
+    GPCRE4 = GPIO_OUT | GPIO_DOWN;
     // EC_RSMRST#
     GPCRE5 = GPIO_OUT;
     // JACK_IN#_EC
@@ -166,7 +166,7 @@ void gpio_init(void) {
     // 80CLK
     GPCRF0 = GPIO_IN;
     // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
+    GPCRF1 = GPIO_OUT | GPIO_UP;
     // 3IN1
     GPCRF2 = GPIO_IN | GPIO_UP;
     // PD_EN

--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -34,7 +34,6 @@ struct Gpio __code SMI_N =          GPIO(D, 4);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
 struct Gpio __code SWI_N =          GPIO(B, 5);
-struct Gpio __code USB_PWR_EN_N =   GPIO(E, 3);
 struct Gpio __code VA_EC_EN =       GPIO(J, 4);
 struct Gpio __code WLAN_EN =        GPIO(G, 1);
 struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
@@ -71,8 +70,8 @@ void gpio_init(void) {
     GPDRC = BIT(5);
     // PWR_BTN#, SMI#
     GPDRD = BIT(5) | BIT(4);
-    // SMD_BAT, SMC_BAT
-    GPDRE = BIT(7) | BIT(0);
+    // USB_PWR_EN
+    GPDRE = BIT(3);
     // H_PECI
     GPDRF = BIT(6);
     // H_PROCHOT_EC
@@ -154,8 +153,8 @@ void gpio_init(void) {
     GPCRE1 = GPIO_OUT;
     // KB-DET
     GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT | GPIO_UP;
+    // USB_PWR_EN# (Actually active high)
+    GPCRE3 = GPIO_OUT;
     // DD_ON
     GPCRE4 = GPIO_OUT;
     // EC_RSMRST#

--- a/src/board/system76/galp6/include/board/gpio.h
+++ b/src/board/system76/galp6/include/board/gpio.h
@@ -42,7 +42,6 @@ extern struct Gpio __code SUSC_N_PCH;
 #define HAVE_SUSWARN_N 0
 #define HAVE_SUS_PWR_ACK 0
 extern struct Gpio __code SWI_N;
-extern struct Gpio __code USB_PWR_EN_N;
 extern struct Gpio __code VA_EC_EN;
 extern struct Gpio __code WLAN_EN;
 extern struct Gpio __code WLAN_PWR_EN;


### PR DESCRIPTION
The schematics incorrectly show the pin as `USB_PWR_EN#`. There is a comment on the port side clarifying that it is actually active high.

Additionally, `PD_EN` is used instead of `VA_EC_EN` (like every other board) for enabling power to TCP0.