### PR TITLE
power: Set `XLP_OUT` at power off

### DIFF
--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -317,6 +317,11 @@ void power_off(void) {
     // Configure WLAN GPIOs after powering off
     wireless_power(false);
 
+#if HAVE_XLP_OUT
+    // Power off VDD3
+    gpio_set(&XLP_OUT, 0);
+#endif // HAVE_XLP_OUT
+
     update_power_state();
 }
 
@@ -609,11 +614,6 @@ void power_event(void) {
             gpio_set(&LED_ACIN, !gpio_get(&LED_ACIN));
             last_time = time;
         }
-
-#if HAVE_XLP_OUT
-        // Power off VDD3 if system should be off
-        gpio_set(&XLP_OUT, 0);
-#endif // HAVE_XLP_OUT
     }
 
 //TODO: do not require both LEDs


### PR DESCRIPTION
Disable VDD3 once at power off instead of setting it every cycle in the LED update logic.