### PR TITLE
Set VCC power domain to 1.8V, GPM6 to VCC

### DIFF
--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -42,6 +42,9 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clange-format on
 
 void gpio_init() {
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4
@@ -52,6 +55,10 @@ void gpio_init() {
     GCR20 = 0;
     // Set GPH0 to 1.8V
     GCR21 = BIT(2);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+    // Set GPM6 power domain to VCC
+    GCR23 = BIT(0);
 
     // Set GPIO data
     GPDRA = 0;

--- a/src/board/system76/darp8/gpio.c
+++ b/src/board/system76/darp8/gpio.c
@@ -39,6 +39,9 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clange-format on
 
 void gpio_init(void) {
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+
     // PWRSW WDT 2 Enable 2
     //GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1
@@ -54,11 +57,10 @@ void gpio_init(void) {
     GCR19 = BIT(0);
     // Set GPF2 and GPF3 to 3.3V
     GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
     // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
+    GCR23 = BIT(0);
 
     // Set GPIO data
     GPDRA = 0;

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -45,6 +45,9 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4
@@ -55,6 +58,10 @@ void gpio_init() {
     GCR20 = 0;
     // Set GPH0 to 1.8V
     GCR21 = BIT(2);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+    // Set GPM6 power domain to VCC
+    GCR23 = BIT(0);
 
     // Set GPIO data
     GPDRA = 0;

--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -42,6 +42,9 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init(void) {
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+
     // PWRSW WDT 2 Enable 2
     //GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1
@@ -57,11 +60,10 @@ void gpio_init(void) {
     GCR19 = BIT(0);
     // Set GPF2 and GPF3 to 3.3V
     GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
     // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
+    GCR23 = BIT(0);
 
     // Set GPIO data
     GPDRA = 0;

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -33,6 +33,9 @@ struct Gpio __code VA_EC_EN =       GPIO(H, 7);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init() {
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs
@@ -43,6 +46,10 @@ void gpio_init() {
     GCR19 = BIT(0);
     // Set GPF2 and GPF3 to 3.3V
     GCR20 = 0;
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+    // Set GPM6 power domain to VCC
+    GCR23 = BIT(0);
 
     // Set GPIO data
     // WLAN_PWR_EN

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -33,6 +33,9 @@ struct Gpio __code VA_EC_EN =       GPIO(J, 4);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init() {
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs
@@ -43,6 +46,10 @@ void gpio_init() {
     GCR19 = BIT(0);
     // Set GPF2 and GPF3 to 3.3V
     GCR20 = 0;
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+    // Set GPM6 power domain to VCC
+    GCR23 = BIT(0);
 
     // Set GPIO data
     GPDRA = 0;

--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -42,6 +42,9 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4
@@ -52,6 +55,10 @@ void gpio_init() {
     GCR20 = 0;
     // Set GPH0 to 1.8V
     GCR21 = BIT(2);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
+    // Set GPM6 power domain to VCC
+    GCR23 = BIT(0);
 
     // Set GPIO data
     GPDRA = 0;

--- a/src/board/system76/lemp11/gpio.c
+++ b/src/board/system76/lemp11/gpio.c
@@ -39,8 +39,8 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clange-format on
 
 void gpio_init(void) {
-    // Not documented
-    //GCR22 = BIT(7);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
 
     // PWRSW WDT 2 Enable 2
     //GCR9 = BIT(5);
@@ -57,11 +57,10 @@ void gpio_init(void) {
     GCR19 = BIT(0);
     // Set GPF2 and GPF3 to 3.3V
     GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
     // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
+    GCR23 = BIT(0);
 
     // Set GPIO data
     // PCH_DPWROK_EC

--- a/src/board/system76/oryp9/gpio.c
+++ b/src/board/system76/oryp9/gpio.c
@@ -40,8 +40,8 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init(void) {
-    // Not documented
-    //GCR22 = BIT(7);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
 
     // PWRSW WDT 2 Enable 2
     //GCR9 = BIT(5);
@@ -58,11 +58,10 @@ void gpio_init(void) {
     GCR19 = BIT(0);
     // Set GPF2 and GPF3 to 3.3V
     GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
+    // Set VCC power domain to 1.8V
+    GCR22 = BIT(7);
     // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
+    GCR23 = BIT(0);
 
     // Set GPIO data
     GPDRA = 0;


### PR DESCRIPTION
Proprietary firmware on at least TGL-U and ADL boards (others not checked) set GCR22 bit 7. This bit is not documented in IT5570E spec v0.3.2, but is documented in IT5571E spec v0.3.3.

Also match proprietary firmware for GPM6 by supplying it from VCC instead of VFSPI.

Ref: IT5571 V0.3.3