### PR TITLE
peci: Fix waiting for completion and error checking

### DIFF
--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -295,8 +295,8 @@ bool peci_get_temp(int16_t *data) {
     // Start transaction
     HOCTLR |= 1;
 
-    // Wait for completion
-    while (HOSTAR & 1) {}
+    // Wait for command completion
+    while (!(HOSTAR & BIT(1))) {}
 
     uint8_t status = HOSTAR;
     if (status & 0xEC) {
@@ -346,8 +346,8 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
     // Start transaction
     HOCTLR |= 1;
 
-    // Wait for completion
-    while (HOSTAR & 1) {}
+    // Wait for command completion
+    while (!(HOSTAR & BIT(1))) {}
 
     uint8_t status = HOSTAR;
     if (status & 0xEC) {

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -301,12 +301,17 @@ bool peci_get_temp(int16_t *data) {
     uint8_t status = HOSTAR;
     if (status & 0xEC) {
         ERROR("peci_get_temp: hardware error: 0x%02X\n", status);
+        // Clear status
+        HOSTAR = HOSTAR;
         return false;
     } else {
         // Read two byte temperature data if finished successfully
         uint8_t low = HORDDR;
         uint8_t high = HORDDR;
         *data = (((int16_t)high << 8) | (int16_t)low);
+
+        // Clear status
+        HOSTAR = HOSTAR;
         return true;
     }
 }
@@ -352,10 +357,15 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
     uint8_t status = HOSTAR;
     if (status & 0xEC) {
         ERROR("peci_wr_pkg_config: hardware error: 0x%02X\n", status);
+        // Clear status
+        HOSTAR = HOSTAR;
         return -(0x1000 | status);
     }
 
     uint8_t cc = HORDDR;
+
+    // Clear status
+    HOSTAR = HOSTAR;
 
     if (cc == 0x40) {
         TRACE("peci_wr_pkg_config: command successful\n");

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -318,15 +318,7 @@ static bool power_peci_limit(bool ac) {
     // Set PL4 using PECI
     int16_t res = peci_wr_pkg_config(60, 0, ((uint32_t)watts) * 8);
     DEBUG("power_peci_limit %d = %d\n", watts, res);
-    if (res == 0x40) {
-        return true;
-    } else if (res < 0) {
-        ERROR("power_peci_limit failed: 0x%02X\n", -res);
-        return false;
-    } else {
-        ERROR("power_peci_limit unknown response: 0x%02X\n", res);
-        return false;
-    }
+    return res == 0x40;
 }
 
 // Set the power draw limit depending on if on AC or DC power


### PR DESCRIPTION
- Check `FINISH` instead of `HOBY` for command completion
- Check hardware error bits (2, 3, 5, 6, 7) for hardware error
- Clear the status after command completion
- Log `WrPkgConfig()` errors in peci instead of power

TODO:

- Check if `peci_wr_pkg_config` error still happens when booting on battery power