### PR TITLE
tool: Update toolchain, edition, deps

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-01-21"
+channel = "nightly-2023-09-07"
 components = ["rust-src"]

--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -27,15 +27,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
@@ -90,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -100,21 +103,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "redox_hwio"
@@ -141,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -172,9 +175,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "system76_ectool"
 version = "0.3.8"
-edition = "2018"
+edition = "2021"
 description = "System76 EC tool"
 license = "MIT"
 authors = ["Jeremy Soller <jeremy@system76.com>"]
@@ -18,7 +18,8 @@ required-features = ["std", "hidapi", "clap"]
 [dependencies]
 clap = { version = "3.2", optional = true }
 libc = { version = "0.2", optional = true }
-hidapi = { version = "1.4", default-features = false, features = ["linux-shared-hidraw"], optional = true }
+# NOTE: Upgrading to 2.x blocked on Ubuntu shipping newer hidapi
+hidapi = { version = "1.5", default-features = false, features = ["linux-shared-hidraw"], optional = true }
 redox_hwio = { version = "0.1.6", default-features = false, optional = true }
 downcast-rs = { version = "1.2.0", default-features = false }
 
@@ -28,6 +29,3 @@ std = ["libc", "downcast-rs/std"]
 
 [package.metadata.docs.rs]
 all-features = true
-
-[registries.crates-io]
-protocol = "sparse"

--- a/tool/src/access/lpc/linux.rs
+++ b/tool/src/access/lpc/linux.rs
@@ -158,7 +158,7 @@ impl Access for AccessLpcLinux {
         }
 
         // Write command byte, which starts command
-        self.write_cmd(SMFI_CMD_CMD, cmd as u8)?;
+        self.write_cmd(SMFI_CMD_CMD, cmd)?;
 
         // Wait for command to finish with timeout
         self.timeout.reset();

--- a/tool/src/access/lpc/sim.rs
+++ b/tool/src/access/lpc/sim.rs
@@ -35,7 +35,7 @@ impl AccessLpcSim {
 
     fn transaction(&mut self, kind: u8, addr: u16, value: u8) -> io::Result<u8> {
         let addr = addr.to_le_bytes();
-        let request = [kind as u8, addr[0], addr[1], value];
+        let request = [kind, addr[0], addr[1], value];
         if self.socket.send(&request)? != request.len() {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
@@ -99,7 +99,7 @@ impl Access for AccessLpcSim {
         }
 
         // Write command byte, which starts command
-        self.write_cmd(SMFI_CMD_CMD, cmd as u8)?;
+        self.write_cmd(SMFI_CMD_CMD, cmd)?;
 
         // Wait for command to finish with timeout
         self.timeout.reset();

--- a/tool/src/ec.rs
+++ b/tool/src/ec.rs
@@ -14,7 +14,7 @@ use crate::{
     SpiTarget,
 };
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 enum Cmd {
     // None = 0,
@@ -46,7 +46,7 @@ const CMD_SPI_FLAG_DISABLE: u8 = 1 << 1;
 const CMD_SPI_FLAG_SCRATCH: u8 = 1 << 2;
 const CMD_SPI_FLAG_BACKUP: u8 = 1 << 3;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum SecurityState {
     // Default value, flashing is prevented, cannot be set with security_set

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+#![allow(clippy::uninlined_format_args)]
+
 use clap::{Arg, App, AppSettings, SubCommand};
 use ectool::{
     Access,
@@ -225,6 +227,7 @@ unsafe fn matrix(ec: &mut Ec<Box<dyn Access>>) -> Result<(), Error> {
 
     let mut data = vec![0; data_size];
     ec.matrix_get(&mut data)?;
+    #[allow(clippy::get_first)]
     let rows = *data.get(0).unwrap_or(&0);
     let cols = *data.get(1).unwrap_or(&0);
     let mut byte = 2;
@@ -305,7 +308,7 @@ fn main() {
         .setting(AppSettings::SubcommandRequired)
         .arg(Arg::with_name("access")
             .long("access")
-            .possible_values(&["lpc-linux", "lpc-sim", "hid"])
+            .possible_values(["lpc-linux", "lpc-sim", "hid"])
             .default_value("lpc-linux")
         )
         .subcommand(SubCommand::with_name("console"))
@@ -386,13 +389,13 @@ fn main() {
         )
         .subcommand(SubCommand::with_name("set_no_input")
             .arg(Arg::with_name("value")
-                .possible_values(&["true", "false"])
+                .possible_values(["true", "false"])
                 .required(true)
             )
         )
         .subcommand(SubCommand::with_name("security")
             .arg(Arg::with_name("state")
-                .possible_values(&["lock", "unlock"])
+                .possible_values(["lock", "unlock"])
             )
         )
         .get_matches();

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -428,7 +428,7 @@ fn main() {
                             _ => {},
                         }
                     }
-                    Err(hidapi::HidError::OpenHidDeviceError.into())
+                    Err(hidapi::HidError::HidApiErrorEmpty.into())
                 }
                 _ => unreachable!(),
             }

--- a/tool/src/spi.rs
+++ b/tool/src/spi.rs
@@ -21,7 +21,7 @@ pub trait Spi {
 }
 
 /// Target which will receive SPI commands
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SpiTarget {
     /// The ROM normally used by the EC
     Main,

--- a/tool/src/spi.rs
+++ b/tool/src/spi.rs
@@ -154,6 +154,7 @@ impl<'a, S: Spi, T: Timeout> SpiRom<'a, S, T> {
         //TODO: automatically detect write command
         match self.spi.target() {
             SpiTarget::Main => for (i, word) in data.chunks(2).enumerate() {
+                #[allow(clippy::get_first)]
                 let low = *word.get(0).unwrap_or(&0xFF);
                 let high = *word.get(1).unwrap_or(&0xFF);
 


### PR DESCRIPTION
- Update toolchain to nightly-2023-09-07
- Update edition to 2021
- Update deps
- Derive `Eq`, `PartialEq` on enums to allow comparisons with `==`

`OpenHidDeviceError` is deprecated, and is removed in newer versions. Replace it with `HidApiErrorEmpty`, because there are no descriptions for what anything means so I just picked one that didn't require fields.

Fix:

- `clippy::unnecessary_cast`
- `clippy::needless_borrow`

Allow:

- `clippy::uninlined_format_args`
- `clippy::get_first`