### PR TITLE
Reduce build output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,4 @@ jobs:
         run: ./scripts/deps.sh
 
       - name: Build firmware
-        run: make BOARD=${{ matrix.vendor}}/${{ matrix.board }}
+        run: make BOARD=${{ matrix.vendor}}/${{ matrix.board }} VERBOSE=1

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 -include config.mk
 
+# Disable built-in rules and variables
+MAKEFLAGS += -rR
+
 # Parameter for current board
 ifeq ($(BOARD),)
 all:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@
 # Disable built-in rules and variables
 MAKEFLAGS += -rR
 
+# Default to silent builds
+ifneq ($(VERBOSE),1)
+MAKEFLAGS += -s
+endif
+
 # Parameter for current board
 ifeq ($(BOARD),)
 all:
@@ -20,11 +25,12 @@ REV=$(shell git describe --abbrev=7 --always --dirty)
 VERSION?=$(DATE)_$(REV)
 
 # Set build directory
-BUILD=build/$(BOARD)/$(VERSION)
+obj = build
+BUILD = $(obj)/$(BOARD)/$(VERSION)
 
 # Default target - build the board's EC firmware
 all: $(BUILD)/ec.rom
-	$(info Built '$(VERSION)' for '$(BOARD)')
+	$(info Built $(VERSION) for $(BOARD))
 
 # Include common source
 COMMON_DIR=src/common
@@ -65,4 +71,4 @@ endif
 
 # Target to remove build artifacts
 clean:
-	rm -rf build
+	rm -rf $(obj)

--- a/src/arch/8051/toolchain.mk
+++ b/src/arch/8051/toolchain.mk
@@ -31,22 +31,26 @@ sim: $(BUILD)/ec.rom
 
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	objcopy -I ihex -O binary --gap-fill=0xFF $< $@
 
 # Link object files into Intel Hex file
 $(BUILD)/ec.ihx: $(OBJ)
-	@mkdir -p $(@D)
+	@echo "  LINK      $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(CC) $(LDFLAGS) -o $@ $^
 
 # Compile ASM files into object files
 $(ASM_OBJ): $(BUILD)/%.rel: src/%.asm
-	@mkdir -p $(@D)
+	@echo "  AS        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(AS) $(ASFLAGS) $@ $<
 
 # Compile C files into object files
 $(C_OBJ): $(BUILD)/%.rel: src/%.c $(INCLUDE)
-	@mkdir -p $(@D)
+	@echo "  CC        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 # Add dependency rules

--- a/src/arch/avr/toolchain.mk
+++ b/src/arch/avr/toolchain.mk
@@ -19,22 +19,26 @@ sim: $(BUILD)/ec.elf
 
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(OBJCOPY) -I ihex -O binary --gap-fill 0xFF $< $@
 
 # Convert from ELF file to Intel Hex file
 $(BUILD)/ec.ihx: $(BUILD)/ec.elf
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(OBJCOPY) -j .text -j .data -O ihex $< $@
 
 # Link object files into ELF file
 $(BUILD)/ec.elf: $(OBJ)
-	@mkdir -p $(@D)
+	@echo "  LINK      $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(CC) -o $@ $^
 
 # Compile C files into object files
 $(BUILD)/%.o: src/%.c $(INCLUDE)
-	@mkdir -p $(@D)
+	@echo "  CC        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 # Add dependency rules

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -33,22 +33,26 @@ FLASH_CC=\
 
 # Convert from binary file to C header
 $(BUILD)/include/flash.h: $(FLASH_BUILD)/flash.rom
-	@mkdir -p $(@D)
+	@echo "  XXD       $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	xxd -include < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(FLASH_BUILD)/flash.rom: $(FLASH_BUILD)/flash.ihx
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	objcopy -I ihex -O binary $< $@
 
 # Link object files into Intel Hex file
 $(FLASH_BUILD)/flash.ihx: $(FLASH_OBJ)
-	@mkdir -p $(@D)
+	@echo "  LINK      $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(FLASH_CC) -o $@ $^
 
 # Compile C files into object files
 $(FLASH_OBJ): $(FLASH_BUILD)/%.rel: src/%.c $(FLASH_INCLUDE)
