### PR TITLE
HACK: pmc: Add hack to force S0ix entry on lemp11

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -19,6 +19,8 @@ extern uint8_t sci_extra;
 
 enum EcOs acpi_ecos = EC_OS_NONE;
 
+extern bool pmc_s0_hack;
+
 static uint8_t fcmd = 0;
 static uint8_t fdat = 0;
 static uint8_t fbuf[4] = { 0, 0, 0, 0 };
@@ -130,7 +132,11 @@ uint8_t acpi_read(uint8_t addr) {
 
         ACPI_16(0x42, battery_info.cycle_count);
 
-        ACPI_8(0x68, acpi_ecos);
+        case 0x68:
+            data = acpi_ecos;
+            // HACK: Kick PMC to fix suspend on lemp11
+            pmc_s0_hack = true;
+            break;
 
         case 0xBC:
             data = battery_get_start_threshold();

--- a/src/board/system76/lemp11/board.mk
+++ b/src/board/system76/lemp11/board.mk
@@ -7,6 +7,8 @@ CFLAGS+=-DEC_ESPI=1
 
 # Use S0ix
 CFLAGS+=-DUSE_S0IX=1
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=14in_83


### PR DESCRIPTION
lemp11 sometimes fails to reach C10 and gets stuck in C0 during s2idle. For some reason, sending a PMC SCI allows the CPU to go to C10.

Requires: system76/coreboot#142