### PR TITLE
kbled: Add a "step" function for BKL hotkey

### DIFF
--- a/src/board/system76/common/include/board/kbled.h
+++ b/src/board/system76/common/include/board/kbled.h
@@ -19,5 +19,6 @@ void kbled_hotkey_color(void);
 void kbled_hotkey_down(void);
 void kbled_hotkey_up(void);
 void kbled_hotkey_toggle(void);
+void kbled_hotkey_step(void);
 
 #endif // _BOARD_KBLED_H

--- a/src/board/system76/common/kbled.c
+++ b/src/board/system76/common/kbled.c
@@ -5,14 +5,26 @@
 
 // clang-format off
 static uint8_t LEVEL_I = 1;
+#ifdef KBLED_DAC
 static const uint8_t __code LEVELS[] = {
+    0,
+    128,
+    144,
+    168,
+    192,
+    255,
+};
+#else
+static const uint8_t __code LEVELS[] = {
+    0,
     48,
     72,
     96,
     144,
     192,
-    255
+    255,
 };
+#endif
 
 static uint8_t COLOR_I = 0;
 static const uint32_t __code COLORS[] = {
@@ -55,4 +67,14 @@ void kbled_hotkey_toggle(void) {
     } else {
         kbled_set(0);
     }
+}
+
+// Change the backlight level to the next value, cycling through "off".
+void kbled_hotkey_step(void) {
+    if (LEVEL_I < (ARRAY_SIZE(LEVELS) - 1)) {
+        LEVEL_I += 1;
+    } else {
+        LEVEL_I = 0;
+    }
+    kbled_set(LEVELS[LEVEL_I]);
 }

--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -175,7 +175,7 @@ static void hardware_hotkey(uint16_t key) {
         fan_max = !fan_max;
         break;
     case K_KBD_BKL:
-        kbled_set(kbled_get() + 1);
+        kbled_hotkey_step();
         break;
     case K_KBD_COLOR:
         if (acpi_ecos != EC_OS_FULL)


### PR DESCRIPTION
Replace the get+set logic with a step function to change the backlight level for `K_KBD_BKL`.

Keyboards using a DAC have a different set of levels due to the brightness difference between the keyboards.

NOTE: This introduces 0 as a level, meaning that the decicated "backlight down" key on the 15" keyboards with keypads can now turn off the backlight at the lowest level.