### PR TITLE
kbscan: Switch from GPIO mode to KBS (Normal) mode

### DIFF
--- a/src/board/system76/addw1/gpio.c
+++ b/src/board/system76/addw1/gpio.c
@@ -105,11 +105,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_OUT;
     // KB-SO16
-    GPCRC3 = GPIO_IN | GPIO_UP;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#_EC
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN | GPIO_UP;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/addw2/gpio.c
+++ b/src/board/system76/addw2/gpio.c
@@ -114,11 +114,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#_EC
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/addw3/gpio.c
+++ b/src/board/system76/addw3/gpio.c
@@ -128,11 +128,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT | GPIO_UP;
     // KB_SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB_SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // BKL_EN

--- a/src/board/system76/bonw14/gpio.c
+++ b/src/board/system76/bonw14/gpio.c
@@ -106,11 +106,11 @@ void gpio_init() {
     // KBC_SMBus_DAT1
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/bonw15/gpio.c
+++ b/src/board/system76/bonw15/gpio.c
@@ -131,11 +131,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT | GPIO_UP;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PLVDD_RST_EC
     GPCRC6 = GPIO_OUT;
     // BKL_EN

--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -103,26 +103,10 @@ static inline bool popcount_more_than_one(uint8_t rowdata) {
     return rowdata & (rowdata - 1);
 }
 
-static uint8_t kbscan_get_real_keys(uint8_t row, uint8_t rowdata) {
-    // Remove any "active" blanks from the matrix.
-    uint8_t realdata = 0;
-    for (uint8_t col = 0; col < KM_IN; col++) {
-        // This tests the default keymap intentionally, to avoid blanks in the
-        // dynamic keymap
-        if (KEYMAP[0][row][col] && (rowdata & BIT(col))) {
-            realdata |= BIT(col);
-        }
-    }
-
-    return realdata;
-}
-
 static bool kbscan_row_has_ghost(uint8_t *matrix, uint8_t col) {
     uint8_t rowdata = matrix[col];
 
-    rowdata = kbscan_get_real_keys(col, matrix[col]);
-
-    // No ghosts exist when  less than 2 keys in the row are active.
+    // No ghosts exist when less than 2 keys in the row are active.
     if (!popcount_more_than_one(rowdata)) {
         return false;
     }
@@ -133,8 +117,7 @@ static bool kbscan_row_has_ghost(uint8_t *matrix, uint8_t col) {
             continue;
         }
 
-        uint8_t otherrow = kbscan_get_real_keys(i, matrix[i]);
-        uint8_t common = rowdata & otherrow;
+        uint8_t common = rowdata & matrix[i];
         if (popcount_more_than_one(common)) {
             return true;
         }

--- a/src/board/system76/darp5/gpio.c
+++ b/src/board/system76/darp5/gpio.c
@@ -105,11 +105,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KSO16 (Darter)
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_OUT;
     // KSO17 (Darter)
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -118,11 +118,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT | GPIO_UP;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/darp8/gpio.c
+++ b/src/board/system76/darp8/gpio.c
@@ -120,11 +120,11 @@ void gpio_init(void) {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT | GPIO_UP;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // Not connected
     GPCRC6 = GPIO_IN | GPIO_DOWN;
     // LED_ACIN

--- a/src/board/system76/galp3-c/gpio.c
+++ b/src/board/system76/galp3-c/gpio.c
@@ -104,11 +104,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_IN | GPIO_UP;
     // KSO16 (Darter)
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_OUT;
     // KSO17 (Darter)
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/gaze15/gpio.c
+++ b/src/board/system76/gaze15/gpio.c
@@ -109,11 +109,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#_EC
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/gaze16-3050/gpio.c
+++ b/src/board/system76/gaze16-3050/gpio.c
@@ -114,11 +114,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // EC_SYS_PWROK
     GPCRC6 = GPIO_OUT;
     // BKL_EN

--- a/src/board/system76/gaze16-3060/gpio.c
+++ b/src/board/system76/gaze16-3060/gpio.c
@@ -114,11 +114,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // EC_SYS_PWROK
     GPCRC6 = GPIO_OUT;
     // BKL_EN

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -112,11 +112,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT | GPIO_UP;
     // KB_SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB_SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // CPU_C10_GATE#
     GPCRC6 = GPIO_IN;
     // BKL_EN

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -118,11 +118,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT | GPIO_UP;
     // KB_SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB_SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PCH_PWROK_EC
     GPCRC6 = GPIO_OUT;
     // BKL_EN

--- a/src/board/system76/oryp11/gpio.c
+++ b/src/board/system76/oryp11/gpio.c
@@ -131,11 +131,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT | GPIO_UP;
     // KB_SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB_SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // SYS_PWROK_EC
     GPCRC6 = GPIO_OUT;
     // BKL_EN

--- a/src/board/system76/oryp5/gpio.c
+++ b/src/board/system76/oryp5/gpio.c
@@ -102,11 +102,11 @@ void gpio_init(void) {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_WIGIG_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/oryp6/gpio.c
+++ b/src/board/system76/oryp6/gpio.c
@@ -112,11 +112,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/oryp7/gpio.c
+++ b/src/board/system76/oryp7/gpio.c
@@ -111,11 +111,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PM_PWROK
     GPCRC6 = GPIO_OUT;
     // LED_ACIN

--- a/src/board/system76/oryp8/gpio.c
+++ b/src/board/system76/oryp8/gpio.c
@@ -114,11 +114,11 @@ void gpio_init() {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PCH_PWROK_EC
     GPCRC6 = GPIO_OUT;
     // BKL_EN

--- a/src/board/system76/oryp9/gpio.c
+++ b/src/board/system76/oryp9/gpio.c
@@ -123,11 +123,11 @@ void gpio_init(void) {
     // SMD_VGA_THERM
     GPCRC2 = GPIO_ALT | GPIO_UP;
     // KB-SO16
-    GPCRC3 = GPIO_IN;
+    GPCRC3 = GPIO_ALT | GPIO_UP;
     // CNVI_DET#
     GPCRC4 = GPIO_IN | GPIO_UP;
     // KB-SO17
-    GPCRC5 = GPIO_IN;
+    GPCRC5 = GPIO_ALT | GPIO_UP;
     // PCH_PWROK_EC
     GPCRC6 = GPIO_OUT;
     // BKL_EN


### PR DESCRIPTION
Use the default mode for reading the keyboard scan matrix when being used as a keyboard. There should be no perceived change in behavior, but should make the code easier to understand.

Note: `KSO[17:16]` are configured by `GPRCRC` on boards that use them. They are now set to alternate function to use in KBS mode rather than GPIO mode, with the pull-up enabled to prevent them from floating when configured as open-drain.

As part of this change, we now only read the hardware matrix state once upfront, instead of on every iteration through the loop applying the logic.

Tested by cherry-picking to darp9 and verifying that typing still worked.

Need to test:

- [x] Wake from sleep on keyboard input
- [x] bonw14 (n-key rollover), but I don't think that has successfully booted on newer firmware in a while
- [x] the 14" keyboards
- [x] External debugging still works
- [x] typing *really fast*

TODO:

- [x] Don't re-read hardware state after initial scan (`kbscan_row_has_ghost()`)
- [x] Check if `kbscan_get_real_keys()` is even needed
  - I don't notice any difference