### PR TITLE
Move gpio_debug from board to EC code

### DIFF
--- a/src/board/system76/addw1/gpio.c
+++ b/src/board/system76/addw1/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 6);
@@ -239,40 +239,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/addw1/include/board/gpio.h
+++ b/src/board/system76/addw1/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/addw2/gpio.c
+++ b/src/board/system76/addw2/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -243,40 +243,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/addw2/include/board/gpio.h
+++ b/src/board/system76/addw2/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/bonw14/gpio.c
+++ b/src/board/system76/bonw14/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -237,40 +237,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/bonw14/include/board/gpio.h
+++ b/src/board/system76/bonw14/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -90,7 +90,7 @@ void main(void) {
 
     INFO("\n");
 
-#if GPIO_DEBUG
+#ifdef GPIO_DEBUG
     gpio_debug();
 #endif
 

--- a/src/board/system76/darp5/gpio.c
+++ b/src/board/system76/darp5/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 6);
@@ -239,40 +239,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/darp5/include/board/gpio.h
+++ b/src/board/system76/darp5/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -248,43 +247,3 @@ void gpio_init() {
     // ALERT#
     GPCRM6 = 0x86;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d: data %d mirror %d pot %d control %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#define GPOTM 0
-    bank(M);
-#undef GPOTM
-#undef bank
-}
-#endif

--- a/src/board/system76/darp7/include/board/gpio.h
+++ b/src/board/system76/darp7/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/darp8/gpio.c
+++ b/src/board/system76/darp8/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -255,43 +254,3 @@ void gpio_init(void) {
     // ESPI_ALRT0#
     GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d: data %d mirror %d pot %d control %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#define GPOTM 0
-    bank(M);
-#undef GPOTM
-#undef bank
-}
-#endif

--- a/src/board/system76/darp8/include/board/gpio.h
+++ b/src/board/system76/darp8/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/galp3-c/gpio.c
+++ b/src/board/system76/galp3-c/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 6);
@@ -239,40 +239,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/galp3-c/include/board/gpio.h
+++ b/src/board/system76/galp3-c/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -250,43 +249,3 @@ void gpio_init() {
     // ALERT#
     GPCRM6 = GPIO_IN | GPIO_UP;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d: data %d mirror %d pot %d control %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#define GPOTM 0
-    bank(M);
-#undef GPOTM
-#undef bank
-}
-#endif

--- a/src/board/system76/galp5/include/board/gpio.h
+++ b/src/board/system76/galp5/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -259,43 +258,3 @@ void gpio_init(void) {
     // ESPI_ALRT0#
     GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d: data %d mirror %d pot %d control %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#define GPOTM 0
-    bank(M);
-#undef GPOTM
-#undef bank
-}
-#endif

--- a/src/board/system76/galp6/include/board/gpio.h
+++ b/src/board/system76/galp6/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/gaze15/gpio.c
+++ b/src/board/system76/gaze15/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -238,40 +238,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/gaze15/include/board/gpio.h
+++ b/src/board/system76/gaze15/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/gaze16-3050/gpio.c
+++ b/src/board/system76/gaze16-3050/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -243,40 +243,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_IN | GPIO_UP;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/gaze16-3050/include/board/gpio.h
+++ b/src/board/system76/gaze16-3050/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;

