### PR TITLE
Fix building with SDCC 4.3.3

### DIFF
--- a/src/arch/avr/i2c_slave.c
+++ b/src/arch/avr/i2c_slave.c
@@ -40,7 +40,7 @@ void i2c_slave_init(
     sei();
 }
 
-void i2c_slave_stop() {
+void i2c_slave_stop(void) {
     // clear interrupts
     cli();
 

--- a/src/arch/avr/include/arch/i2c_slave.h
+++ b/src/arch/avr/include/arch/i2c_slave.h
@@ -9,6 +9,6 @@ void i2c_slave_init(
     void (*recv_cb)(uint8_t),
     uint8_t (*send_cb)()
 );
-void i2c_slave_stop();
+void i2c_slave_stop(void);
 
 #endif // _ARCH_I2C_SLAVE_H

--- a/src/arch/avr/include/arch/uart.h
+++ b/src/arch/avr/include/arch/uart.h
@@ -21,7 +21,7 @@ struct Uart {
 
 void uart_init(struct Uart *uart, uint32_t baud);
 
-int16_t uart_count();
+int16_t uart_count(void);
 struct Uart *uart_new(int16_t num);
 
 uint8_t uart_can_read(struct Uart *uart);

--- a/src/arch/avr/uart.c
+++ b/src/arch/avr/uart.c
@@ -42,7 +42,7 @@
 #endif
 // clang-format on
 
-int16_t uart_count() {
+int16_t uart_count(void) {
     return sizeof(UARTS) / sizeof(struct Uart);
 }
 

--- a/src/board/system76/addw1/gpio.c
+++ b/src/board/system76/addw1/gpio.c
@@ -44,7 +44,7 @@ struct Gpio __code WLAN_EN =        GPIO(J, 2);
 struct Gpio __code WLAN_PWR_EN =    GPIO(B, 0);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // Enable LPC reset on GPD2
     GCR = 0x04;
 

--- a/src/board/system76/addw2/gpio.c
+++ b/src/board/system76/addw2/gpio.c
@@ -42,7 +42,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(J, 7);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/addw3/gpio.c
+++ b/src/board/system76/addw3/gpio.c
@@ -34,7 +34,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(D, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/bonw14/gpio.c
+++ b/src/board/system76/bonw14/gpio.c
@@ -41,7 +41,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4); // renamed to EN_3V
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/bonw15/gpio.c
+++ b/src/board/system76/bonw15/gpio.c
@@ -36,7 +36,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(B, 5);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/common/smfi.c
+++ b/src/board/system76/common/smfi.c
@@ -241,9 +241,7 @@ static enum Result cmd_matrix_get(void) {
     smfi_cmd[SMFI_CMD_DATA] = KM_OUT;
     smfi_cmd[SMFI_CMD_DATA + 1] = KM_IN;
     for (uint8_t row = 0; row < KM_OUT; row++) {
-        if ((SMFI_CMD_DATA + 2 + row) < ARRAY_SIZE(smfi_cmd)) {
-            smfi_cmd[SMFI_CMD_DATA + 2 + row] = kbscan_matrix[row];
-        }
+        smfi_cmd[SMFI_CMD_DATA + 2 + row] = kbscan_matrix[row];
     }
     return RES_OK;
 }

--- a/src/board/system76/darp5/gpio.c
+++ b/src/board/system76/darp5/gpio.c
@@ -45,7 +45,7 @@ struct Gpio __code WLAN_EN =        GPIO(H, 5);
 struct Gpio __code WLAN_PWR_EN =    GPIO(J, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // Enable LPC reset on GPD2
     GCR = 0x04;
 

--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -42,7 +42,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/galp3-c/gpio.c
+++ b/src/board/system76/galp3-c/gpio.c
@@ -44,7 +44,7 @@ struct Gpio __code WLAN_EN =        GPIO(H, 5);
 struct Gpio __code WLAN_PWR_EN =    GPIO(J, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // Enable LPC reset on GPD2
     GCR = 0x04;
 

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -43,7 +43,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/gaze15/gpio.c
+++ b/src/board/system76/gaze15/gpio.c
@@ -40,7 +40,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/gaze16-3050/gpio.c
+++ b/src/board/system76/gaze16-3050/gpio.c
@@ -38,7 +38,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/gaze16-3060/gpio.c
+++ b/src/board/system76/gaze16-3060/gpio.c
@@ -39,7 +39,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -38,7 +38,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -38,7 +38,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(D, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/gaze18/gpio.c
+++ b/src/board/system76/gaze18/gpio.c
@@ -35,7 +35,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // Not documented
     //GCR22 = BIT(7);
     GCR10 = 0x02;

--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -41,7 +41,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/lemp9/gpio.c
+++ b/src/board/system76/lemp9/gpio.c
@@ -42,7 +42,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // Enable LPC reset on GPD2
     GCR = 0x04;
     // Enable SMBus channel 4

--- a/src/board/system76/oryp11/gpio.c
+++ b/src/board/system76/oryp11/gpio.c
@@ -36,7 +36,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(D, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/oryp6/gpio.c
+++ b/src/board/system76/oryp6/gpio.c
@@ -40,7 +40,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/oryp7/gpio.c
+++ b/src/board/system76/oryp7/gpio.c
@@ -39,7 +39,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(H, 4);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1

--- a/src/board/system76/oryp8/gpio.c
+++ b/src/board/system76/oryp8/gpio.c
@@ -37,7 +37,7 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(H, 4);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // clang-format on
 
-void gpio_init() {
+void gpio_init(void) {
     // PWRSW WDT 2 Enable 2
     GCR9 = BIT(5);
     // PWRSW WDT 2 Enable 1


### PR DESCRIPTION
I don't know if any distro provides patch releases, because SDCC itself doesn't even bother to make releases for them (creates SVN tags, but no source tarballs). I built from the [SVN tag for 4.3.3](https://sourceforge.net/p/sdcc/code/HEAD/tree/tags/sdcc-4.3.3/) in a container and these were the errors.

Containerfile for testing:

<details>
  <summary>Containerfile</summary>

  ```dockerfile
  # A container for Small Device C Compiler based on Alpine
  
  ARG CONTAINER_IMAGE="alpine:3.18.4"
  
  FROM ${CONTAINER_IMAGE} as sdcc-build
  ARG SDCC_REPO
  ARG SDCC_REV
  WORKDIR /tmp
  
  RUN apk update && \
      apk add --no-cache \
          autoconf \
          automake \
          bison \
          boost-dev \
          ca-certificates \
          flex \
          g++ \
          gcc \
          make \
          subversion \
          zlib-dev
  
  RUN svn checkout \
      --depth infinity \
      --revision ${SDCC_REV} \
      ${SDCC_REPO}/trunk/sdcc \
      sdcc
  
  # PIC requires gputils, which is not available on Alpine
  RUN cd sdcc && \
      sh ./configure \
          --disable-pic14-port \
          --disable-pic16-port \
          --disable-non-free \
          --prefix= && \
      make -j $(nproc) && \
      make install DESTDIR=/opt/sdcc
  
  FROM ${CONTAINER_IMAGE}
  ARG SDCC_REV
  COPY --from=sdcc-build /opt/sdcc /opt/sdcc
  ENV SDCC_REV "${SDCC_REV}"
  ENV SDCC_PATH "/opt/sdcc"
  ENV PATH "${SDCC_PATH}/bin:$PATH"
  
  # NOTE: Using SDCC requires libstdc++ installed
  RUN apk update && \
      apk add --no-cache \
          bash \
          binutils \
          git \
          libstdc++ \
          make \
          xxd
  
  WORKDIR /workspace
  CMD ["bash"]
  ```
</details>


```sh
podman build \
    --tag system76/ec:latest \
    --build-arg=SDCC_REV=14376 \
    --file Containerfile \
    containers/ec-alpine
podman run -it --rm -v $PWD:/workspace:Z system76/ec:latest make BOARD=system76/oryp8
```