### PR TITLE
Enable power switch WDT on IT8587E boards

### DIFF
--- a/src/board/system76/addw1/gpio.c
+++ b/src/board/system76/addw1/gpio.c
@@ -45,6 +45,9 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(B, 0);
 // uncrustify:on
 
 void gpio_init(void) {
+    // PWRSW WDT 2 Enable
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
 

--- a/src/board/system76/darp5/gpio.c
+++ b/src/board/system76/darp5/gpio.c
@@ -46,6 +46,9 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(J, 4);
 // uncrustify:on
 
 void gpio_init(void) {
+    // PWRSW WDT 2 Enable
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
 

--- a/src/board/system76/galp3-c/gpio.c
+++ b/src/board/system76/galp3-c/gpio.c
@@ -45,6 +45,9 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(J, 4);
 // uncrustify:on
 
 void gpio_init(void) {
+    // PWRSW WDT 2 Enable
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
 

--- a/src/board/system76/oryp5/gpio.c
+++ b/src/board/system76/oryp5/gpio.c
@@ -41,6 +41,9 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(B, 0);
 // uncrustify:on
 
 void gpio_init(void) {
+    // PWRSW WDT 2 Enable
+    GCR8 = BIT(4);
+
     // Enable LPC reset on GPD2
     GCR = 0x04;
 


### PR DESCRIPTION
Enable PWRSW WDT 2 and use the default timeout of 10 seconds.

Allows forcing an EC reset in case it gets into an invalid state.

Models with IT8587E:

- addw1
- darp5
- darp6
- galp3-c
- galp4
- oryp5

Ref: #315
Ref: #472