### PR TITLE
kbscan: Reduce debounce time from 15ms to 5ms

### DIFF
--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -58,7 +58,7 @@ void kbscan_init(void) {
 }
 
 // Debounce time in milliseconds
-#define DEBOUNCE_DELAY 15
+#define DEBOUNCE_DELAY 5
 
 static uint8_t kbscan_get_row(uint8_t i) {
     // Report all keys as released when lid is closed


### PR DESCRIPTION
Allows increased typing speed while avoiding repeating keys due to contact bounce and keys being rejected by ghost key detection.

This is also the default value for QMK.

Replaces: #359