### PR TITLE
galp6,galp7: Enable firmware security

### DIFF
--- a/src/board/system76/galp6/board.mk
+++ b/src/board/system76/galp6/board.mk
@@ -9,6 +9,9 @@ CONFIG_EC_ITE_IT5570E=y
 # Enable eSPI
 CONFIG_BUS_ESPI=y
 
+# Enable firmware security
+CONFIG_SECURITY=y
+
 # Include keyboard
 KEYBOARD=14in_83
 


### PR DESCRIPTION
Enable firmware security for galp7. Because the board is shared with galp6, that gets enabled as well.