### PR TITLE
Replace makebin with objcopy

### DIFF
--- a/src/arch/8051/arch.mk
+++ b/src/arch/8051/arch.mk
@@ -14,7 +14,7 @@ sim: $(BUILD)/ec.rom
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
 	@mkdir -p $(@D)
-	makebin -s $(CODE_SIZE) -p < $< > $@
+	objcopy -I ihex -O binary --gap-fill=0xFF $< $@
 
 # Link object files into Intel Hex file
 $(BUILD)/ec.ihx: $(OBJ)

--- a/src/arch/avr/arch.mk
+++ b/src/arch/avr/arch.mk
@@ -2,6 +2,7 @@
 
 CC=avr-gcc -mmcu=$(EC_VARIANT)
 CFLAGS+=-Os -fstack-usage -Wall -Werror -Wl,--gc-sections -Wl,-u,vfprintf -lprintf_flt
+OBJCOPY = avr-objcopy
 OBJ=$(sort $(patsubst src/%.c,$(BUILD)/%.o,$(SRC)))
 
 # Run EC rom in simulator
@@ -11,12 +12,12 @@ sim: $(BUILD)/ec.elf
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
 	@mkdir -p $(@D)
-	makebin -p < $< > $@
+	$(OBJCOPY) -I ihex -O binary --gap-fill 0xFF $< $@
 
 # Convert from ELF file to Intel Hex file
 $(BUILD)/ec.ihx: $(BUILD)/ec.elf
 	@mkdir -p $(@D)
-	avr-objcopy -j .text -j .data -O ihex $< $@
+	$(OBJCOPY) -j .text -j .data -O ihex $< $@
 
 # Link object files into ELF file
 $(BUILD)/ec.elf: $(OBJ)

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -31,12 +31,12 @@ FLASH_CC=\
 # Convert from binary file to C header
 $(BUILD)/include/flash.h: $(FLASH_BUILD)/flash.rom
 	@mkdir -p $(@D)
-	xxd -s $(FLASH_OFFSET) --include < $< > $@
+	xxd -include < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(FLASH_BUILD)/flash.rom: $(FLASH_BUILD)/flash.ihx
 	@mkdir -p $(@D)
-	makebin -p < $< > $@
+	objcopy -I ihex -O binary $< $@
 
 # Link object files into Intel Hex file
 $(FLASH_BUILD)/flash.ihx: $(FLASH_OBJ)

--- a/src/board/system76/common/scratch/scratch.mk
+++ b/src/board/system76/common/scratch/scratch.mk
@@ -32,12 +32,12 @@ SCRATCH_CC=\
 # Convert from binary file to C header
 $(BUILD)/include/scratch.h: $(SCRATCH_BUILD)/scratch.rom
 	@mkdir -p $(@D)
-	xxd -s $(SCRATCH_OFFSET) --include < $< > $@
+	xxd -include < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(SCRATCH_BUILD)/scratch.rom: $(SCRATCH_BUILD)/scratch.ihx
 	@mkdir -p $(@D)
-	makebin -p < $< > $@
+	objcopy -I ihex -O binary $< $@
 
 # Link object files into Intel Hex file
 $(SCRATCH_BUILD)/scratch.ihx: $(SCRATCH_OBJ)


### PR DESCRIPTION
Replace custom SDCC tool with the more standard binutils tool.

`scratch.rom` and `flash.rom` are different (no unnecessary padding), but resulting `ec.rom` is the same.