### PR TITLE
ite: Add support for 256K flash

### DIFF
--- a/src/board/system76/addw1/board.mk
+++ b/src/board/system76/addw1/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT8587E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/addw2/board.mk
+++ b/src/board/system76/addw2/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/addw3/board.mk
+++ b/src/board/system76/addw3/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/bonw14/board.mk
+++ b/src/board/system76/bonw14/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102_nkey

--- a/src/board/system76/bonw15/board.mk
+++ b/src/board/system76/bonw15/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/darp5/board.mk
+++ b/src/board/system76/darp5/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT8587E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/darp6/board.mk
+++ b/src/board/system76/darp6/board.mk
@@ -8,6 +8,7 @@ CFLAGS += -I$(BOARD_DIR)/../darp5/include
 
 EC=ite
 CONFIG_EC_ITE_IT8587E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/darp7/board.mk
+++ b/src/board/system76/darp7/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/darp8/board.mk
+++ b/src/board/system76/darp8/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/darp9/board.mk
+++ b/src/board/system76/darp9/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/galp3-c/board.mk
+++ b/src/board/system76/galp3-c/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT8587E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=14in_86

--- a/src/board/system76/galp4/board.mk
+++ b/src/board/system76/galp4/board.mk
@@ -8,6 +8,7 @@ CFLAGS += -I$(BOARD_DIR)/../galp3-c/include
 
 EC=ite
 CONFIG_EC_ITE_IT8587E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=14in_86

--- a/src/board/system76/galp5/board.mk
+++ b/src/board/system76/galp5/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/galp6/board.mk
+++ b/src/board/system76/galp6/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/galp7/board.mk
+++ b/src/board/system76/galp7/board.mk
@@ -8,6 +8,7 @@ CFLAGS += -I$(BOARD_DIR)/../galp6/include
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/gaze15/board.mk
+++ b/src/board/system76/gaze15/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/gaze16-3050/board.mk
+++ b/src/board/system76/gaze16-3050/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/gaze16-3060-b/board.mk
+++ b/src/board/system76/gaze16-3060-b/board.mk
@@ -8,6 +8,7 @@ CFLAGS += -I$(BOARD_DIR)/../gaze16-3060/include
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/gaze16-3060/board.mk
+++ b/src/board/system76/gaze16-3060/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/gaze17-3050/board.mk
+++ b/src/board/system76/gaze17-3050/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/gaze17-3060-b/board.mk
+++ b/src/board/system76/gaze17-3060-b/board.mk
@@ -8,6 +8,7 @@ CFLAGS += -I$(BOARD_DIR)/../gaze17-3060/include
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/gaze17-3060/board.mk
+++ b/src/board/system76/gaze17-3060/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/gaze18/board.mk
+++ b/src/board/system76/gaze18/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/lemp10/board.mk
+++ b/src/board/system76/lemp10/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/lemp11/board.mk
+++ b/src/board/system76/lemp11/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/lemp12/board.mk
+++ b/src/board/system76/lemp12/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/lemp9/board.mk
+++ b/src/board/system76/lemp9/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=14in_83

--- a/src/board/system76/oryp10/board.mk
+++ b/src/board/system76/oryp10/board.mk
@@ -8,6 +8,7 @@ CFLAGS += -I$(BOARD_DIR)/../oryp9/include
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/oryp11/board.mk
+++ b/src/board/system76/oryp11/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/oryp5/board.mk
+++ b/src/board/system76/oryp5/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT8587E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/oryp6/board.mk
+++ b/src/board/system76/oryp6/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/oryp7/board.mk
+++ b/src/board/system76/oryp7/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Include keyboard
 KEYBOARD=15in_102

--- a/src/board/system76/oryp8/board.mk
+++ b/src/board/system76/oryp8/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/oryp9/board.mk
+++ b/src/board/system76/oryp9/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/board/system76/serw13/board.mk
+++ b/src/board/system76/serw13/board.mk
@@ -5,6 +5,7 @@ board-y += gpio.c
 
 EC=ite
 CONFIG_EC_ITE_IT5570E=y
+CONFIG_EC_FLASH_SIZE_128K = y
 
 # Enable eSPI
 CONFIG_BUS_ESPI=y

--- a/src/ec/ite/ec.mk
+++ b/src/ec/ite/ec.mk
@@ -34,5 +34,11 @@ ARCH=8051
 # 64 KB is the max without banking
 CODE_SIZE=65536
 
-# Total flash size: 128 KiB
+# Chip flash size
+ifeq ($(CONFIG_EC_FLASH_SIZE_128K),y)
 CONFIG_EC_FLASH_SIZE = 131072
+else ifeq ($(CONFIG_EC_FLASH_SIZE_256K),y)
+CONFIG_EC_FLASH_SIZE = 262144
+else
+$(error flash size not specified)
+endif


### PR DESCRIPTION
The upcoming addw4 will use the IT5570E-256, which requires removing the assumption that every ITE chip is 128K. Introduce new configs so boards may select which flash size they use.