### PR TITLE
Allow controlling debug via `config.mk`

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -15,11 +15,19 @@ Terms used:
     ```bash
     make BOARD=system76/<model> console_internal
     ```
-1. If you're not seeing seeing expected output, check the
-  [`LEVEL` cflag][level_cflag]. This is an EC compile time configuration and
-  changing will require a build and flash of the EC.
+If you're not seeing seeing expected output, check the value of
+`CONFIG_LOG_LEVEL` in `common.mk`. This is an EC compile time configuration
+and changing it will require a build and flash of the EC. Supported log levels
+are:
 
-[level_cflag]: https://github.com/system76/ec/blob/01907011bb63/src/board/system76/common/common.mk#L31-L39
+- `none`
+- `error`
+- `warn`
+- `info`
+- `debug`
+- `trace`
+
+The default value is `debug` if unspecified.
 
 ## Debugging with external device
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -49,7 +49,7 @@ For details on configuring the Mega 2560 and breakout board, see
 #### Setup
 
 1. Enable parallel port debugging in the EC firmware
-    - Uncomment `PARALLEL_DEBUG` in `src/board/system76/common/common.mk`
+    - Set `CONFIG_PARALLEL_DEBUG=y` in `config.mk`
     - Build and flash the firmware for the target
 2. Power off target
 3. Remove bottom panel
@@ -120,7 +120,7 @@ Requirements:
 - USB-C cable
 
 1. Enable I2C debugging in the EC firmware for the target
-    - Uncomment `I2C_DEBUGGER` in `src/board/system76/common/common.mk`
+    - Set `CONFIG_I2C_DEBUG=y` in `config.mk`
     - Build and flash firmware
 2. Connect Trinket M0 to host
     - This will create an ACM device at `/dev/ttyACM*`

--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -29,13 +29,28 @@ board-common-y += stdio.c
 board-common-y += wireless.c
 
 # Set log level
-# 0 - NONE
-# 1 - ERROR
-# 2 - WARN
-# 3 - INFO
-# 4 - DEBUG
-# 5 - TRACE
-CFLAGS+=-DLEVEL=4
+# - none
+# - error
+# - warn
+# - info
+# - debug
+# - trace
+ifeq ($(CONFIG_LOG_LEVEL),none)
+CFLAGS += -DLEVEL=0
+else ifeq ($(CONFIG_LOG_LEVEL),error)
+CFLAGS += -DLEVEL=1
+else ifeq ($(CONFIG_LOG_LEVEL),warn)
+CFLAGS += -DLEVEL=2
+else ifeq ($(CONFIG_LOG_LEVEL),info)
+CFLAGS += -DLEVEL=3
+else ifeq ($(CONFIG_LOG_LEVEL),debug)
+CFLAGS += -DLEVEL=4
+else ifeq ($(CONFIG_LOG_LEVEL),trace)
+CFLAGS += -DLEVEL=5
+else
+# XXX: Preserve old behavior of LEVEL always being set to DEBUG.
+CFLAGS += -DLEVEL=4
+endif
 
 # Uncomment to enable debug logging over keyboard parallel port
 #CFLAGS+=-DPARALLEL_DEBUG

--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -52,11 +52,15 @@ else
 CFLAGS += -DLEVEL=4
 endif
 
-# Uncomment to enable debug logging over keyboard parallel port
-#CFLAGS+=-DPARALLEL_DEBUG
+ifeq ($(CONFIG_PARALLEL_DEBUG),y)
+# Enable debug logging over the keyboard parallel port
+CFLAGS += -DPARALLEL_DEBUG=1
+endif
 
-# Uncomment to enable I2C debug on 0x76
-#CFLAGS+=-DI2C_DEBUGGER=0x76
+ifeq ($(CONFIG_I2C_DEBUG),y)
+# Enable debug logging over battery SMBus connection
+CFLAGS += -DI2C_DEBUGGER=0x76
+endif
 
 ifeq ($(CONFIG_SECURITY),y)
 CFLAGS+=-DCONFIG_SECURITY=1

--- a/src/common/include/common/debug.h
+++ b/src/common/include/common/debug.h
@@ -12,11 +12,6 @@
 #define LEVEL_ERROR 1
 #define LEVEL_NONE 0
 
-// This is the user-configurable log level
-#ifndef LEVEL
-#define LEVEL LEVEL_INFO
-#endif
-
 #if LEVEL >= LEVEL_TRACE
 #define TRACE(...) printf(__VA_ARGS__)
 #else


### PR DESCRIPTION
Add new Makefile configs for controlling the log level and mechanisms instead of having to modify the `CFLAGS` directly.

Allows adding values to top level `config.mk` instead of the nested `common.mk` file.