### PR TITLE
Increase Oryp8 CPU Battery power limit to 45W

### DIFF
--- a/src/board/system76/oryp8/board.mk
+++ b/src/board/system76/oryp8/board.mk
@@ -35,7 +35,7 @@ CFLAGS+=\
 # Set CPU power limits in watts
 CFLAGS+=\
 	-DPOWER_LIMIT_AC=180 \
-	-DPOWER_LIMIT_DC=28
+	-DPOWER_LIMIT_DC=45
 
 # Don't smooth fan speed changes below 25% to mitigate buzzing
 CFLAGS+=-DSMOOTH_FANS_MIN=25


### PR DESCRIPTION
This massively improves system responsiveness (CPU can now run at 2.1Ghz constantly rather than locked at 1.5Ghz when on battery), does not put the laptop in a current overdraw situation resulting in the system powering off like mentioned in #331 