### PR TITLE
Apply hack for S0ix to all ADL boards

### DIFF
--- a/src/board/system76/darp8/board.mk
+++ b/src/board/system76/darp8/board.mk
@@ -5,6 +5,8 @@ EC_VARIANT=it5570e
 
 # Enable eSPI
 CFLAGS+=-DEC_ESPI=1
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Use S0ix
 CFLAGS+=-DUSE_S0IX=1

--- a/src/board/system76/galp6/board.mk
+++ b/src/board/system76/galp6/board.mk
@@ -8,6 +8,8 @@ CFLAGS+=-DEC_ESPI=1
 
 # Use S0ix
 CFLAGS+=-DUSE_S0IX=1
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=14in_83

--- a/src/board/system76/gaze17-3050/board.mk
+++ b/src/board/system76/gaze17-3050/board.mk
@@ -8,6 +8,8 @@ CFLAGS+=-DEC_ESPI=1
 
 # FIXME: Use S3 instead of S0ix
 CFLAGS+=-DUSE_S0IX=1
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/gaze17-3060/board.mk
+++ b/src/board/system76/gaze17-3060/board.mk
@@ -8,6 +8,8 @@ CFLAGS+=-DEC_ESPI=1
 
 # FIXME: Use S3 instead of S0ix
 CFLAGS+=-DUSE_S0IX=1
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/oryp9/board.mk
+++ b/src/board/system76/oryp9/board.mk
@@ -8,6 +8,8 @@ CFLAGS+=-DEC_ESPI=1
 
 # FIXME: Use S3 instead of S0ix
 CFLAGS+=-DUSE_S0IX=1
+# Apply PMC hack for S0ix
+CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102


### PR DESCRIPTION
For some reason, *all* the ADL boards are now failing to enter S0ix. Apply the PMC hack to the remaining boards.