### PR TITLE
galp6: Do not provide power while off

### DIFF
--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -73,6 +73,11 @@
     #define HAVE_VA_EC_EN 1
 #endif
 
+// Only galp6 has this, so disable by default.
+#ifndef HAVE_PD_EN
+    #define HAVE_PD_EN 0
+#endif
+
 #ifndef HAVE_XLP_OUT
     #define HAVE_XLP_OUT 1
 #endif
@@ -184,6 +189,9 @@ void power_on(void) {
     // avoid leakage
     GPIO_SET_DEBUG(VA_EC_EN, true);
 #endif // HAVE_VA_EC_EN
+#if HAVE_PD_EN
+    GPIO_SET_DEBUG(PD_EN, true);
+#endif
     tPCH06;
 
     // Enable VDD5
@@ -267,6 +275,9 @@ void power_off(void) {
     GPIO_SET_DEBUG(DD_ON, false);
     tPCH12;
 
+#if HAVE_PD_EN
+    GPIO_SET_DEBUG(PD_EN, false);
+#endif
 #if HAVE_VA_EC_EN
     // Disable VCCPRIM_* planes
     GPIO_SET_DEBUG(VA_EC_EN, false);

--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -25,6 +25,7 @@ struct Gpio __code LED_PWR =        GPIO(D, 0);
 struct Gpio __code LID_SW_N =       GPIO(B, 1);
 struct Gpio __code PCH_DPWROK_EC =  GPIO(C, 5);
 struct Gpio __code PCH_PWROK_EC =   GPIO(A, 6);
+struct Gpio __code PD_EN =          GPIO(F, 3);
 struct Gpio __code PM_PWROK =       GPIO(C, 6);
 struct Gpio __code PWR_BTN_N =      GPIO(D, 5);
 struct Gpio __code PWR_SW_N =       GPIO(B, 3);
@@ -72,8 +73,8 @@ void gpio_init(void) {
     GPDRD = BIT(5) | BIT(4);
     // USB_PWR_EN
     GPDRE = BIT(3);
-    // H_PECI, PD_EN
-    GPDRF = BIT(6) | BIT(3);
+    // H_PECI
+    GPDRF = BIT(6);
     // H_PROCHOT_EC
     GPDRG = BIT(6);
     GPDRH = 0;

--- a/src/board/system76/galp6/include/board/gpio.h
+++ b/src/board/system76/galp6/include/board/gpio.h
@@ -30,6 +30,8 @@ extern struct Gpio __code LED_PWR;
 extern struct Gpio __code LID_SW_N;
 extern struct Gpio __code PCH_DPWROK_EC;
 extern struct Gpio __code PCH_PWROK_EC;
+#define HAVE_PD_EN 1
+extern struct Gpio __code PD_EN;
 extern struct Gpio __code PM_PWROK;
 extern struct Gpio __code PWR_BTN_N;
 extern struct Gpio __code PWR_SW_N;


### PR DESCRIPTION
The previous commit incorrectly enabled power while off. Model `PD_EN` after `VA_EC_EN`, which it replaced on galp6 for TCP0.

Fixes: a6a6c5fba4fb ("galp6: Fix TCP0 power")

### Test

Power off and unplug the unit.

- Before change
  - Power LED blinks orange, indicating CPU is powered
  - Battery is drained over night
- After change
  - Power LED remains off
  - Battery is at the same capacity as before (probably <2% difference, due to powering off/on)