### PR TITLE
Set wireless power at init and power off

### DIFF
--- a/src/board/system76/addw1/board.c
+++ b/src/board/system76/addw1/board.c
@@ -4,6 +4,7 @@
 #include <board/gpio.h>
 #include <board/kbc.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 
 extern uint8_t main_cycle;
@@ -15,16 +16,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/addw2/board.c
+++ b/src/board/system76/addw2/board.c
@@ -5,6 +5,7 @@
 #include <board/gpio.h>
 #include <board/kbc.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -15,13 +16,12 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/addw2/include/board/gpio.h
+++ b/src/board/system76/addw2/include/board/gpio.h
@@ -13,6 +13,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code DD_ON;

--- a/src/board/system76/bonw14/board.c
+++ b/src/board/system76/bonw14/board.c
@@ -4,6 +4,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -14,16 +15,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable USB port power?
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -25,6 +25,7 @@ board-common-y += scratch.c
 board-common-y += smbus.c
 board-common-y += smfi.c
 board-common-y += stdio.c
+board-common-y += wireless.c
 
 # Set log level
 # 0 - NONE

--- a/src/board/system76/common/include/board/wireless.h
+++ b/src/board/system76/common/include/board/wireless.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#ifndef _BOARD_WIRELESS_H
+#define _BOARD_WIRELESS_H
+
+#include <stdbool.h>
+
+void wireless_power(bool);
+
+#endif // _BOARD_WIRELESS_H

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -14,6 +14,7 @@
 #include <board/power.h>
 #include <board/pmc.h>
 #include <board/pnp.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 
 #include <ec/espi.h>
