### PR TITLE
addw4: Enable security

### DIFF
--- a/src/board/system76/addw4/board.mk
+++ b/src/board/system76/addw4/board.mk
@@ -12,7 +12,7 @@ CONFIG_BUS_ESPI = y
 CONFIG_PECI_OVER_ESPI = y
 
 # Enable firmware security
-#CONFIG_SECURITY = y
+CONFIG_SECURITY = y
 
 # Set keyboard configs
 KEYBOARD = 18H9LHA04


### PR DESCRIPTION
Development is sufficiently far along that this can default to enabled.