### PR TITLE
make: Remove version from build output path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ VERSION?=$(DATE)_$(REV)
 
 # Set build directory
 obj = build
-BUILD = $(obj)/$(BOARD)/$(VERSION)
+BUILD = $(obj)/$(BOARD)
 
 # Default target - build the board's EC firmware
 all: $(BUILD)/ec.rom


### PR DESCRIPTION
Support building only a single version for a model. This removes the need to determine the git commit hash and date in order to access build artifacts.