### PR TITLE
galp{6,7}: Reduce PL4 on AC to 65W

### DIFF
--- a/src/board/system76/galp6/board.mk
+++ b/src/board/system76/galp6/board.mk
@@ -37,7 +37,7 @@ CFLAGS+=\
 
 # Set CPU power limits in watts
 CFLAGS+=\
-	-DPOWER_LIMIT_AC=90 \
+	-DPOWER_LIMIT_AC=65 \
 	-DPOWER_LIMIT_DC=45
 
 # Add system76 common code


### PR DESCRIPTION
Reduce PL4 to the same value as other non-GPU units, even though the galp7 has an H series CPU.