### PR TITLE
Add config for using S0ix and fix detection

### DIFF
--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -127,8 +127,8 @@ uint8_t peci_get_fan_duty(void) {
     uint8_t duty;
 
 #if USE_S0IX
-    // Use PECI if CPU is not in C10 state
-    peci_on = gpio_get(&CPU_C10_GATE_N);
+    // Use PECI if platform is not in CS
+    peci_on = gpio_get(&SLP_S0_N);
 #else // USE_S0IX
     // Use PECI if in S0 state
     peci_on = power_state == POWER_STATE_S0;

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -10,6 +10,10 @@
 #include <ec/gpio.h>
 #include <ec/pwm.h>
 
+#ifndef USE_S0IX
+    #define USE_S0IX 0
+#endif
+
 // Fan speed is the lowest requested over HEATUP seconds
 #ifndef BOARD_HEATUP
     #define BOARD_HEATUP 4
@@ -122,13 +126,13 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
 uint8_t peci_get_fan_duty(void) {
     uint8_t duty;
 
-#if EC_ESPI
+#if USE_S0IX
     // Use PECI if CPU is not in C10 state
     peci_on = gpio_get(&CPU_C10_GATE_N);
-#else // EC_ESPI
+#else // USE_S0IX
     // Use PECI if in S0 state
     peci_on = power_state == POWER_STATE_S0;
-#endif // EC_ESPI
+#endif // USE_S0IX
 
     if (peci_on) {
         // Wait for completion

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -21,6 +21,10 @@
     #include <board/espi.h>
 #endif
 
+#ifndef USE_S0IX
+    #define USE_S0IX 0
+#endif
+
 #define GPIO_SET_DEBUG(G, V) { \
     DEBUG("%s = %s\n", #G, V ? "true" : "false"); \
     gpio_set(&G, V); \
@@ -313,7 +317,7 @@ static bool power_peci_limit(bool ac) {
 void power_set_limit(void) {
     static bool last_power_limit_ac = true;
     // We don't use power_state because the latency needs to be low
-#if EC_ESPI
+#if USE_S0IX
     if (gpio_get(&CPU_C10_GATE_N)) {
 #else
     if (gpio_get(&BUF_PLT_RST_N)) {
@@ -547,7 +551,7 @@ void power_event(void) {
     static uint32_t last_time = 0;
     uint32_t time = time_get();
     if (power_state == POWER_STATE_S0) {
-#if EC_ESPI
+#if USE_S0IX
         if (!gpio_get(&CPU_C10_GATE_N)) {
             // Modern suspend, flashing green light
             if ((time - last_time) >= 1000) {

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -318,7 +318,7 @@ void power_set_limit(void) {
     static bool last_power_limit_ac = true;
     // We don't use power_state because the latency needs to be low
 #if USE_S0IX
-    if (gpio_get(&CPU_C10_GATE_N)) {
+    if (gpio_get(&SLP_S0_N)) {
 #else
     if (gpio_get(&BUF_PLT_RST_N)) {
 #endif
@@ -552,7 +552,7 @@ void power_event(void) {
     uint32_t time = time_get();
     if (power_state == POWER_STATE_S0) {
 #if USE_S0IX
-        if (!gpio_get(&CPU_C10_GATE_N)) {
+        if (!gpio_get(&SLP_S0_N)) {
             // Modern suspend, flashing green light
             if ((time - last_time) >= 1000) {
                 gpio_set(&LED_PWR, !gpio_get(&LED_PWR));

--- a/src/board/system76/darp7/board.mk
+++ b/src/board/system76/darp7/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Use S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=15in_102
 

--- a/src/board/system76/darp8/board.mk
+++ b/src/board/system76/darp8/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Use S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=15in_102
 

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Use S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=14in_83
 

--- a/src/board/system76/galp6/board.mk
+++ b/src/board/system76/galp6/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Use S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=14in_83
 

--- a/src/board/system76/gaze17-3050/board.mk
+++ b/src/board/system76/gaze17-3050/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# FIXME: Use S3 instead of S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=15in_102
 

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -25,6 +25,7 @@ struct Gpio __code PCH_DPWROK_EC =  GPIO(H, 4);
 struct Gpio __code PCH_PWROK_EC =   GPIO(F, 3);
 struct Gpio __code PWR_BTN_N =      GPIO(D, 5);
 struct Gpio __code PWR_SW_N =       GPIO(B, 3);
+struct Gpio __code SLP_S0_N =       GPIO(C, 6); // XXX: Really CPU_C10_GATE#
 struct Gpio __code SLP_SUS_N =      GPIO(J, 4);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);

--- a/src/board/system76/gaze17-3050/include/board/gpio.h
+++ b/src/board/system76/gaze17-3050/include/board/gpio.h
@@ -32,6 +32,7 @@ extern struct Gpio __code PCH_PWROK_EC;
 #define HAVE_PM_PWROK 0
 extern struct Gpio __code PWR_BTN_N;
 extern struct Gpio __code PWR_SW_N;
+extern struct Gpio __code SLP_S0_N;
 extern struct Gpio __code SLP_SUS_N;
 #define HAVE_SUS_PWR_ACK 0
 extern struct Gpio __code SUSB_N_PCH;

--- a/src/board/system76/gaze17-3060/board.mk
+++ b/src/board/system76/gaze17-3060/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# FIXME: Use S3 instead of S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=15in_102
 

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -25,6 +25,7 @@ struct Gpio __code PCH_DPWROK_EC =  GPIO(F, 3);
 struct Gpio __code PCH_PWROK_EC =   GPIO(C, 6);
 struct Gpio __code PWR_BTN_N =      GPIO(D, 5);
 struct Gpio __code PWR_SW_N =       GPIO(B, 3);
+struct Gpio __code SLP_S0_N =       GPIO(J, 2); // XXX: Really CPU_C10_GATE#
 struct Gpio __code SLP_SUS_N =      GPIO(J, 7);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);

--- a/src/board/system76/gaze17-3060/include/board/gpio.h
+++ b/src/board/system76/gaze17-3060/include/board/gpio.h
@@ -32,6 +32,7 @@ extern struct Gpio __code PCH_PWROK_EC;
 #define HAVE_PM_PWROK 0
 extern struct Gpio __code PWR_BTN_N;
 extern struct Gpio __code PWR_SW_N;
+extern struct Gpio __code SLP_S0_N;
 extern struct Gpio __code SLP_SUS_N;
 #define HAVE_SUS_PWR_ACK 0
 extern struct Gpio __code SUSB_N_PCH;

--- a/src/board/system76/lemp10/board.mk
+++ b/src/board/system76/lemp10/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Use S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=14in_83
 

--- a/src/board/system76/lemp11/board.mk
+++ b/src/board/system76/lemp11/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# Use S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=14in_83
 

--- a/src/board/system76/oryp9/board.mk
+++ b/src/board/system76/oryp9/board.mk
@@ -5,6 +5,9 @@ EC=it5570e
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
 
+# FIXME: Use S3 instead of S0ix
+CFLAGS+=-DUSE_S0IX=1
+
 # Include keyboard
 KEYBOARD=15in_102
 


### PR DESCRIPTION
S0ix does not require eSPI, and eSPI does not mandate S0ix.

Enable S0ix for:

- darp7 (TGL-U)
- darp8 (ADL-P)
- galp5 (TGL-U)
- galp6 (ADL-P)
- lemp10 (TGL-U)
- lemp11 (ADL-U)

It is also currently enabled on ADL-H due to a bug with S3:

- gaze17-3050
- gaze17-3060-b
- oryp9