### PR TITLE
Pad binary file to total flash size

### DIFF
--- a/src/arch/8051/toolchain.mk
+++ b/src/arch/8051/toolchain.mk
@@ -33,7 +33,7 @@ sim: $(BUILD)/ec.rom
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
 	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
 	mkdir -p $(@D)
-	objcopy -I ihex -O binary --gap-fill=0xFF $< $@
+	objcopy -I ihex -O binary --gap-fill=0xFF --pad-to=$(CONFIG_EC_FLASH_SIZE) $< $@
 
 # Link object files into Intel Hex file
 $(BUILD)/ec.ihx: $(OBJ)

--- a/src/ec/ite/ec.mk
+++ b/src/ec/ite/ec.mk
@@ -27,3 +27,6 @@ ARCH=8051
 
 # 64 KB is the max without banking
 CODE_SIZE=65536
+
+# Total flash size: 128 KiB
+CONFIG_EC_FLASH_SIZE = 131072


### PR DESCRIPTION
Ensure ROMs are the exact size of the flash device.