### PR TITLE
Allow ACPI to set fan speeds

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -3,6 +3,7 @@
 #include <board/acpi.h>
 #include <board/battery.h>
 #include <board/dgpu.h>
+#include <board/fan.h>
 #include <board/gpio.h>
 #include <board/kbled.h>
 #include <board/lid.h>
@@ -65,6 +66,14 @@ void fcommand(void) {
             break;
         }
         break;
+    case 0xCE:
+        acpi_peci_fan_duty = fbuf[0];
+        break;
+#if HAVE_DGPU
+    case 0xCF:
+        acpi_dgpu_fan_duty = fbuf[0];
+        break;
+#endif
     }
 }
 

--- a/src/board/system76/common/include/board/fan.h
+++ b/src/board/system76/common/include/board/fan.h
@@ -46,6 +46,8 @@ struct Fan {
     bool interpolate;
 };
 
+extern uint8_t acpi_dgpu_fan_duty;
+extern uint8_t acpi_peci_fan_duty;
 extern bool fan_max;
 
 void fan_reset(void);


### PR DESCRIPTION
- Relays ACPI writes to ACPI fan variables
- Fan speeds will be a smoothed maximum of what EC would set and what ACPI has requested.
- Needs testing, ACPI requested speeds that differ when multiple fans present may override the EC fan syncing, which should be okay. If userspace wants control, allow them to control the fan speeds independently.

Futher discussion/consideration should be had on:
- Should EC set fan speed floors or not spin fans at all? I currently have EC set floors.
- Should EC be responsible for smoothing fan speeds when ACPI values are used? I currently have EC smoothing always, but this yields poor `pwmconfig` detection. [A PR exists for not smoothing ACPI values here](https://github.com/curiousercreative/ec/pull/2)
- Depending on the above, we should revisit the existing fan curves and perhaps make them far more conservative and push any fan speed "performance" concerns to userspace.

Relates to:
- https://github.com/system76/coreboot/pull/143
- https://github.com/pop-os/system76-acpi-dkms/pull/18