### PR TITLE
kbc: Enable Transaction Done interrupt

### DIFF
--- a/src/board/system76/common/kbc.c
+++ b/src/board/system76/common/kbc.c
@@ -396,6 +396,9 @@ static void kbc_on_input_data(struct Kbc *kbc, uint8_t data) {
         state = KBC_STATE_NORMAL;
         // Begin write
         *(PS2_TOUCHPAD.control) = 0x0D;
+        // Enable Transaction Done interrupt
+        *(PS2_TOUCHPAD.interrupt) |= BIT(2);
+        // Write the data
         *(PS2_TOUCHPAD.data) = data;
         // Pull data line low
         *(PS2_TOUCHPAD.control) = 0x0C;
@@ -481,6 +484,8 @@ void kbc_event(struct Kbc *kbc) {
         if (kbc_second_wait == 0) {
             // Attempt to read from touchpad
             *(PS2_TOUCHPAD.control) = 0x07;
+            // Enable Transaction Done interrupt
+            *(PS2_TOUCHPAD.interrupt) |= BIT(2);
             if (state == KBC_STATE_NORMAL) {
                 uint8_t sts = *(PS2_TOUCHPAD.status);
                 *(PS2_TOUCHPAD.status) = sts;


### PR DESCRIPTION
Step 2 for data transmission (both RX and TX) is to enable the Transaction Done interrupt.

Ref: IT5570 V0.3.2, 7.9.3.1 Hardware Mode Selected