### PR TITLE
Add and use Make targets for deps/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: ./scripts/deps.sh
+        run: make install-deps
 
       - name:  Check SPDX tags
         run: ./scripts/lint/01-spdx-tags.sh
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: ./scripts/deps.sh
+        run: make install-deps
 
       - name: Build tool
         run: cargo build ${{ matrix.features }} --release --manifest-path tool/Cargo.toml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: ./scripts/deps.sh
+        run: make install-deps
 
       - name: Build firmware
         run: make BOARD=${{ matrix.boards }} VERBOSE=1

--- a/Makefile
+++ b/Makefile
@@ -88,11 +88,29 @@ list-boards:
 		echo "$$(dirname "$$board")"; \
 	done
 
-# This target is run during setup, and is not shown in the help text.
-.PHONY: git-config
-git-config:
+# Install all development dependencies
+.PHONY: install-deps
+install-deps: install-sys-deps install-rust
+
+# Install system dependencies
+.PHONY: install-sys-deps
+install-sys-deps:
+	./scripts/install-deps.sh
+
+# Install Rust via rustup
+.PHONY: install-rust
+install-rust:
+	./scripts/install-rust.sh
+
+# Install git hooks for development
+.PHONY: install-git-config
+install-git-config:
 	$(eval HOOKS = "$(shell git rev-parse --git-dir)/hooks")
 	ln -sfrv scripts/hooks/pre-commit.sh "$(HOOKS)/pre-commit"
+
+# Set up a new system for development
+.PHONY: set-up
+set-up: install-deps install-git-hooks
 
 .PHONY: help
 help:
@@ -102,4 +120,7 @@ help:
 	@echo "    clean                Remove build artifacts"
 	@echo "    fmt                  Format the source code"
 	@echo "    lint                 Run lint checks"
+	@echo "    install-deps         Install development dependencies"
+	@echo "    install-git-hooks    Install git hooks for development"
+	@echo "    set-up               Set up a new system for development"
 	@echo "    help                 Print this message"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ laptops.
 
 ## Quickstart
 
-Install dependencies using the provided script.
+Install GNU Make, then install the rest of the dependencies and set up the
+environment for development using the Make target.
 
 ```sh
-./scripts/deps.sh
+make set-up
 ```
 
 If rustup was installed as part of this, then the correct `cargo` will not be

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -9,7 +9,7 @@ Terms used:
 
 1. Install dependencies
     ```bash
-    ./scripts/deps.sh
+    make install-deps
     ```
 1. Start the console
     ```bash

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -18,7 +18,7 @@ No specific IDE or editor is required or recommended.
 EC development depends on using distro-provided packages for the most of the
 toolset.
 
-A complete list of dependencies can be seen in `scripts/deps.sh`.
+A complete list of dependencies can be seen in `scripts/install-deps.sh`.
 
 ### Cargo
 

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Install dependencies for development.
+
+# shellcheck disable=SC1091
+
 set -eE
 
 function msg {
@@ -72,26 +76,4 @@ git submodule update --init --recursive
 msg "Installing git hooks"
 make git-config
 
-RUSTUP_NEW_INSTALL=0
-if which rustup &> /dev/null; then
-    msg "Updating rustup"
-    rustup self update
-else
-    RUSTUP_NEW_INSTALL=1
-    msg "Installing Rust"
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-      | sh -s -- -y --default-toolchain none
-
-    msg "Loading Rust environment"
-    source "${HOME}/.cargo/env"
-fi
-
-msg "Installing pinned Rust toolchain and components"
-rustup show
-
-if [[ $RUSTUP_NEW_INSTALL = 1 ]]; then
-    msg "rustup was just installed. Ensure cargo is on the PATH with:"
-    echo -e "    source ~/.cargo/env\n"
-fi
-
-msg "\x1B[32mSuccessfully installed dependencies"
+./scripts/install-rust.sh

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -7,15 +7,7 @@
 
 set -eE
 
-function msg {
-  echo -e "\x1B[1m$*\x1B[0m" >&2
-}
-
-trap 'msg "\x1B[31mFailed to install dependencies!"' ERR
-
-source /etc/os-release
-
-msg "Installing system build dependencies"
+. /etc/os-release
 if [[ "${ID}" =~ "debian" ]] || [[ "${ID_LIKE}" =~ "debian" ]]; then
     sudo apt-get update
     sudo apt-get install \
@@ -65,15 +57,10 @@ elif [[ "${ID}" =~ "arch" ]] || [[ "${ID_LIKE}" =~ "arch" ]]; then
         systemd-libs \
         vim
 else
-    msg "Please add support for your distribution to:"
-    msg "scripts/deps.sh"
+    printf "\e[1m\e[31munsupported host:\e[0m %s\n" "${ID}"
     exit 1
 fi
 
-msg "Initializing submodules"
-git submodule update --init --recursive
-
-msg "Installing git hooks"
-make git-config
-
-./scripts/install-rust.sh
+if [ -z "$CI" ]; then
+    git submodule update --init --recursive
+fi

--- a/scripts/install-rust.sh
+++ b/scripts/install-rust.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-only
+
+# Install Rust via rustup, along with the pinned toolchain.
+
+# shellcheck shell=dash
+# shellcheck disable=SC1091
+
+set -Ee
+
+RUSTUP_NEW_INSTALL=0
+
+# NOTE: rustup is used to allow multiple toolchain installations.
+if command -v rustup >/dev/null 2>&1; then
+    rustup self update
+else
+    RUSTUP_NEW_INSTALL=1
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable
+
+    . "${HOME}/.cargo/env"
+fi
+
+# XXX: rustup has no command to install a toolchain from a TOML file.
+# Rely on the fact that `show` will install the default toolchain.
+rustup show
+
+if [ "$RUSTUP_NEW_INSTALL" = "1" ]; then
+    printf "\e[33m>> rustup was just installed. Ensure cargo is on the PATH with:\e[0m\n"
+    printf "    source ~/.cargo/env\n\n"
+fi


### PR DESCRIPTION
Split the single `deps.sh` script into logically separate Make targets, including installing Rust in a separate script.

Note:

- CI works because GitHub runners have a thousand things installed, GNU Make included
- Submodules also aren't needed for CI as they are not used for building