### PR TITLE
darp9: Set CC_EN high

### DIFF
--- a/src/board/system76/darp9/gpio.c
+++ b/src/board/system76/darp9/gpio.c
@@ -70,8 +70,8 @@ void gpio_init(void) {
     GPDRD = BIT(5);
     // USB_PWR_EN
     GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
+    // CC_EN, H_PECI
+    GPDRF = BIT(7) | BIT(6);
     // H_PROCHOT_EC#
     GPDRG = BIT(6);
     GPDRH = 0;


### PR DESCRIPTION
Fixes using the non-TBT USB-C port.