### PR TITLE
Enable power switch WDT on IT5570E boards

### DIFF
--- a/src/board/system76/addw2/gpio.c
+++ b/src/board/system76/addw2/gpio.c
@@ -43,6 +43,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/addw3/gpio.c
+++ b/src/board/system76/addw3/gpio.c
@@ -35,6 +35,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs
@@ -49,8 +54,6 @@ void gpio_init() {
     //TODO: what do these do?
     GCR1 = 0;
     GCR2 = 0;
-    GCR8 = 0x10;
-    GCR9 = 0x20;
     GCR10 = 0x02;
     GCR21 = 0;
     GCR22 = 0x80;

--- a/src/board/system76/bonw14/gpio.c
+++ b/src/board/system76/bonw14/gpio.c
@@ -42,6 +42,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4); // renamed to EN_3V
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/bonw15/gpio.c
+++ b/src/board/system76/bonw15/gpio.c
@@ -37,6 +37,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs
@@ -51,8 +56,6 @@ void gpio_init() {
     //TODO: what do these do?
     GCR1 = 0;
     GCR2 = 0;
-    GCR8 = 0x10;
-    GCR9 = 0x20;
     GCR10 = 0x02;
     GCR21 = 0;
     GCR22 = 0x80;

--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -43,6 +43,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/darp8/gpio.c
+++ b/src/board/system76/darp8/gpio.c
@@ -41,9 +41,9 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
-    //GCR9 = BIT(5);
+    GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1
-    //GCR8 = BIT(4);
+    GCR8 = BIT(4);
 
     // Enable LPC reset on GPD2
     GCR = 0b10 << 1;

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -44,6 +44,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -43,9 +43,9 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
-    //GCR9 = BIT(5);
+    GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1
-    //GCR8 = BIT(4);
+    GCR8 = BIT(4);
 
     // Enable LPC reset on GPD2
     GCR = 0b10 << 1;

--- a/src/board/system76/gaze15/gpio.c
+++ b/src/board/system76/gaze15/gpio.c
@@ -41,6 +41,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/gaze16-3050/gpio.c
+++ b/src/board/system76/gaze16-3050/gpio.c
@@ -39,6 +39,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs

--- a/src/board/system76/gaze16-3060/gpio.c
+++ b/src/board/system76/gaze16-3060/gpio.c
@@ -40,6 +40,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -39,6 +39,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -39,6 +39,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs

--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -42,6 +42,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/lemp11/gpio.c
+++ b/src/board/system76/lemp11/gpio.c
@@ -43,9 +43,9 @@ void gpio_init(void) {
     //GCR22 = BIT(7);
 
     // PWRSW WDT 2 Enable 2
-    //GCR9 = BIT(5);
+    GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1
-    //GCR8 = BIT(4);
+    GCR8 = BIT(4);
 
     // Enable LPC reset on GPD2
     GCR = 0b10 << 1;

--- a/src/board/system76/oryp11/gpio.c
+++ b/src/board/system76/oryp11/gpio.c
@@ -37,6 +37,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs
@@ -51,8 +56,6 @@ void gpio_init() {
     //TODO: what do these do?
     GCR1 = 0;
     GCR2 = 0;
-    GCR8 = 0x10;
-    GCR9 = 0x20;
     GCR10 = 0x02;
     GCR21 = 0;
     GCR22 = 0x80;

--- a/src/board/system76/oryp6/gpio.c
+++ b/src/board/system76/oryp6/gpio.c
@@ -41,6 +41,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/oryp7/gpio.c
+++ b/src/board/system76/oryp7/gpio.c
@@ -40,6 +40,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/oryp8/gpio.c
+++ b/src/board/system76/oryp8/gpio.c
@@ -38,6 +38,11 @@ struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
 void gpio_init() {
+    // PWRSW WDT 2 Enable 2
+    GCR9 = BIT(5);
+    // PWRSW WDT 2 Enable 1
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Disable UARTs

--- a/src/board/system76/oryp9/gpio.c
+++ b/src/board/system76/oryp9/gpio.c
@@ -45,9 +45,9 @@ void gpio_init(void) {
     //GCR22 = BIT(7);
 
     // PWRSW WDT 2 Enable 2
-    //GCR9 = BIT(5);
+    GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1
-    //GCR8 = BIT(4);
+    GCR8 = BIT(4);
 
     // Enable LPC reset on GPD2
     GCR = 0b10 << 1;


### PR DESCRIPTION
Enable PWRSW WDT 2 and use the default timeout of 10 seconds.

Allows forcing an EC reset in case it gets into an invalid state.