### PR TITLE
tool: Update Rust toolchain to nightly-2024-05-11

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-09-07"
+channel = "nightly-2024-05-11"
 components = ["rust-src"]


### PR DESCRIPTION
Update toolchain to match the version used in Redox.