-	@mkdir -p $(@D)
+	@echo "  CC        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(FLASH_CC) $(FLASH_CFLAGS) -o $@ -c $<
 
 # Include flash header in main firmware

--- a/src/board/system76/common/scratch/scratch.mk
+++ b/src/board/system76/common/scratch/scratch.mk
@@ -32,22 +32,26 @@ SCRATCH_CC=\
 
 # Convert from binary file to C header
 $(BUILD)/include/scratch.h: $(SCRATCH_BUILD)/scratch.rom
-	@mkdir -p $(@D)
+	@echo "  XXD       $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	xxd -include < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(SCRATCH_BUILD)/scratch.rom: $(SCRATCH_BUILD)/scratch.ihx
-	@mkdir -p $(@D)
+	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	objcopy -I ihex -O binary $< $@
 
 # Link object files into Intel Hex file
 $(SCRATCH_BUILD)/scratch.ihx: $(SCRATCH_OBJ)
-	@mkdir -p $(@D)
+	@echo "  LINK      $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(SCRATCH_CC) -o $@ $^
 
 # Compile C files into object files
 $(SCRATCH_OBJ): $(SCRATCH_BUILD)/%.rel: src/%.c $(SCRATCH_INCLUDE)
-	@mkdir -p $(@D)
+	@echo "  CC        $(subst $(obj)/,,$@)"
+	mkdir -p $(@D)
 	$(SCRATCH_CC) $(SCRATCH_CFLAGS) -o $@ -c $<
 
 # Include scratch header in main firmware


### PR DESCRIPTION
Default to silent builds, only outputting the file being generated. This gives output similar to Linux/coreboot output when building. `VERBOSE=1` can be passed to show the actual commands.

Example output:

```
$ make BOARD=system76/lemp10
  CC        system76/lemp10/2023-01-13_7b75a7b/scratch/board/system76/common/scratch/../smfi.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/scratch/board/system76/common/scratch/main.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/scratch/board/system76/common/scratch/stdio.rel
  LINK      system76/lemp10/2023-01-13_7b75a7b/scratch/scratch.ihx
  OBJCOPY   system76/lemp10/2023-01-13_7b75a7b/scratch/scratch.rom
  XXD       system76/lemp10/2023-01-13_7b75a7b/include/scratch.h
  CC        system76/lemp10/2023-01-13_7b75a7b/flash/board/system76/common/flash/main.rel
  LINK      system76/lemp10/2023-01-13_7b75a7b/flash/flash.ihx
  OBJCOPY   system76/lemp10/2023-01-13_7b75a7b/flash/flash.rom
  XXD       system76/lemp10/2023-01-13_7b75a7b/include/flash.h
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/main.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/arch/8051/arch.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/arch/8051/delay.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/arch/8051/time.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/acpi.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/battery.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/charger/bq24780s.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/config.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/dgpu.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/ecpm.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/espi.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/fan.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/flash/wrapper.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/gctrl.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/kbc.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/kbled.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/kbled/white_dac.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/kbscan.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/keymap.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/lid.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/parallel.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/peci.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/pmc.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/pnp.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/power.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/ps2.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/pwm.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/scratch.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/smbus.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/smfi.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/stdio.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/common/wireless.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/lemp10/board.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/board/system76/lemp10/gpio.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/common/i2c.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/common/keymap.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/common/version.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/ec/ite/ec.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/ec/ite/espi.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/ec/ite/gpio.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/ec/ite/i2c.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/ec/ite/kbc.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/ec/ite/pmc.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/ec/ite/ps2.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/ec/ite/signature.rel
  CC        system76/lemp10/2023-01-13_7b75a7b/keyboard/system76/14in_83/keymap/default.rel
  LINK      system76/lemp10/2023-01-13_7b75a7b/ec.ihx
  OBJCOPY   system76/lemp10/2023-01-13_7b75a7b/ec.rom
Built 2023-01-13_7b75a7b for system76/lemp10
```