### PR TITLE
Generate and use compiler dep rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,4 @@ jobs:
         run: ./scripts/deps.sh
 
       - name: Build firmware
-        run: make BOARD=${{ matrix.vendor}}/${{ matrix.board }}
+        run: make BOARD=${{ matrix.vendor}}/${{ matrix.board }} VERBOSE=1

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ all: $(BUILD)/ec.rom
 
 # Include common source
 COMMON_DIR=src/common
-INCLUDE=$(wildcard $(COMMON_DIR)/include/common/*.h) $(COMMON_DIR)/common.mk
+INCLUDE += $(COMMON_DIR)/common.mk
 CFLAGS=-I$(COMMON_DIR)/include -D__FIRMWARE_VERSION__=$(VERSION)
 include $(COMMON_DIR)/common.mk
 SRC += $(foreach src, $(common-y), $(COMMON_DIR)/$(src))
 
 # Include the board's source
 BOARD_DIR=src/board/$(BOARD)
-INCLUDE+=$(wildcard $(BOARD_DIR)/include/board/*.h) $(BOARD_DIR)/board.mk
+INCLUDE += $(BOARD_DIR)/board.mk
 CFLAGS+=-I$(BOARD_DIR)/include -D__BOARD__=$(BOARD)
 include $(BOARD_DIR)/board.mk
 SRC += $(foreach src, $(board-y), $(BOARD_DIR)/$(src))
@@ -42,7 +42,7 @@ SRC += $(foreach src, $(keyboard-y), $(KEYBOARD_DIR)/$(src))
 # The board will define the embedded controller
 # Include the embedded controller's source
 EC_DIR=src/ec/$(EC)
-INCLUDE+=$(wildcard $(EC_DIR)/include/ec/*.h) $(EC_DIR)/ec.mk
+INCLUDE += $(EC_DIR)/ec.mk
 CFLAGS+=-I$(EC_DIR)/include
 include $(EC_DIR)/ec.mk
 SRC += $(foreach src, $(ec-y), $(EC_DIR)/$(src))
@@ -50,7 +50,7 @@ SRC += $(foreach src, $(ec-y), $(EC_DIR)/$(src))
 # The EC will define the architecture
 # Include the architecture's source
 ARCH_DIR=src/arch/$(ARCH)
-INCLUDE+=$(wildcard $(ARCH_DIR)/include/arch/*.h) $(ARCH_DIR)/arch.mk
+INCLUDE += $(ARCH_DIR)/arch.mk
 CFLAGS+=-I$(ARCH_DIR)/include -D__ARCH__=$(ARCH)
 include $(ARCH_DIR)/arch.mk
 SRC += $(foreach src, $(arch-y), $(ARCH_DIR)/$(src))

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 -include config.mk
 
+# Disable built-in rules and variables
+MAKEFLAGS += -rR
+
 # Parameter for current board
 ifeq ($(BOARD),)
 all:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@
 # Disable built-in rules and variables
 MAKEFLAGS += -rR
 
+# Default to silent builds
+ifneq ($(VERBOSE),1)
+MAKEFLAGS += -s
+endif
+
 # Parameter for current board
 ifeq ($(BOARD),)
 all:
@@ -20,11 +25,12 @@ REV=$(shell git describe --abbrev=7 --always --dirty)
 VERSION?=$(DATE)_$(REV)
 
 # Set build directory
-BUILD=build/$(BOARD)/$(VERSION)
+obj = build
+BUILD = $(obj)/$(BOARD)/$(VERSION)
 
 # Default target - build the board's EC firmware
 all: $(BUILD)/ec.rom
-	$(info Built '$(VERSION)' for '$(BOARD)')
+	$(info Built $(VERSION) for $(BOARD))
 
 # Include common source
 COMMON_DIR=src/common
@@ -65,4 +71,4 @@ endif
 
 # Target to remove build artifacts
 clean:
-	rm -rf build
+	rm -rf $(obj)

--- a/src/arch/8051/toolchain.mk
+++ b/src/arch/8051/toolchain.mk
@@ -31,22 +31,26 @@ sim: $(BUILD)/ec.rom
 
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	objcopy -I ihex -O binary --gap-fill=0xFF $< $@
 
 # Link object files into Intel Hex file
 $(BUILD)/ec.ihx: $(OBJ)
-	@mkdir -p $(@D)
+	@echo "  LINK      $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(CC) $(LDFLAGS) -o $@ $^
 
 # Compile ASM files into object files
 $(ASM_OBJ): $(BUILD)/%.rel: src/%.asm
-	@mkdir -p $(@D)
+	@echo "  AS        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(AS) $(ASFLAGS) $@ $<
 
 # Compile C files into object files
 $(C_OBJ): $(BUILD)/%.rel: src/%.c $(INCLUDE)
-	@mkdir -p $(@D)
+	@echo "  CC        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 # Add dependency rules

--- a/src/arch/8051/toolchain.mk
+++ b/src/arch/8051/toolchain.mk
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
-CC = sdcc -mmcs51 --model-large --code-size $(CODE_SIZE) --xram-size $(SRAM_SIZE) --Werror
+CC = sdcc -mmcs51 -MMD --model-large --code-size $(CODE_SIZE) --xram-size $(SRAM_SIZE) --Werror
 
 AS = sdas8051
 ASFLAGS = -plosgff
@@ -48,3 +48,7 @@ $(ASM_OBJ): $(BUILD)/%.rel: src/%.asm
 $(C_OBJ): $(BUILD)/%.rel: src/%.c $(INCLUDE)
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ -c $<
+
+# Add dependency rules
+DEP = $(OBJ:%.rel=%.d)
+-include $(DEP)

--- a/src/arch/avr/toolchain.mk
+++ b/src/arch/avr/toolchain.mk
@@ -19,22 +19,26 @@ sim: $(BUILD)/ec.elf
 
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(OBJCOPY) -I ihex -O binary --gap-fill 0xFF $< $@
 
 # Convert from ELF file to Intel Hex file
 $(BUILD)/ec.ihx: $(BUILD)/ec.elf
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(OBJCOPY) -j .text -j .data -O ihex $< $@
 
 # Link object files into ELF file
 $(BUILD)/ec.elf: $(OBJ)
-	@mkdir -p $(@D)
+	@echo "  LINK      $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(CC) -o $@ $^
 
 # Compile C files into object files
 $(BUILD)/%.o: src/%.c $(INCLUDE)
-	@mkdir -p $(@D)
+	@echo "  CC        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 # Add dependency rules

--- a/src/arch/avr/toolchain.mk
+++ b/src/arch/avr/toolchain.mk
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
-CC=avr-gcc -mmcu=$(EC_VARIANT)
-CFLAGS+=-Os -fstack-usage -Wall -Werror -Wl,--gc-sections -Wl,-u,vfprintf -lprintf_flt
+CC = avr-gcc -mmcu=$(EC_VARIANT)
+CFLAGS += -MMD -Os -fstack-usage -Wall -Werror \
+	-Wl,--gc-sections -Wl,-u,vfprintf -lprintf_flt
 
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
 ifneq ($(findstring 12.,$(shell avr-gcc --version 2>/dev/null)),)
@@ -35,3 +36,7 @@ $(BUILD)/ec.elf: $(OBJ)
 $(BUILD)/%.o: src/%.c $(INCLUDE)
 	@mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ -c $<
+
+# Add dependency rules
+DEP = $(OBJ:%.o=%.d)
+-include $(DEP)

--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -51,7 +51,7 @@ endif
 
 # Include system76 common source
 SYSTEM76_COMMON_DIR=src/board/system76/common
-INCLUDE+=$(wildcard $(SYSTEM76_COMMON_DIR)/include/board/*.h) $(SYSTEM76_COMMON_DIR)/common.mk
+INCLUDE += $(SYSTEM76_COMMON_DIR)/common.mk
 CFLAGS+=-I$(SYSTEM76_COMMON_DIR)/include
 
 # Set battery charging thresholds

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -14,7 +14,7 @@ FLASH_CFLAGS=$(CFLAGS)
 # Include flash source.
 FLASH_DIR=$(SYSTEM76_COMMON_DIR)/flash
 # Note: main.c *must* be first to ensure that flash_start is at the correct address
-FLASH_INCLUDE+=$(wildcard $(FLASH_DIR)/include/flash/*.h) $(FLASH_DIR)/flash.mk
+FLASH_INCLUDE += $(FLASH_DIR)/flash.mk
 FLASH_CFLAGS+=-I$(FLASH_DIR)/include -D__FLASH__
 FLASH_SRC += $(foreach src, $(flash-y), $(FLASH_DIR)/$(src))
 
@@ -23,6 +23,7 @@ FLASH_OBJ=$(sort $(patsubst src/%.c,$(FLASH_BUILD)/%.rel,$(FLASH_SRC)))
 FLASH_CC=\
 	sdcc \
 	-mmcs51 \
+	-MMD \
 	--model-large \
 	--opt-code-size \
 	--acall-ajmp \

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -33,22 +33,26 @@ FLASH_CC=\
 
 # Convert from binary file to C header
 $(BUILD)/include/flash.h: $(FLASH_BUILD)/flash.rom
-	@mkdir -p $(@D)
+	@echo "  XXD       $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	xxd -include < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(FLASH_BUILD)/flash.rom: $(FLASH_BUILD)/flash.ihx
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	objcopy -I ihex -O binary $< $@
 
 # Link object files into Intel Hex file
 $(FLASH_BUILD)/flash.ihx: $(FLASH_OBJ)
-	@mkdir -p $(@D)
+	@echo "  LINK      $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(FLASH_CC) -o $@ $^
 
 # Compile C files into object files
 $(FLASH_OBJ): $(FLASH_BUILD)/%.rel: src/%.c $(FLASH_INCLUDE)
-	@mkdir -p $(@D)
+	@echo "  CC        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(FLASH_CC) $(FLASH_CFLAGS) -o $@ -c $<
 
 # Include flash header in main firmware

--- a/src/board/system76/common/scratch/scratch.mk
+++ b/src/board/system76/common/scratch/scratch.mk
@@ -15,7 +15,7 @@ SCRATCH_CFLAGS=$(CFLAGS)
 
 # Include scratch source
 SCRATCH_DIR=$(SYSTEM76_COMMON_DIR)/scratch
-SCRATCH_INCLUDE+=$(wildcard $(SCRATCH_DIR)/include/scratch/*.h) $(SCRATCH_DIR)/scratch.mk
+SCRATCH_INCLUDE += $(SCRATCH_DIR)/scratch.mk
 SCRATCH_CFLAGS+=-I$(SCRATCH_DIR)/include -D__SCRATCH__
 SCRATCH_SRC += $(foreach src, $(scratch-y), $(SCRATCH_DIR)/$(src))
 
@@ -24,6 +24,7 @@ SCRATCH_OBJ=$(sort $(patsubst src/%.c,$(SCRATCH_BUILD)/%.rel,$(SCRATCH_SRC)))
 SCRATCH_CC=\
 	sdcc \
 	-mmcs51 \
+	-MMD \
 	--model-small \
 	--code-loc $(SCRATCH_OFFSET) \
 	--code-size $(SCRATCH_SIZE) \

--- a/src/board/system76/common/scratch/scratch.mk
+++ b/src/board/system76/common/scratch/scratch.mk
@@ -32,22 +32,26 @@ SCRATCH_CC=\
 
 # Convert from binary file to C header
 $(BUILD)/include/scratch.h: $(SCRATCH_BUILD)/scratch.rom
-	@mkdir -p $(@D)
+	@echo "  XXD       $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	xxd -include < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(SCRATCH_BUILD)/scratch.rom: $(SCRATCH_BUILD)/scratch.ihx
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	objcopy -I ihex -O binary $< $@
 
 # Link object files into Intel Hex file
 $(SCRATCH_BUILD)/scratch.ihx: $(SCRATCH_OBJ)
-	@mkdir -p $(@D)
+	@echo "  LINK      $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(SCRATCH_CC) -o $@ $^
 
 # Compile C files into object files
 $(SCRATCH_OBJ): $(SCRATCH_BUILD)/%.rel: src/%.c $(SCRATCH_INCLUDE)
-	@mkdir -p $(@D)
+	@echo "  CC        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(SCRATCH_CC) $(SCRATCH_CFLAGS) -o $@ -c $<
 
 # Include scratch header in main firmware

--- a/src/keyboard/system76/14in_83/keyboard.mk
+++ b/src/keyboard/system76/14in_83/keyboard.mk
@@ -3,5 +3,5 @@
 KEYMAP?=default
 keyboard-y += keymap/$(KEYMAP).c
 
-INCLUDE+=$(wildcard $(KEYBOARD_DIR)/include/board/*.h) $(KEYBOARD_DIR)/keyboard.mk
+INCLUDE += $(KEYBOARD_DIR)/keyboard.mk
 CFLAGS+=-I$(KEYBOARD_DIR)/include

--- a/src/keyboard/system76/14in_86/keyboard.mk
+++ b/src/keyboard/system76/14in_86/keyboard.mk
@@ -3,5 +3,5 @@
 KEYMAP?=default
 keyboard-y += keymap/$(KEYMAP).c
 
-INCLUDE+=$(wildcard $(KEYBOARD_DIR)/include/board/*.h) $(KEYBOARD_DIR)/keyboard.mk
+INCLUDE += $(KEYBOARD_DIR)/keyboard.mk
 CFLAGS+=-I$(KEYBOARD_DIR)/include

--- a/src/keyboard/system76/15in_102/keyboard.mk
+++ b/src/keyboard/system76/15in_102/keyboard.mk
@@ -3,5 +3,5 @@
 KEYMAP?=default
 keyboard-y += keymap/$(KEYMAP).c
 
-INCLUDE+=$(wildcard $(KEYBOARD_DIR)/include/board/*.h) $(KEYBOARD_DIR)/keyboard.mk
+INCLUDE += $(KEYBOARD_DIR)/keyboard.mk
 CFLAGS+=-I$(KEYBOARD_DIR)/include

--- a/src/keyboard/system76/15in_102_nkey/keyboard.mk
+++ b/src/keyboard/system76/15in_102_nkey/keyboard.mk
@@ -3,5 +3,5 @@
 KEYMAP?=default
 keyboard-y += keymap/$(KEYMAP).c
 
-INCLUDE+=$(wildcard $(KEYBOARD_DIR)/include/board/*.h) $(KEYBOARD_DIR)/keyboard.mk
+INCLUDE += $(KEYBOARD_DIR)/keyboard.mk
 CFLAGS+=-I$(KEYBOARD_DIR)/include


### PR DESCRIPTION
SDCC supports the `-MMD` option. Use it instead of having every file depend on *all* the headers. Reduces incremental build time after modifying headers as it will now only rebuild the actual dependents and not the entire project.