### PR TITLE
kbscan: Do not read matrix if lid is closed

### DIFF
--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -65,11 +65,6 @@ void kbscan_init(void) {
 
 // Read the state of the row for the selected column.
 static inline uint8_t kbscan_get_row(void) {
-    // Report all keys as released when lid is closed
-    if (!lid_state) {
-        return 0;
-    }
-
     // Invert KSI for positive logic of pressed keys.
     return ~KSI;
 }
@@ -163,7 +158,7 @@ static void hardware_hotkey(uint16_t key) {
 
 bool kbscan_press(uint16_t key, bool pressed, uint8_t *layer) {
     // Wake from sleep on keypress
-    if (pressed && lid_state && (power_state == POWER_STATE_S3)) {
+    if (pressed && (power_state == POWER_STATE_S3)) {
         pmc_swi();
     }
 
@@ -311,8 +306,13 @@ void kbscan_event(void) {
 
     // Read the current state of the hardware matrix
     for (uint8_t i = 0; i < KM_OUT; i++) {
-        kbscan_set_column(i);
-        matrix_curr[i] = kbscan_get_row();
+        if (!lid_state) {
+            // Report all keys as released when lid is closed
+            matrix_curr[i] = 0;
+        } else {
+            kbscan_set_column(i);
+            matrix_curr[i] = kbscan_get_row();
+        }
     }
     // Disable reading any keys
     kbscan_set_column(KBSCAN_MATRIX_NONE);

--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -282,7 +282,6 @@ void kbscan_event(void) {
     static uint8_t kbscan_layer = 0;
     uint8_t layer = kbscan_layer;
     static uint8_t kbscan_last_layer[KM_OUT][KM_IN] = { { 0 } };
-    static bool kbscan_ghost[KM_OUT] = { false };
     uint8_t matrix_curr[KM_OUT];
 
     static bool debounce = false;


### PR DESCRIPTION
Pull the lid check out to the loop to avoid accessing the matrix when we know we do not need the data. It is left in kbscan (instead of simply disabling reading) to clear the state of the matrix data.

The lid check for wake is removed as it will never be true.