### PR TITLE
tgl-u: Use PECI-over-eSPI implementation

### DIFF
--- a/src/board/system76/darp7/board.mk
+++ b/src/board/system76/darp7/board.mk
@@ -8,6 +8,7 @@ CONFIG_EC_ITE_IT5570E=y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y
+CONFIG_PECI_OVER_ESPI=y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -68,8 +68,7 @@ void gpio_init() {
     GPDRD = BIT(5) | BIT(4);
     // USB_PWR_EN#
     GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
+    GPDRF = 0;
     // H_PROCHOT_EC#
     GPDRG = BIT(6);
     GPDRH = 0;
@@ -172,7 +171,7 @@ void gpio_init() {
     // TP_DATA
     GPCRF5 = GPIO_ALT;
     // H_PECI
-    GPCRF6 = GPIO_ALT;
+    GPCRF6 = GPIO_IN | GPIO_DOWN;
     //TODO: CC_EN
     GPCRF7 = GPIO_IN | GPIO_UP;
     // VCCIN_AUX_PG

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -8,6 +8,7 @@ CONFIG_EC_ITE_IT5570E=y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y
+CONFIG_PECI_OVER_ESPI=y
 
 # Include keyboard
 KEYBOARD=14in_83

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -69,8 +69,7 @@ void gpio_init() {
     // PWR_BTN#, SMI#
     GPDRD = BIT(5) | BIT(4);
     GPDRE = 0;
-    // H_PECI
-    GPDRF = BIT(6);
+    GPDRF = 0;
     // H_PROCHOT_EC
     GPDRG = BIT(6);
     GPDRH = 0;
@@ -173,7 +172,7 @@ void gpio_init() {
     // TP_DATA
     GPCRF5 = GPIO_ALT | GPIO_UP;
     // H_PECI
-    GPCRF6 = GPIO_ALT;
+    GPCRF6 = GPIO_IN | GPIO_DOWN;
     // CC_EN: TODO!
     GPCRF7 = GPIO_IN | GPIO_UP;
     // dGPU_GPIO8_OVERT

--- a/src/board/system76/lemp10/board.mk
+++ b/src/board/system76/lemp10/board.mk
@@ -8,6 +8,7 @@ CONFIG_EC_ITE_IT5570E=y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y
+CONFIG_PECI_OVER_ESPI=y
 
 # Include keyboard
 KEYBOARD=14in_83

--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -67,8 +67,7 @@ void gpio_init() {
     GPDRD = BIT(5) | BIT(4);
     // USB_PWR_EN#
     GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
+    GPDRF = 0;
     GPDRG = 0;
     GPDRH = 0;
     GPDRI = 0;
@@ -170,7 +169,7 @@ void gpio_init() {
     // TP_DATA
     GPCRF5 = GPIO_ALT | GPIO_UP;
     // H_PECI
-    GPCRF6 = GPIO_ALT;
+    GPCRF6 = GPIO_IN | GPIO_DOWN;
     // CPU_C10_GATE#
     GPCRF7 = GPIO_IN | GPIO_DOWN;
     // VCCIN_AUX_PG


### PR DESCRIPTION
Using the legacy implementation causes the EC to lock up during S0ix opportunistic suspend. Switch them to the new PECI implementation.

Ref: #412