### PR TITLE
src/board/clevo/ns50mu: add board as symlink to darp7

### DIFF
--- a/src/board/clevo/ns50mu
+++ b/src/board/clevo/ns50mu
@@ -1,0 +1,1 @@
+../system76/darp7


### PR DESCRIPTION
Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>