### PR TITLE
kbscan: Increase debounce time from 10ms to 20ms

### DIFF
--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -21,7 +21,7 @@
 #endif // KM_NKEY
 
 // Debounce time in milliseconds
-#define DEBOUNCE_DELAY 10
+#define DEBOUNCE_DELAY 20
 
 bool kbscan_fn_held = false;
 bool kbscan_esc_held = false;


### PR DESCRIPTION
I found that a debounce time of 10ms was causing very frequent twice-registered keys with my typing style.  After setting the debounce time to 20ms I find that no repeated characters occur when typing 10 line of text.

Fixes: https://github.com/system76/firmware-open/issues/509