### PR TITLE
battery: Limit charging to 90% of actual capacity

### DIFF
--- a/src/board/system76/common/battery.c
+++ b/src/board/system76/common/battery.c
@@ -57,8 +57,8 @@ int16_t battery_charger_configure(void) {
     static bool should_charge = true;
 
     if (battery_get_end_threshold() == BATTERY_END_DEFAULT) {
-        // Stop threshold not configured: Always charge on AC.
-        should_charge = true;
+        // Stop threshold not configured: Charge on AC if not full.
+        should_charge = !(battery_info.status & BATTERY_FULLY_CHARGED);
     } else if (battery_info.charge > battery_get_end_threshold()) {
         // Stop threshold configured: Stop charging at threshold.
         should_charge = false;
@@ -90,6 +90,10 @@ void battery_limit_capacity(void) {
     battery_info.charge = ((uint32_t)battery_info.remaining_capacity * 100) /
         battery_info.full_capacity;
     battery_info.charge = MIN(100, battery_info.charge);
+
+    // Override status bit to lie about being fully charged
+    if (battery_info.charge == 100)
+        battery_info.status |= BATTERY_FULLY_CHARGED;
 }
 
 void battery_event(void) {

--- a/src/board/system76/common/include/board/battery.h
+++ b/src/board/system76/common/include/board/battery.h
@@ -16,6 +16,9 @@
 #define CHARGER_ADDRESS 0x09
 #endif
 
+#define BATTERY_FULLY_DISCHARGED BIT(4)
+#define BATTERY_FULLY_CHARGED BIT(5)
+#define BATTERY_DISCHARGING BIT(6)
 #define BATTERY_INITIALIZED BIT(7)
 
 struct battery_info {


### PR DESCRIPTION
Per Clevo's requirement, limit batteries to charging to 90% of their actual `FullChargeCapacity()`.