### PR TITLE
Add other launch keyboards

### DIFF
--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -402,7 +402,13 @@ fn main() {
                         #[allow(clippy::single_match)]
                         match (info.vendor_id(), info.product_id(), info.interface_number()) {
                             // System76 launch_1
-                            (0x3384, 0x0001, 1) => {
+                            (0x3384, 0x0001, 1) |
+                            // System76 launch_lite_1
+                            (0x3384, 0x0005, 1) |
+                            // System76 launch_2
+                            (0x3384, 0x0006, 1) |
+                            // System76 launch_heavy_1
+                            (0x3384, 0x0007, 1) => {
                                 let device = info.open_device(&api)?;
                                 let access = AccessHid::new(device, 10, 100)?;
                                 return Ok(Ec::new(access)?.into_dyn());


### PR DESCRIPTION
Adds newer launch versions to ec tool.

`sudo ./system76_ectool --access hid info` used to only work launch_1. This should now work with all current lanuch products.

Can be tested by plugging in each launch and running the above command, and/or
```bash
cargo build --release
sudo ./target/debug/system76_ectool --access hid led_mode 0 10 110
sudo ./target/debug/system76_ectool --access hid led_save
```
then plug and replug keyboard. LEDs should have saved.