### PR TITLE
Fix sdcc error 283 - "function declarator with no prototype"

### DIFF
--- a/src/board/system76/common/pnp.c
+++ b/src/board/system76/common/pnp.c
@@ -41,7 +41,7 @@ void pnp_write(uint8_t reg, uint8_t data) {
     ec2i_write(0x2F, data);
 }
 
-void pnp_enable() {
+void pnp_enable(void) {
     DEBUG("Enable PNP devices\n");
 
     // Enable PMC1

--- a/src/common/include/common/version.h
+++ b/src/common/include/common/version.h
@@ -3,7 +3,7 @@
 #ifndef _COMMON_VERSION_H
 #define _COMMON_VERSION_H
 
-const char *board();
-const char *version();
+const char *board(void);
+const char *version(void);
 
 #endif // _COMMON_VERSION_H

--- a/src/common/version.c
+++ b/src/common/version.c
@@ -17,10 +17,10 @@ static const char __code VERSION[] =
     xstr(__FIRMWARE_VERSION__);
 // clang-format on
 
-const char *board() {
+const char *board(void) {
     return &BOARD[11];
 }
 
-const char *version() {
+const char *version(void) {
     return &VERSION[13];
 }


### PR DESCRIPTION
You may be using an older version, or perhaps recently set a -Werror type cflag, but the current master fails to build without this adjustment.