### PR TITLE
kbscan: Increase debounce time from 5ms to 10ms

### DIFF
--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -21,7 +21,7 @@
 #endif // KM_NKEY
 
 // Debounce time in milliseconds
-#define DEBOUNCE_DELAY 5
+#define DEBOUNCE_DELAY 10
 
 // Deselect all columns for reading
 #define KBSCAN_MATRIX_NONE 0xFF


### PR DESCRIPTION
Some users are reporting that a debounce time of 5ms is not enough to prevent keys from registering twice. Split the difference between the old and the new debounce times and set it to 10ms.

Ref: https://github.com/system76/firmware-open/issues/471