@@ -256,6 +257,8 @@ void power_on(void) {
 
 void power_off(void) {
     DEBUG("%02X: power_off\n", main_cycle);
+
+    wireless_power(false);
 
 #if HAVE_PCH_PWROK_EC
     // De-assert SYS_PWROK

--- a/src/board/system76/common/wireless.c
+++ b/src/board/system76/common/wireless.c
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <board/gpio.h>
+#include <board/wireless.h>
+
+#ifndef HAVE_BT_EN
+    #define HAVE_BT_EN 1
+#endif
+#ifndef HAVE_WLAN_EN
+    #define HAVE_WLAN_EN 1
+#endif
+#ifndef HAVE_WLAN_PWR_EN
+    #define HAVE_WLAN_PWR_EN 1
+#endif
+
+/**
+ * Set the WLAN card power state.
+ */
+void wireless_power(bool enable) {
+#if HAVE_BT_EN
+    gpio_set(&BT_EN, enable);
+#endif
+#if HAVE_WLAN_EN
+    gpio_set(&WLAN_EN, enable);
+#endif
+#if HAVE_WLAN_PWR_EN
+    gpio_set(&WLAN_PWR_EN, enable);
+#endif
+}

--- a/src/board/system76/darp5/board.c
+++ b/src/board/system76/darp5/board.c
@@ -2,6 +2,7 @@
 
 #include <board/board.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 
 void board_init(void) {
     // Allow CPU to boot
@@ -10,16 +11,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {}

--- a/src/board/system76/darp7/board.c
+++ b/src/board/system76/darp7/board.c
@@ -4,6 +4,7 @@
 #include <board/espi.h>
 #include <board/gctrl.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -16,14 +17,13 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI# and SWI#
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/darp7/include/board/gpio.h
+++ b/src/board/system76/darp7/include/board/gpio.h
@@ -13,7 +13,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
-extern struct Gpio __code BT_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;

--- a/src/board/system76/darp8/board.c
+++ b/src/board/system76/darp8/board.c
@@ -4,6 +4,7 @@
 #include <board/board.h>
 #include <board/espi.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 #include <ec/ec.h>
 
 void board_init(void) {
@@ -18,12 +19,11 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Assert SMI# and SWI#
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/darp8/include/board/gpio.h
+++ b/src/board/system76/darp8/include/board/gpio.h
@@ -13,6 +13,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;

--- a/src/board/system76/galp3-c/board.c
+++ b/src/board/system76/galp3-c/board.c
@@ -2,6 +2,7 @@
 
 #include <board/board.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 
 void board_init(void) {
     // Allow CPU to boot
@@ -10,16 +11,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {}

--- a/src/board/system76/galp5/board.c
+++ b/src/board/system76/galp5/board.c
@@ -22,7 +22,6 @@ void board_init(void) {
     // Enable camera
     gpio_set(&CCD_EN, true);
     // Enable wireless
-    gpio_set(&BT_EN, true);
     gpio_set(&WLAN_EN, true);
     gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port

--- a/src/board/system76/galp5/board.c
+++ b/src/board/system76/galp5/board.c
@@ -6,6 +6,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -21,14 +22,13 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI# and SWI#
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -9,7 +9,6 @@ struct Gpio __code ACIN_N =         GPIO(B, 0);
 struct Gpio __code AC_PRESENT =     GPIO(E, 1);
 struct Gpio __code ALL_SYS_PWRGD =  GPIO(C, 0);
 struct Gpio __code BKL_EN =         GPIO(H, 2);
-struct Gpio __code BT_EN =          GPIO(F, 3);
 struct Gpio __code BUF_PLT_RST_N =  GPIO(D, 2); // renamed to EC_ERST#
 struct Gpio __code CCD_EN =         GPIO(D, 1);
 struct Gpio __code CPU_C10_GATE_N = GPIO(D, 3);
@@ -162,7 +161,7 @@ void gpio_init() {
     GPCRF1 = GPIO_OUT | GPIO_UP;
     // 3IN1
     GPCRF2 = GPIO_IN | GPIO_UP;
-    // BT_EN
+    // BT_EN: Not connected
     GPCRF3 = GPIO_OUT | GPIO_UP;
     // TP_CLK
     GPCRF4 = GPIO_ALT | GPIO_UP;

--- a/src/board/system76/galp5/include/board/gpio.h
+++ b/src/board/system76/galp5/include/board/gpio.h
@@ -13,6 +13,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;

--- a/src/board/system76/galp5/include/board/gpio.h
+++ b/src/board/system76/galp5/include/board/gpio.h
@@ -13,7 +13,6 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
-extern struct Gpio __code BT_EN;
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;

--- a/src/board/system76/galp6/board.c
+++ b/src/board/system76/galp6/board.c
@@ -4,6 +4,7 @@
 #include <board/board.h>
 #include <board/espi.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 #include <ec/ec.h>
 
 void board_init(void) {
@@ -13,12 +14,11 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Assert SMI# and SWI#
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();

--- a/src/board/system76/galp6/include/board/gpio.h
+++ b/src/board/system76/galp6/include/board/gpio.h
@@ -13,6 +13,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;

--- a/src/board/system76/gaze15/board.c
+++ b/src/board/system76/gaze15/board.c
@@ -4,6 +4,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -12,14 +13,12 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/gaze16-3050/board.c
+++ b/src/board/system76/gaze16-3050/board.c
@@ -6,6 +6,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -19,6 +20,8 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/gaze16-3050/gpio.c
+++ b/src/board/system76/gaze16-3050/gpio.c
@@ -30,6 +30,8 @@ struct Gpio __code SLP_SUS_N =      GPIO(H, 3);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
 struct Gpio __code VA_EC_EN =       GPIO(J, 4);
+struct Gpio __code WLAN_EN =        GPIO(G, 1);
+struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init() {
@@ -47,8 +49,7 @@ void gpio_init() {
     GCR21 = BIT(2);
 
     // Set GPIO data
-    // WLAN_PWR_EN
-    GPDRA = BIT(3);
+    GPDRA = 0;
     // SWI#, XLP_OUT, PWR_SW#
     GPDRB = BIT(5) | BIT(4) | BIT(3);
     GPDRC = 0;
@@ -57,8 +58,8 @@ void gpio_init() {
     GPDRE = 0;
     // CC_EN
     GPDRF = BIT(7);
-    // H_PROCHOT_EC, WLAN_EN
-    GPDRG = BIT(6) | BIT(1);
+    // H_PROCHOT_EC
+    GPDRG = BIT(6);
     // AIRPLAN_LED#
     GPDRH = BIT(7);
     GPDRI = 0;

--- a/src/board/system76/gaze16-3050/include/board/gpio.h
+++ b/src/board/system76/gaze16-3050/include/board/gpio.h
@@ -12,6 +12,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;
@@ -37,6 +38,8 @@ extern struct Gpio __code SLP_SUS_N;
 extern struct Gpio __code SUSB_N_PCH;
 extern struct Gpio __code SUSC_N_PCH;
 extern struct Gpio __code VA_EC_EN;
+extern struct Gpio __code WLAN_EN;
+extern struct Gpio __code WLAN_PWR_EN;
 extern struct Gpio __code XLP_OUT;
 
 #endif // _BOARD_GPIO_H

--- a/src/board/system76/gaze16-3060/board.c
+++ b/src/board/system76/gaze16-3060/board.c
@@ -6,6 +6,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -19,6 +20,8 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/gaze16-3060/gpio.c
+++ b/src/board/system76/gaze16-3060/gpio.c
@@ -31,6 +31,8 @@ struct Gpio __code SLP_SUS_N =      GPIO(I, 6);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
 struct Gpio __code VA_EC_EN =       GPIO(J, 4);
+struct Gpio __code WLAN_EN =        GPIO(G, 1);
+struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init() {
@@ -48,8 +50,7 @@ void gpio_init() {
     GCR21 = BIT(2);
 
     // Set GPIO data
-    // WLAN_PWR_EN
-    GPDRA = BIT(3);
+    GPDRA = 0;
     // SWI#, XLP_OUT, PWR_SW#
     GPDRB = BIT(5) | BIT(4) | BIT(3);
     GPDRC = 0;
@@ -57,8 +58,8 @@ void gpio_init() {
     GPDRD = BIT(5) | BIT(4) | BIT(3);
     GPDRE = 0;
     GPDRF = 0;
-    // H_PROCHOT#_EC, WLAN_EN
-    GPDRG = BIT(6) | BIT(1);
+    // H_PROCHOT#_EC
+    GPDRG = BIT(6);
     // AIRPLAN_LED#
     GPDRH = BIT(7);
     GPDRI = 0;

--- a/src/board/system76/gaze16-3060/include/board/gpio.h
+++ b/src/board/system76/gaze16-3060/include/board/gpio.h
@@ -12,6 +12,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;
@@ -37,6 +38,8 @@ extern struct Gpio __code SLP_SUS_N;
 extern struct Gpio __code SUSB_N_PCH;
 extern struct Gpio __code SUSC_N_PCH;
 extern struct Gpio __code VA_EC_EN;
+extern struct Gpio __code WLAN_EN;
+extern struct Gpio __code WLAN_PWR_EN;
 extern struct Gpio __code XLP_OUT;
 
 #endif // _BOARD_GPIO_H

--- a/src/board/system76/gaze17-3050/board.c
+++ b/src/board/system76/gaze17-3050/board.c
@@ -6,6 +6,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -19,6 +20,8 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -30,6 +30,8 @@ struct Gpio __code SLP_SUS_N =      GPIO(J, 4);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
 struct Gpio __code VA_EC_EN =       GPIO(H, 7);
+struct Gpio __code WLAN_EN =        GPIO(G, 1);
+struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init() {
@@ -45,8 +47,7 @@ void gpio_init() {
     GCR20 = 0;
 
     // Set GPIO data
-    // WLAN_PWR_EN
-    GPDRA = BIT(3);
+    GPDRA = 0;
     // XLP_OUT
     GPDRB = BIT(4);
     GPDRC = 0;
@@ -55,8 +56,8 @@ void gpio_init() {
     GPDRE = BIT(3);
     // CC_EN
     GPDRF = BIT(7);
-    // H_PROCHOT#_EC, WLAN_EN
-    GPDRG = BIT(6) | BIT(1);
+    // H_PROCHOT#_EC
+    GPDRG = BIT(6);
     GPDRH = 0;
     GPDRI = 0;
     // KBC_MUTE#

--- a/src/board/system76/gaze17-3050/include/board/gpio.h
+++ b/src/board/system76/gaze17-3050/include/board/gpio.h
@@ -12,6 +12,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;
@@ -38,6 +39,8 @@ extern struct Gpio __code SLP_SUS_N;
 extern struct Gpio __code SUSB_N_PCH;
 extern struct Gpio __code SUSC_N_PCH;
 extern struct Gpio __code VA_EC_EN;
+extern struct Gpio __code WLAN_EN;
+extern struct Gpio __code WLAN_PWR_EN;
 extern struct Gpio __code XLP_OUT;
 
 #endif // _BOARD_GPIO_H

--- a/src/board/system76/gaze17-3060/board.c
+++ b/src/board/system76/gaze17-3060/board.c
@@ -6,6 +6,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -19,6 +20,8 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -30,6 +30,8 @@ struct Gpio __code SLP_SUS_N =      GPIO(J, 7);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
 struct Gpio __code VA_EC_EN =       GPIO(J, 4);
+struct Gpio __code WLAN_EN =        GPIO(G, 1);
+struct Gpio __code WLAN_PWR_EN =    GPIO(D, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init() {
@@ -49,13 +51,12 @@ void gpio_init() {
     // XLP_OUT
     GPDRB = BIT(4);
     GPDRC = 0;
-    // WLAN_PWR_EN
-    GPDRD = BIT(3);
+    GPDRD = 0;
     // USB_PWR_EN
     GPDRE = BIT(3);
     GPDRF = 0;
-    // H_PROCHOT_EC, WLAN_EN
-    GPDRG = BIT(6) | BIT(1);
+    // H_PROCHOT_EC
+    GPDRG = BIT(6);
     GPDRH = 0;
     GPDRI = 0;
     // KBC_MUTE#

--- a/src/board/system76/gaze17-3060/include/board/gpio.h
+++ b/src/board/system76/gaze17-3060/include/board/gpio.h
@@ -12,6 +12,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;
@@ -38,6 +39,8 @@ extern struct Gpio __code SLP_SUS_N;
 extern struct Gpio __code SUSB_N_PCH;
 extern struct Gpio __code SUSC_N_PCH;
 extern struct Gpio __code VA_EC_EN;
+extern struct Gpio __code WLAN_EN;
+extern struct Gpio __code WLAN_PWR_EN;
 extern struct Gpio __code XLP_OUT;
 
 #endif // _BOARD_GPIO_H

--- a/src/board/system76/lemp10/board.c
+++ b/src/board/system76/lemp10/board.c
@@ -4,6 +4,7 @@
 #include <board/espi.h>
 #include <board/gctrl.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -16,16 +17,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/lemp11/board.c
+++ b/src/board/system76/lemp11/board.c
@@ -4,6 +4,7 @@
 #include <board/board.h>
 #include <board/espi.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 #include <ec/ec.h>
 
 
@@ -19,14 +20,12 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/lemp9/board.c
+++ b/src/board/system76/lemp9/board.c
@@ -2,6 +2,7 @@
 
 #include <board/board.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 
 void board_init(void) {
     // Allow CPU to boot
@@ -10,16 +11,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable right USB port
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_on_ac(bool ac) { /* Fix unused variable */ ac = ac; }

--- a/src/board/system76/oryp5/board.c
+++ b/src/board/system76/oryp5/board.c
@@ -3,6 +3,7 @@
 #include <board/board.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 
 void board_init(void) {
@@ -12,16 +13,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable USB power
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/oryp6/board.c
+++ b/src/board/system76/oryp6/board.c
@@ -4,6 +4,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -14,16 +15,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&BT_EN, true);
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable USB port power?
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/oryp7/board.c
+++ b/src/board/system76/oryp7/board.c
@@ -4,6 +4,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -14,15 +15,14 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&WLAN_EN, true);
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable USB port power?
     gpio_set(&USB_PWR_EN_N, false);
     // Assert SMI#, SCI#, and SWI#
     gpio_set(&SCI_N, true);
     gpio_set(&SMI_N, true);
     gpio_set(&SWI_N, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/oryp7/include/board/gpio.h
+++ b/src/board/system76/oryp7/include/board/gpio.h
@@ -13,6 +13,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code DD_ON;

--- a/src/board/system76/oryp8/board.c
+++ b/src/board/system76/oryp8/board.c
@@ -5,6 +5,7 @@
 #include <board/gctrl.h>
 #include <board/gpio.h>
 #include <board/power.h>
+#include <board/wireless.h>
 #include <common/debug.h>
 #include <ec/ec.h>
 
@@ -15,6 +16,8 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/oryp8/gpio.c
+++ b/src/board/system76/oryp8/gpio.c
@@ -29,6 +29,8 @@ struct Gpio __code SLP_SUS_N =      GPIO(D, 4);
 struct Gpio __code SUSB_N_PCH =     GPIO(H, 6);
 struct Gpio __code SUSC_N_PCH =     GPIO(H, 1);
 struct Gpio __code VA_EC_EN =       GPIO(J, 4); // renamed to EC_SLP_SUS#
+struct Gpio __code WLAN_EN =        GPIO(G, 1);
+struct Gpio __code WLAN_PWR_EN =    GPIO(H, 4);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 
 void gpio_init() {
@@ -46,7 +48,7 @@ void gpio_init() {
     GCR21 = BIT(2);
 
     // Set GPIO data
-    // WLAN_PWR_EN
+    // DDS_EC_PWM
     GPDRA = BIT(3);
     // SWI#, XLP_OUT, PWR_SW#
     GPDRB = BIT(5) | BIT(4) | BIT(3);
@@ -56,10 +58,9 @@ void gpio_init() {
     GPDRE = 0;
     // BL_PWM_EN_EC, PCH_DPWROK_EC
     GPDRF = BIT(7) | BIT(3);
-    // H_PROCHOT#_EC, WLAN_EN
-    GPDRG = BIT(6) | BIT(1);
-    // WLAN_PWR_EN
-    GPDRH = BIT(4);
+    // H_PROCHOT#_EC
+    GPDRG = BIT(6);
+    GPDRH = 0;
     // PLVDD_RST_EC, EC_AMP_EN
     GPDRI = BIT(6) | BIT(5);
     GPDRJ = 0;

--- a/src/board/system76/oryp8/include/board/gpio.h
+++ b/src/board/system76/oryp8/include/board/gpio.h
@@ -12,6 +12,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;
@@ -37,6 +38,8 @@ extern struct Gpio __code SLP_SUS_N;
 extern struct Gpio __code SUSB_N_PCH;
 extern struct Gpio __code SUSC_N_PCH;
 extern struct Gpio __code VA_EC_EN;
+extern struct Gpio __code WLAN_EN;
+extern struct Gpio __code WLAN_PWR_EN;
 extern struct Gpio __code XLP_OUT;
 
 #endif // _BOARD_GPIO_H

--- a/src/board/system76/oryp9/board.c
+++ b/src/board/system76/oryp9/board.c
@@ -4,6 +4,7 @@
 #include <board/board.h>
 #include <board/espi.h>
 #include <board/gpio.h>
+#include <board/wireless.h>
 #include <ec/ec.h>
 
 void board_init(void) {
@@ -16,10 +17,10 @@ void board_init(void) {
     gpio_set(&BKL_EN, true);
     // Enable camera
     gpio_set(&CCD_EN, true);
-    // Enable wireless
-    gpio_set(&WLAN_PWR_EN, true);
     // Enable USB port power
     gpio_set(&USB_PWR_EN_N, false);
+
+    wireless_power(true);
 }
 
 void board_event(void) {

--- a/src/board/system76/oryp9/include/board/gpio.h
+++ b/src/board/system76/oryp9/include/board/gpio.h
@@ -13,6 +13,7 @@ extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;
 extern struct Gpio __code ALL_SYS_PWRGD;
 extern struct Gpio __code BKL_EN;
+#define HAVE_BT_EN 0
 extern struct Gpio __code BUF_PLT_RST_N;
 extern struct Gpio __code CCD_EN;
 extern struct Gpio __code CPU_C10_GATE_N;
@@ -43,6 +44,7 @@ extern struct Gpio __code SUSC_N_PCH;
 extern struct Gpio __code SWI_N;
 extern struct Gpio __code USB_PWR_EN_N;
 extern struct Gpio __code VA_EC_EN;
+#define HAVE_WLAN_EN 0
 extern struct Gpio __code WLAN_PWR_EN;
 extern struct Gpio __code XLP_OUT;
 // clang-format on


### PR DESCRIPTION
Add a new wireless object for controlling WLAN power state. Change the power sequence to enable WLAN at board init and disable it at power off.

Newer galp5 units sold to customers have an issue where they do not fully power off. This is apparently somehow caused by `WLAN_PWR_EN`.

The unit received for development do not have this issue.


### Test

- Ensure WiFi and Bluetooth still work
- Ensure power LED doesn't blink after power off on battery power