--- a/src/board/system76/gaze16-3060/gpio.c
+++ b/src/board/system76/gaze16-3060/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -243,40 +243,3 @@ void gpio_init() {
     // ESPI_ALRT0#
     GPCRM6 = GPIO_IN | GPIO_UP;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/gaze16-3060/include/board/gpio.h
+++ b/src/board/system76/gaze16-3060/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -241,40 +241,3 @@ void gpio_init() {
     // ESPI_ALRT0#
     GPCRM6 = GPIO_IN | GPIO_UP;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/gaze17-3050/include/board/gpio.h
+++ b/src/board/system76/gaze17-3050/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -247,40 +247,3 @@ void gpio_init() {
     // ESPI_ALRT0#
     GPCRM6 = GPIO_IN | GPIO_UP;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/gaze17-3060/include/board/gpio.h
+++ b/src/board/system76/gaze17-3060/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;

--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -247,43 +246,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d: data %d mirror %d pot %d control %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#define GPOTM 0
-    bank(M);
-#undef GPOTM
-#undef bank
-}
-#endif

--- a/src/board/system76/lemp10/include/board/gpio.h
+++ b/src/board/system76/lemp10/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/lemp11/gpio.c
+++ b/src/board/system76/lemp11/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -259,43 +258,3 @@ void gpio_init(void) {
     // ESPI_ALRT0#
     GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d: data %d mirror %d pot %d control %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#define GPOTM 0
-    bank(M);
-#undef GPOTM
-#undef bank
-}
-#endif

--- a/src/board/system76/lemp11/include/board/gpio.h
+++ b/src/board/system76/lemp11/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/lemp9/gpio.c
+++ b/src/board/system76/lemp9/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -237,40 +237,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/lemp9/include/board/gpio.h
+++ b/src/board/system76/lemp9/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/oryp5/gpio.c
+++ b/src/board/system76/oryp5/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 6);
@@ -244,40 +244,3 @@ void gpio_init(void) {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/oryp5/include/board/gpio.h
+++ b/src/board/system76/oryp5/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/oryp6/gpio.c
+++ b/src/board/system76/oryp6/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -242,40 +241,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/oryp6/include/board/gpio.h
+++ b/src/board/system76/oryp6/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/oryp7/gpio.c
+++ b/src/board/system76/oryp7/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -241,40 +240,3 @@ void gpio_init() {
     // SERIRQ
     GPCRM6 = GPIO_ALT;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/oryp7/include/board/gpio.h
+++ b/src/board/system76/oryp7/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/board/system76/oryp8/gpio.c
+++ b/src/board/system76/oryp8/gpio.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
+#include <common/macro.h>
 
 // clang-format off
 struct Gpio __code ACIN_N =         GPIO(B, 0);
@@ -243,40 +243,3 @@ void gpio_init() {
     // SERIRQ_ESPI_ALERT0
     GPCRM6 = GPIO_IN | GPIO_UP;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d:\n\tdata %d\n\tmirror %d\n\tpot %d\n\tcontrol %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#undef bank
-}
-#endif

--- a/src/board/system76/oryp8/include/board/gpio.h
+++ b/src/board/system76/oryp8/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 extern struct Gpio __code ACIN_N;
 extern struct Gpio __code AC_PRESENT;

--- a/src/board/system76/oryp9/gpio.c
+++ b/src/board/system76/oryp9/gpio.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <board/gpio.h>
-#include <common/debug.h>
 #include <common/macro.h>
 
 // clang-format off
@@ -258,43 +257,3 @@ void gpio_init(void) {
     // ESPI_ALRT0#
     GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
 }
-
-#if GPIO_DEBUG
-void gpio_debug_bank(
-    char *bank,
-    uint8_t data,
-    uint8_t mirror,
-    uint8_t pot,
-    volatile uint8_t *control
-) {
-    for (char i = 0; i < 8; i++) {
-        DEBUG(
-            "%s%d: data %d mirror %d pot %d control %02X\n",
-            bank,
-            i,
-            (data >> i) & 1,
-            (mirror >> i) & 1,
-            (pot >> i) & 1,
-            *(control + i)
-        );
-    }
-}
-
-void gpio_debug(void) {
-#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
-    bank(A);
-    bank(B);
-    bank(C);
-    bank(D);
-    bank(E);
-    bank(F);
-    bank(G);
-    bank(H);
-    bank(I);
-    bank(J);
-#define GPOTM 0
-    bank(M);
-#undef GPOTM
-#undef bank
-}
-#endif

--- a/src/board/system76/oryp9/include/board/gpio.h
+++ b/src/board/system76/oryp9/include/board/gpio.h
@@ -6,7 +6,6 @@
 #include <ec/gpio.h>
 
 void gpio_init(void);
-void gpio_debug(void);
 
 // clang-format off
 extern struct Gpio __code ACIN_N;

--- a/src/ec/ite/gpio.c
+++ b/src/ec/ite/gpio.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <ec/gpio.h>
+#include <common/debug.h>
 
 bool gpio_get(struct Gpio *gpio) {
     if (*(gpio->data) & gpio->value) {
@@ -17,3 +18,43 @@ void gpio_set(struct Gpio *gpio, bool value) {
         *(gpio->data) &= ~(gpio->value);
     }
 }
+
+#ifdef GPIO_DEBUG
+static void gpio_debug_bank(
+    char *bank,
+    uint8_t data,
+    uint8_t mirror,
+    uint8_t pot,
+    volatile uint8_t *control
+) {
+    for (char i = 0; i < 8; i++) {
+        DEBUG(
+            "%s%d: data %d mirror %d pot %d control %02X\n",
+            bank,
+            i,
+            (data >> i) & 1,
+            (mirror >> i) & 1,
+            (pot >> i) & 1,
+            *(control + i)
+        );
+    }
+}
+
+void gpio_debug(void) {
+#define bank(BANK) gpio_debug_bank(#BANK, GPDR##BANK, GPDMR##BANK, GPOT##BANK, &GPCR##BANK##0)
+    bank(A);
+    bank(B);
+    bank(C);
+    bank(D);
+    bank(E);
+    bank(F);
+    bank(G);
+    bank(H);
+    bank(I);
+    bank(J);
+#define GPOTM 0
+    bank(M);
+#undef GPOTM
+#undef bank
+}
+#endif // GPIO_DEBUG

--- a/src/ec/ite/include/ec/gpio.h
+++ b/src/ec/ite/include/ec/gpio.h
@@ -35,6 +35,10 @@ struct Gpio {
 bool gpio_get(struct Gpio *gpio);
 void gpio_set(struct Gpio *gpio, bool value);
 
+#ifdef GPIO_DEBUG
+void gpio_debug(void);
+#endif
+
 volatile uint8_t __xdata __at(0x1600) GCR;
 volatile uint8_t __xdata __at(0x16F0) GCR1;
 volatile uint8_t __xdata __at(0x16F1) GCR2;


### PR DESCRIPTION
The `gpio_debug()` functionality depends on the ITE registers and not anything board-specific.