### PR TITLE
avr: Fix compiling with GCC 13

### DIFF
--- a/src/arch/avr/toolchain.mk
+++ b/src/arch/avr/toolchain.mk
@@ -5,7 +5,10 @@ CFLAGS += -MMD -Os -fstack-usage -Wall -Werror \
 	-Wl,--gc-sections -Wl,-u,vfprintf -lprintf_flt
 
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-ifneq ($(findstring 12.,$(shell avr-gcc --version 2>/dev/null)),)
+_gcc_version = $(shell avr-gcc --version 2>/dev/null)
+ifneq ($(findstring 12.,$(_gcc_version)),)
+CFLAGS += --param=min-pagesize=0
+else ifneq ($(findstring 13.,$(_gcc_version)),)
 CFLAGS += --param=min-pagesize=0
 endif
 


### PR DESCRIPTION
Apply the CFLAGS workaround for GCC 13.

The issue is fixed in GCC 14, so only 12 and 13 are affected.

Ref: 84fe76cad47d ("avr: Fix compiling with GCC 12")
Ref: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523