### PR TITLE
scripts: Disable showing signature when getting date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all:
 	@exit 1
 else
 # Calculate version
-DATE=$(shell git show --format="%cd" --date="format:%Y-%m-%d" --no-patch)
+DATE=$(shell git show --format="%cd" --date="format:%Y-%m-%d" --no-patch --no-show-signature)
 REV=$(shell git describe --abbrev=7 --always --dirty)
 VERSION?=$(DATE)_$(REV)
 


### PR DESCRIPTION
Fixes building when `log.showSignature` is enabled.

See also: https://github.com/system76/firmware-open/pull/423