### PR TITLE
main: Remove empty switch case

### DIFF
--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -102,6 +102,8 @@ void main(void) {
     uint32_t last_time_fan = 0;
 
     for (main_cycle = 0;; main_cycle++) {
+        // NOTE: Do note use modulo to avoid expensive call to SDCC library
+        // call. (Modulo is optimized for powers of 2, however.)
         switch (main_cycle & 3U) {
         case 0:
             // Handle USB-C events immediately before power states
@@ -122,11 +124,6 @@ void main(void) {
         case 2:
             // Handle lid close/open
             lid_event();
-            break;
-
-        case 3:
-            // We previously used modulo to limit when the logic for other
-            // cases ran, so this case is unused.
             break;
         }
 


### PR DESCRIPTION
SDCC 4.4.0 now fails to compile if there are empty switch cases.

    src/board/system76/common/main.c:105: error 110: conditional flow changed by optimizer: so said EVELYN the modified DOG

Tested using #418.