### PR TITLE
time: Replace hard-coded values with macro

### DIFF
--- a/src/arch/8051/time.c
+++ b/src/arch/8051/time.c
@@ -3,23 +3,34 @@
 // Uses timer 0 to keep track of global time
 
 #include <8051.h>
-
 #include <arch/time.h>
+
+#define OSC_DIVISOR 12
+#define TICK_INTERVAL_MS 1
+// Value to reload into the timer when the overflow interrupt is triggered.
+#define TIMER_RELOAD (0xFFFF - ((TICK_INTERVAL_MS) * ((CONFIG_CLOCK_FREQ_KHZ) / OSC_DIVISOR)))
 
 static volatile uint32_t time_overflows = 0;
 
 void timer_0(void) __interrupt(1) {
+    // Hardware automatically clears the the interrupt
+
     // Stop timer
     TR0 = 0;
 
     time_overflows++;
 
-    // Start timer
-    TH0 = 0xFD;
-    TL0 = 0x01;
+    // Reload the values
+    TH0 = TIMER_RELOAD >> 8;
+    TL0 = TIMER_RELOAD & 0xFF;
+
+    // Restart the timer
     TR0 = 1;
 }
 
+/**
+ * Set up Timer 0 as the system tick.
+ */
 void time_init(void) __critical {
     // Stop the timer
     TR0 = 0;
@@ -27,14 +38,17 @@ void time_init(void) __critical {
 
     time_overflows = 0;
 
-    // Enable timer interrupts
+    // Enable the interrupt
     ET0 = 1;
 
-    // Start timer in mode 1
-    // (65536 - 64769) / (9.2 MHz / 12) = ~1 ms interval
+    // Set the timer to mode 1 (16-bit timer)
     TMOD = (TMOD & 0xF0) | 0x01;
-    TH0 = 0xFD;
-    TL0 = 0x01;
+
+    // Set the initial values
+    TH0 = TIMER_RELOAD >> 8;
+    TL0 = TIMER_RELOAD & 0xFF;
+
+    // Start the timer
     TR0 = 1;
 }
 

--- a/src/ec/ite/ec.mk
+++ b/src/ec/ite/ec.mk
@@ -11,6 +11,9 @@ ec-y += ps2.c
 ec-y += signature.c
 ec-y += wuc.c
 
+# Chip clock frequency: 9.2 MHz
+CFLAGS += -DCONFIG_CLOCK_FREQ_KHZ=9200
+
 ifeq ($(CONFIG_EC_ITE_IT8587E), y)
 CFLAGS+=-DCONFIG_EC_ITE_IT8587E=1
 # SRAM is 4096 bytes, but SRAM at address 2048 is used for scratch ROM


### PR DESCRIPTION
This is more descriptive than the comment and allows for changing values, such as using a chip with a different clock frequency.

The resulting binary is identical.