### PR TITLE
scripts: Remove explicit rustup self update

### DIFF
--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -73,10 +73,7 @@ msg "Installing git hooks"
 make git-config
 
 RUSTUP_NEW_INSTALL=0
-if which rustup &> /dev/null; then
-    msg "Updating rustup"
-    rustup self update
-else
+if ! command -v rustup >/dev/null 2>&1; then
     RUSTUP_NEW_INSTALL=1
     msg "Installing Rust"
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \


### PR DESCRIPTION
Commit 17f8e37ed578 ("Convert toolchain file to TOML syntax") switched from the bare toolchain file to the TOML-based one for better management of the toolchain and components used.

Commit 1cb61e69186d ("deps.sh: Update rustup or inform user of env vars") added an explicit `rustup self update` because there were still cases, a year later, of people not having a rustup new enough to support the TOML-based toolchain file.

Now 2 years after that, it should be safe to drop the explicit self update. The TOML format has widespread adoption and rustup now self updates by default. This should allow distro-provided rustup, which disables the self update feature, to work if it is already installed in place of the one downloaded from https://rustup.rs.