### PR TITLE
avr: Fix compiling with GCC 12

### DIFF
--- a/src/arch/avr/i2c.c
+++ b/src/arch/avr/i2c.c
@@ -40,7 +40,7 @@ int16_t i2c_start(struct I2C *i2c, uint8_t addr, bool read) {
         return -1;
 
     // check if the device has acknowledged the READ / WRITE mode
-    uint8_t twst = TW_STATUS & 0xF8;
+    uint8_t twst = TW_STATUS;
     if ((twst != TW_MT_SLA_ACK) && (twst != TW_MR_SLA_ACK))
         return -1;
 

--- a/src/arch/avr/toolchain.mk
+++ b/src/arch/avr/toolchain.mk
@@ -2,7 +2,14 @@
 
 CC=avr-gcc -mmcu=$(EC_VARIANT)
 CFLAGS+=-Os -fstack-usage -Wall -Werror -Wl,--gc-sections -Wl,-u,vfprintf -lprintf_flt
+
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+ifneq ($(findstring 12.,$(shell avr-gcc --version 2>/dev/null)),)
+CFLAGS += --param=min-pagesize=0
+endif
+
 OBJCOPY = avr-objcopy
+
 OBJ=$(sort $(patsubst src/%.c,$(BUILD)/%.o,$(SRC)))
 
 # Run EC rom in simulator


### PR DESCRIPTION
Compiling the Arduino targets with GCC 12 fails with the following:

    error: array subscript 0 is outside array bounds of 'volatile uint8_t[0]' {aka 'volatile unsigned char[]'} [-Werror=array-bounds]

Apply the workaround from the bug discussion to fix it.

Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523