### PR TITLE
Fix keyboard skipping 'o' on lemp11

### DIFF
--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -58,7 +58,7 @@ void kbscan_init(void) {
 }
 
 // Debounce time in milliseconds
-#define DEBOUNCE_DELAY 15
+#define DEBOUNCE_DELAY 3
 
 static uint8_t kbscan_get_row(uint8_t i) {
     // Report all keys as released when lid is closed


### PR DESCRIPTION
## Summary

I had an issue on my Lemur Pro 11 where the keyboard was skipping the o when typing fast for every word that ended in "sion". 

This issue is well documented in support ticket 123465 

I played around with different debounce values. I don't fully understand the logic but when I disabled debouncing caused by ghost keys (see https://github.com/system76/ec/issues/58#issuecomment-1566973105) I got the occasional ghost key (eg 'version' comes out as 'vers5ion')

The perfect compromise seems to be (from my tests) a low debounce value such as 3ms. Now I can type perfectly without ghost keys or missed keys.

## Resume from suspend issue 1
I first tried flashing with the current master (82f091ef55e0a921c23c59f460eee27414484de0) and resume from suspend broke: it worked normally most of the time but on some occasions the laptop didn't resume: upon attempting a resume, the screen remained off, LED solid green, no keyboard combos work and holding the power button didn't do anything either, I had to disconnect the battery.

Then I went back to ef6ea32c374d6b1a6e59df0f67a07bfb7de9e002 - this time, **the laptop did not suspend AT ALL**.

Then I went back to e032c5f0f216dfa5a88aa105f8669d81206f18b9 and now the laptop seems to be functioning flawlessly.

I always performed internal flashing via `make BOARD=system76/lemp11 internal_flash`