### PR TITLE
Remove PMC hack for S0ix

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -19,8 +19,6 @@ extern uint8_t sci_extra;
 
 enum EcOs acpi_ecos = EC_OS_NONE;
 
-extern bool pmc_s0_hack;
-
 static uint8_t fcmd = 0;
 static uint8_t fdat = 0;
 static uint8_t fbuf[4] = { 0, 0, 0, 0 };
@@ -136,8 +134,6 @@ uint8_t acpi_read(uint8_t addr) {
 
         case 0x68:
             data = acpi_ecos;
-            // HACK: Kick PMC to fix suspend on lemp11
-            pmc_s0_hack = true;
             break;
 
         case 0xBC:

--- a/src/board/system76/common/pmc.c
+++ b/src/board/system76/common/pmc.c
@@ -9,12 +9,6 @@
 #include <common/debug.h>
 #include <ec/espi.h>
 
-#ifndef PMC_S0IX_HACK
-#define PMC_S0IX_HACK 0
-#endif
-
-bool pmc_s0_hack = false;
-
 void pmc_init(void) {
     *(PMC_1.control) = 0x41;
     *(PMC_2.control) = 0x41;
@@ -187,36 +181,8 @@ static void pmc_on_output_empty(struct Pmc *pmc) {
     }
 }
 
-#if PMC_S0IX_HACK
-// HACK: Kick PMC to fix suspend on lemp11
-static void pmc_hack(void) {
-    static bool pmc_s0_hack2 = false;
-    static uint32_t last_time = 0;
-    // Get time the system requested S0ix (ACPI MS0X)
-    if (pmc_s0_hack) {
-        last_time = time_get();
-        pmc_s0_hack = false;
-        pmc_s0_hack2 = true;
-    }
-    uint32_t time = time_get();
-    // If SLP_S0# not asserted after 5 seconds, apply the hack
-    if ((time - last_time) >= 5000) {
-        if (pmc_s0_hack2 && gpio_get(&SLP_S0_N)) {
-            DEBUG("FIXME: PMC HACK\n");
-            pmc_sci(&PMC_1, 0x50);
-        }
-        pmc_s0_hack2 = false;
-        last_time = time;
-    }
-}
-#else
-static void pmc_hack(void) {}
-#endif
-
 void pmc_event(struct Pmc *pmc) {
     uint8_t sts;
-
-    pmc_hack();
 
     // Read command/data if available
     sts = pmc_status(pmc);

--- a/src/board/system76/darp8/board.mk
+++ b/src/board/system76/darp8/board.mk
@@ -11,8 +11,6 @@ CONFIG_BUS_ESPI=y
 
 # Use S0ix
 CFLAGS+=-DUSE_S0IX=1
-# Apply PMC hack for S0ix
-CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/galp6/board.mk
+++ b/src/board/system76/galp6/board.mk
@@ -11,8 +11,6 @@ CONFIG_BUS_ESPI=y
 
 # Use S0ix
 CFLAGS+=-DUSE_S0IX=1
-# Apply PMC hack for S0ix
-CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=14in_83

--- a/src/board/system76/gaze17-3050/board.mk
+++ b/src/board/system76/gaze17-3050/board.mk
@@ -11,8 +11,6 @@ CONFIG_BUS_ESPI=y
 
 # FIXME: Use S3 instead of S0ix
 CFLAGS+=-DUSE_S0IX=1
-# Apply PMC hack for S0ix
-CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/gaze17-3060/board.mk
+++ b/src/board/system76/gaze17-3060/board.mk
@@ -11,8 +11,6 @@ CONFIG_BUS_ESPI=y
 
 # FIXME: Use S3 instead of S0ix
 CFLAGS+=-DUSE_S0IX=1
-# Apply PMC hack for S0ix
-CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/lemp11/board.mk
+++ b/src/board/system76/lemp11/board.mk
@@ -11,8 +11,6 @@ CONFIG_BUS_ESPI=y
 
 # Use S0ix
 CFLAGS+=-DUSE_S0IX=1
-# Apply PMC hack for S0ix
-CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=14in_83

--- a/src/board/system76/oryp9/board.mk
+++ b/src/board/system76/oryp9/board.mk
@@ -11,8 +11,6 @@ CONFIG_BUS_ESPI=y
 
 # FIXME: Use S3 instead of S0ix
 CFLAGS+=-DUSE_S0IX=1
-# Apply PMC hack for S0ix
-CFLAGS+=-DPMC_S0IX_HACK=1
 
 # Include keyboard
 KEYBOARD=15in_102


### PR DESCRIPTION
Whatever the issue was appears to be fixed after rebasing coreboot on the 4.19 release. lemp11 has successfully reached S0ix with `SLP_S0#` asserted when booted on battery power for 100 cycles.

Requires: https://github.com/system76/coreboot/pull/160