### PR TITLE
tool: Add error for write locked

### DIFF
--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -1,15 +1,27 @@
 # Flashing firmware
 
+## UEFI application
+
+The `flash.sh` script from the top-level firmware-open project will use
+firmware-update, the UEFI application which is used for normal system updates.
+
+This will flash both the SBIOS and the EC after building the firmware. To
+flash just the EC, delete the built `firmware.rom` before running `flash.sh`.
+
 ## Internal programmer
 
 Use this method for flashing a system already running System76 EC.
 
 This method will only work if the running firmware is not locked. Firmware is
-write locked if it was built with `CONFIG_SECURITY=y`. firmware-update must be
-used to flash from UEFI in this state (see `flash.sh` in firmware-open).
+write locked if it was built with `CONFIG_SECURITY=y`. The firmware can be
+unlocked using ectool for a single boot:
 
-This will trigger a watchdog reset causing the system to **immediately power
-off**. OS data may be lost or corrupted as a result. Save and close all
+```
+./scripts/ectool.sh security unlock
+```
+
+This method will trigger a watchdog reset causing the system to **immediately
+power off**. OS data may be lost or corrupted as a result. Save and close all
 applications before flashing.
 
 ```

--- a/docs/keyboard-layout-customization.md
+++ b/docs/keyboard-layout-customization.md
@@ -104,10 +104,6 @@ make
 
 See [flashing firmware](./flashing.md) for details.
 
-```sh
-make flash_internal
-```
-
 Do not use the keyboard or touchpad while it is flashing.
 
 The system will power off as part of the flash process. Turn it back on after

--- a/scripts/ectool.sh
+++ b/scripts/ectool.sh
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 set -e
-cargo build --release --manifest-path tool/Cargo.toml
+cargo build --release --quiet --manifest-path tool/Cargo.toml
 sudo tool/target/release/system76_ectool "$@"

--- a/src/board/system76/common/security.c
+++ b/src/board/system76/common/security.c
@@ -11,7 +11,7 @@ enum SecurityState security_get(void) {
 
 bool security_set(enum SecurityState state) {
     switch (state) {
-    // Allow perpare states to be set
+    // Allow prepare states to be set
     case SECURITY_STATE_PREPARE_LOCK:
     case SECURITY_STATE_PREPARE_UNLOCK:
         security_state = state;

--- a/tool/src/error.rs
+++ b/tool/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     /// Encountered a hidapi::Error
     #[cfg(feature = "hidapi")]
     Hid(hidapi::HidError),
+    /// Writing to flash is disabled
+    WriteLocked,
 }
 
 #[cfg(feature = "std")]

--- a/tool/src/main.rs
+++ b/tool/src/main.rs
@@ -170,6 +170,12 @@ unsafe fn flash(ec: &mut Ec<Box<dyn Access>>, path: &str, target: SpiTarget) -> 
         println!("ec version: {:?}", str::from_utf8(ec_version));
     }
 
+    if let Ok(security) = ec.security_get() {
+        if security != SecurityState::Unlock {
+            return Err(Error::WriteLocked);
+        }
+    }
+
     if scratch {
         // Wait for any key releases
         eprintln!("Waiting 5 seconds for all keys to be released");
@@ -379,8 +385,6 @@ struct Args {
 }
 
 fn main() {
-    //.subcommand(Command::new("security").arg(Arg::new("state").value_parser(["lock", "unlock"])))
-
     let args = Args::parse();
 
     let get_ec = || -> Result<_, Error> {


### PR DESCRIPTION
Add a new error for the case of trying to flash when security is enabled and it is still locked and update the related docs.