### PR TITLE
Only support building a single board at a time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ ifneq ($(VERBOSE),1)
 MAKEFLAGS += -s
 endif
 
+# Set build directory
+BUILD = build
+
 # Parameter for current board
 ifeq ($(BOARD),)
 all:
@@ -20,10 +23,6 @@ else
 DATE=$(shell git show --format="%cs" --no-patch --no-show-signature)
 REV=$(shell git describe --abbrev=7 --always --dirty)
 VERSION?=$(DATE)_$(REV)
-
-# Set build directory
-obj = build
-BUILD = $(obj)/$(BOARD)
 
 # Default target - build the board's EC firmware
 all: $(BUILD)/ec.rom
@@ -72,7 +71,7 @@ docs:
 
 .PHONY: clean
 clean:
-	rm -rf $(obj)
+	rm -rf $(BUILD)
 
 .PHONY: fmt
 fmt:

--- a/src/arch/8051/toolchain.mk
+++ b/src/arch/8051/toolchain.mk
@@ -31,25 +31,25 @@ sim: $(BUILD)/ec.rom
 
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
-	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	@echo "  OBJCOPY   $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	objcopy -I ihex -O binary --gap-fill=0xFF --pad-to=$(CONFIG_EC_FLASH_SIZE) $< $@
 
 # Link object files into Intel Hex file
 $(BUILD)/ec.ihx: $(OBJ)
-	@echo "  LINK      $(subst $(obj)/,,$@)"
+	@echo "  LINK      $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(CC) $(LDFLAGS) -o $@ $^
 
 # Compile ASM files into object files
 $(ASM_OBJ): $(BUILD)/%.rel: src/%.asm
-	@echo "  AS        $(subst $(obj)/,,$@)"
+	@echo "  AS        $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(AS) $(ASFLAGS) $@ $<
 
 # Compile C files into object files
 $(C_OBJ): $(BUILD)/%.rel: src/%.c $(INCLUDE)
-	@echo "  CC        $(subst $(obj)/,,$@)"
+	@echo "  CC        $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ -c $<
 

--- a/src/arch/avr/toolchain.mk
+++ b/src/arch/avr/toolchain.mk
@@ -22,25 +22,25 @@ sim: $(BUILD)/ec.elf
 
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
-	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	@echo "  OBJCOPY   $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(OBJCOPY) -I ihex -O binary --gap-fill 0xFF $< $@
 
 # Convert from ELF file to Intel Hex file
 $(BUILD)/ec.ihx: $(BUILD)/ec.elf
-	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	@echo "  OBJCOPY   $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(OBJCOPY) -j .text -j .data -O ihex $< $@
 
 # Link object files into ELF file
 $(BUILD)/ec.elf: $(OBJ)
-	@echo "  LINK      $(subst $(obj)/,,$@)"
+	@echo "  LINK      $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(CC) -o $@ $^
 
 # Compile C files into object files
 $(BUILD)/%.o: src/%.c $(INCLUDE)
-	@echo "  CC        $(subst $(obj)/,,$@)"
+	@echo "  CC        $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(CC) $(CFLAGS) -o $@ -c $<
 

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -33,25 +33,25 @@ FLASH_CC=\
 
 # Convert from binary file to C header
 $(BUILD)/include/flash.h: $(FLASH_BUILD)/flash.rom
-	@echo "  XXD       $(subst $(obj)/,,$@)"
+	@echo "  XXD       $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	xxd -include < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(FLASH_BUILD)/flash.rom: $(FLASH_BUILD)/flash.ihx
-	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	@echo "  OBJCOPY   $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	objcopy -I ihex -O binary $< $@
 
 # Link object files into Intel Hex file
 $(FLASH_BUILD)/flash.ihx: $(FLASH_OBJ)
-	@echo "  LINK      $(subst $(obj)/,,$@)"
+	@echo "  LINK      $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(FLASH_CC) -o $@ $^
 
 # Compile C files into object files
 $(FLASH_OBJ): $(FLASH_BUILD)/%.rel: src/%.c $(FLASH_INCLUDE)
-	@echo "  CC        $(subst $(obj)/,,$@)"
+	@echo "  CC        $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(FLASH_CC) $(FLASH_CFLAGS) -o $@ -c $<
 

--- a/src/board/system76/common/scratch/scratch.mk
+++ b/src/board/system76/common/scratch/scratch.mk
@@ -32,25 +32,25 @@ SCRATCH_CC=\
 
 # Convert from binary file to C header
 $(BUILD)/include/scratch.h: $(SCRATCH_BUILD)/scratch.rom
-	@echo "  XXD       $(subst $(obj)/,,$@)"
+	@echo "  XXD       $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	xxd -include < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(SCRATCH_BUILD)/scratch.rom: $(SCRATCH_BUILD)/scratch.ihx
-	@echo "  OBJCOPY   $(subst $(obj)/,,$@)"
+	@echo "  OBJCOPY   $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	objcopy -I ihex -O binary $< $@
 
 # Link object files into Intel Hex file
 $(SCRATCH_BUILD)/scratch.ihx: $(SCRATCH_OBJ)
-	@echo "  LINK      $(subst $(obj)/,,$@)"
+	@echo "  LINK      $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(SCRATCH_CC) -o $@ $^
 
 # Compile C files into object files
 $(SCRATCH_OBJ): $(SCRATCH_BUILD)/%.rel: src/%.c $(SCRATCH_INCLUDE)
-	@echo "  CC        $(subst $(obj)/,,$@)"
+	@echo "  CC        $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
 	$(SCRATCH_CC) $(SCRATCH_CFLAGS) -o $@ -c $<
 


### PR DESCRIPTION
As a follow up to c461e20df364 ("make: Remove version from build output path"), only support building a single version of a single board by default. The build directory can still be specified by passing `BUILD`.

Fixes running the `clean` target when `BUILD` is a custom value or `BOARD` isn't set.

Fixes: b03c960b4f52 ("make: Reduce build output")