### PR TITLE
make: Enable compiling asm files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all:
 else
 # Calculate version
 DATE=$(shell git show --format="%cd" --date="format:%Y-%m-%d" --no-patch)
-REV=$(shell git describe --always --dirty)
+REV=$(shell git describe --abbrev=7 --always --dirty)
 VERSION?=$(DATE)_$(REV)
 
 # Set build directory

--- a/src/arch/8051/toolchain.mk
+++ b/src/arch/8051/toolchain.mk
@@ -5,6 +5,11 @@ CC = sdcc -mmcs51 --model-large --code-size $(CODE_SIZE) --xram-size $(SRAM_SIZE
 AS = sdas8051
 ASFLAGS = -plosgff
 
+# XXX: SDCC "requires" main() to be in the first item passed to the linker.
+# Ref: SDCC Manual 4.2.8; Section 3.2.3 Projects with Multiple Source Files
+MAIN_SRC = $(filter %/main.c, $(SRC))
+MAIN_OBJ = $(sort $(patsubst src/%.c, $(BUILD)/%.rel, $(MAIN_SRC)))
+
 # NOTE: sdas *must* be used for assembly files as sdcc cannot compile them
 # itself. They must use an extension of `.asm` so they can be filtered here.
 
@@ -14,7 +19,7 @@ ASM_OBJ = $(sort $(patsubst src/%.asm, $(BUILD)/%.rel, $(ASM_SRC)))
 C_SRC = $(filter %.c, $(SRC))
 C_OBJ = $(sort $(patsubst src/%.c, $(BUILD)/%.rel, $(C_SRC)))
 
-OBJ = $(sort $(ASM_OBJ) $(C_OBJ))
+OBJ = $(MAIN_OBJ) $(sort $(ASM_OBJ) $(C_OBJ))
 
 # Run EC rom in simulator
 sim: $(BUILD)/ec.rom


### PR DESCRIPTION
Allow specifying asm files the same way C files are added:

    board-common-y += foo.asm

The file *must* use an `.asm` extension for 8051. The toolchain file filters the sources to compile them into objects correctly, as the C compiler doesn't handle asm files itself.