### PR TITLE
Docs: update models that use 0.5mm pitch FPC cable

### DIFF
--- a/doc/mega2560.md
+++ b/doc/mega2560.md
@@ -18,7 +18,7 @@ it uses the ATmega16U2, find a different model.
 A flexible printed circuit (FPC) breakout board is required. It should have:
 
 - 24 pins with 0.1" (2.54mm) pitch
-- One side with 0.5mm pitch FPC connector (for the Lemur Pro)
+- One side with 0.5mm pitch FPC connector (for lemp9, lemp10, lemp11, galp5, and galp6)
 - One side with 1.0mm pitch FPC connector (for all other models)
 
 Depending on the vendor, the connectors may not come soldered to the board (or


### PR DESCRIPTION
Having this list that we have to keep updated probably isn't ideal, but I figured I might as well update it now than I'm thinking about it.