### PR TITLE
Only use PECI over eSPI on oryp11

### DIFF
--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -52,6 +52,11 @@ PROGRAMMER=$(wildcard /dev/serial/by-id/usb-Arduino*)
 
 ifeq ($(CONFIG_BUS_ESPI),y)
 CFLAGS += -DCONFIG_BUS_ESPI=1
+
+# TODO: Use PECI over eSPI on all boards using eSPI
+ifeq ($(CONFIG_PECI_OVER_ESPI),y)
+CFLAGS += -DCONFIG_PECI_OVER_ESPI=1
+endif
 endif
 
 # Include system76 common source

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -60,7 +60,7 @@ static struct Fan __code FAN = {
     .interpolate = SMOOTH_FANS != 0,
 };
 
-#if CONFIG_BUS_ESPI
+#if CONFIG_PECI_OVER_ESPI
 
 // Maximum OOB channel response time in ms
 #define PECI_ESPI_TIMEOUT 10
@@ -254,7 +254,10 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
     }
 }
 
-#else // CONFIG_BUS_ESPI
+#else // CONFIG_PECI_OVER_ESPI
+
+// Legacy PECI implementation; requires a dedicated PECI pin connected to the
+// PCH and EC (H_PECI).
 
 void peci_init(void) {
     // Allow PECI pin to be used
@@ -380,7 +383,7 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
     return -((int16_t)cc);
 }
 
-#endif // CONFIG_BUS_ESPI
+#endif // CONFIG_PECI_OVER_ESPI
 
 // PECI information can be found here: https://www.intel.com/content/dam/www/public/us/en/documents/design-guides/core-i7-lga-2011-guide.pdf
 uint8_t peci_get_fan_duty(void) {

--- a/src/board/system76/oryp11/board.mk
+++ b/src/board/system76/oryp11/board.mk
@@ -8,6 +8,8 @@ CONFIG_EC_ITE_IT5570E=y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y
+# Use PECI over eSPI
+CONFIG_PECI_OVER_ESPI=y
 
 # Enable firmware security
 CONFIG_SECURITY=y


### PR DESCRIPTION
Make all boards except oryp11 use the legacy PECI implementation. The oryp11 removed the legacy pin (`H_PECI`) and must use PECI over eSPI.

All boards that use eSPI should switch to using PECI over eSPI once the implementation is working correctly.