### PR TITLE
Remove GPB7 on IT5570E

### DIFF
--- a/src/board/system76/addw2/gpio.c
+++ b/src/board/system76/addw2/gpio.c
@@ -105,8 +105,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EN
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    //
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/addw3/gpio.c
+++ b/src/board/system76/addw3/gpio.c
@@ -118,8 +118,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/board/system76/addw4/gpio.c
+++ b/src/board/system76/addw4/gpio.c
@@ -105,8 +105,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_IN;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/board/system76/bonw14/gpio.c
+++ b/src/board/system76/bonw14/gpio.c
@@ -97,8 +97,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // EC_EN
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // NO PIN
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // KBC_SMBus_CLK1

--- a/src/board/system76/bonw15/gpio.c
+++ b/src/board/system76/bonw15/gpio.c
@@ -121,8 +121,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -109,8 +109,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EN
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Does not exist
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/darp8/gpio.c
+++ b/src/board/system76/darp8/gpio.c
@@ -111,8 +111,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Does not exist
-    GPCRB7 = GPIO_IN | GPIO_DOWN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/darp9/gpio.c
+++ b/src/board/system76/darp9/gpio.c
@@ -112,8 +112,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Missing
-    GPCRB7 = GPIO_IN | GPIO_DOWN;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -110,8 +110,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // N/A
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -114,8 +114,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_IN;
     // SUSBC_EC
     GPCRB6 = GPIO_OUT;
-    // Does not exist
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/gaze15/gpio.c
+++ b/src/board/system76/gaze15/gpio.c
@@ -100,8 +100,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // H_PROCHOT_EC
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    //
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/gaze16-3050/gpio.c
+++ b/src/board/system76/gaze16-3050/gpio.c
@@ -105,8 +105,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    //
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/gaze16-3060/gpio.c
+++ b/src/board/system76/gaze16-3060/gpio.c
@@ -105,8 +105,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Doesn't exist
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -103,8 +103,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -109,8 +109,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_IN | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/gaze18/gpio.c
+++ b/src/board/system76/gaze18/gpio.c
@@ -107,8 +107,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN | GPIO_UP;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -107,8 +107,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // EC_FORCE_POWER
     GPCRB6 = GPIO_IN;
-    // NC
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMB_CLK_EC

--- a/src/board/system76/lemp11/gpio.c
+++ b/src/board/system76/lemp11/gpio.c
@@ -114,8 +114,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Does not exist
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMB_CLK_EC

--- a/src/board/system76/lemp12/gpio.c
+++ b/src/board/system76/lemp12/gpio.c
@@ -113,8 +113,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Does not exist
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMB_CLK_EC

--- a/src/board/system76/lemp13/gpio.c
+++ b/src/board/system76/lemp13/gpio.c
@@ -108,8 +108,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_IN;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT;
-    // Does not exist
-    GPCRB7 = GPIO_IN;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/board/system76/lemp9/gpio.c
+++ b/src/board/system76/lemp9/gpio.c
@@ -93,8 +93,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT;
     // NC
     GPCRB6 = GPIO_IN;
-    // NC
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMB_CLK_EC

--- a/src/board/system76/oryp11/gpio.c
+++ b/src/board/system76/oryp11/gpio.c
@@ -121,8 +121,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/board/system76/oryp12/gpio.c
+++ b/src/board/system76/oryp12/gpio.c
@@ -109,8 +109,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // NC
-    GPCRB7 = GPIO_IN;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/board/system76/oryp6/gpio.c
+++ b/src/board/system76/oryp6/gpio.c
@@ -103,8 +103,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EN#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Does not exist
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/oryp7/gpio.c
+++ b/src/board/system76/oryp7/gpio.c
@@ -102,8 +102,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EN#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Does not exist
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/oryp8/gpio.c
+++ b/src/board/system76/oryp8/gpio.c
@@ -105,8 +105,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Doesn't exist
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/oryp9/gpio.c
+++ b/src/board/system76/oryp9/gpio.c
@@ -114,8 +114,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT | GPIO_UP;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN;
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;
     // SMC_VGA_THERM

--- a/src/board/system76/serw13/gpio.c
+++ b/src/board/system76/serw13/gpio.c
@@ -109,8 +109,6 @@ void gpio_init(void) {
     GPCRB5 = GPIO_OUT;
     // SUSBC_EC#
     GPCRB6 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRB7 = GPIO_IN | GPIO_UP;
 
     // ALL_SYS_PWRGD
     GPCRC0 = GPIO_IN;

--- a/src/ec/ite/include/ec/gpio.h
+++ b/src/ec/ite/include/ec/gpio.h
@@ -118,7 +118,9 @@ volatile uint8_t __xdata __at(0x161B) GPCRB3;
 volatile uint8_t __xdata __at(0x161C) GPCRB4;
 volatile uint8_t __xdata __at(0x161D) GPCRB5;
 volatile uint8_t __xdata __at(0x161E) GPCRB6;
+#if CONFIG_EC_ITE_IT5571E || CONFIG_EC_ITE_IT8587E
 volatile uint8_t __xdata __at(0x161F) GPCRB7;
+#endif
 
 volatile uint8_t __xdata __at(0x1620) GPCRC0;
 volatile uint8_t __xdata __at(0x1621) GPCRC1;


### PR DESCRIPTION
On IT5570E, pin A1 is `VSTBY0` and not a GPIO pin.