### PR TITLE
pwm: Reload counters when they reach 0

### DIFF
--- a/src/board/system76/common/pwm.c
+++ b/src/board/system76/common/pwm.c
@@ -26,6 +26,11 @@ void pwm_init(void) {
     // Turn off CPU fan (temperature control in peci_get_fan_duty)
     DCR2 = 0;
 
+#ifdef it5570e
+    // Reload counters when they reach 0 instead of immediately
+    PWMLCCR = 0xFF;
+#endif
+
     // Enable PWM
     ZTIER = BIT(1);
 }

--- a/src/ec/ite/include/ec/pwm.h
+++ b/src/ec/ite/include/ec/pwm.h
@@ -62,4 +62,9 @@ volatile uint8_t __xdata __at(0x1823) ZTIER;
 // Tachometer switch control register
 volatile uint8_t __xdata __at(0x1848) TSWCTLR;
 
+#ifdef it5570e
+// PWM Load Counter Control Register
+volatile uint8_t __xdata __at(0x185A) PWMLCCR;
+#endif
+
 #endif // _EC_PWM_H


### PR DESCRIPTION
Add IT5570E register that controls when the down counters are updated. Set them to update when they reach 0, instead of immediately when DCRi is written.

Fixes keyboard color changing when changing brightness levels if not using 0xFF for an RGB value.

Fixes: #174