### PR TITLE
ci: Update actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       boards: ${{ steps.board-matrix.outputs.boards }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: ./scripts/deps.sh
@@ -37,7 +37,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: ./scripts/deps.sh
@@ -54,7 +54,7 @@ jobs:
         # TODO: Conditionally build based on files changed?
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: ./scripts/deps.sh


### PR DESCRIPTION
Fixes the following warnings in Actions:

    Node.js 16 actions are deprecated. Please update the following
    actions to use Node.js 20: actions/checkout@v3.