### PR TITLE
Initialize GPIOs from static config table

### DIFF
--- a/src/board/system76/addw1/gpio.c
+++ b/src/board/system76/addw1/gpio.c
@@ -44,198 +44,123 @@ struct Gpio __code WLAN_EN =        GPIO(J, 2);
 struct Gpio __code WLAN_PWR_EN =    GPIO(B, 0);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+
+    // Port data
+    { &GPDRA, BIT(3) }, // SYS_FAN
+    { &GPDRB, 0 },
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SCI#, SMI#
+    { &GPDRE, 0 },
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // AIRPLAN_LED#
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(5) | BIT(4) | BIT(3) | BIT(1) }, // LED_CAP#, LED_NUM#, LED_SCROLL#, KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // TODO: SYS_FAN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRB1, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_ALT }, // SMC_BAT
+    { &GPCRB4, GPIO_ALT }, // SMD_BAT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SUSBC_EN#
+    { &GPCRB6, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB7, GPIO_IN | GPIO_UP }, // PERKB-DET#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_OUT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_OUT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#_EC
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_IN | GPIO_UP }, // PWR_SW#
+    { &GPCRD1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SMI#
+    { &GPCRD4, GPIO_IN }, // SCI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // ALL_FANSEN
+
+    { &GPCRE0, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRE1, GPIO_IN }, // OVERT#
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT | GPIO_UP }, // SB_KBCRST#
+    { &GPCRE7, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // BT_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT | GPIO_UP }, // USB_PWR_EN#
+
+    { &GPCRG0, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRG1, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRG2, GPIO_OUT }, // AUTO_LOAD
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // AIRPLAN_LED#
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // ECCLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH4, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // MPS_ID
+    { &GPCRI6, GPIO_OUT }, // FANSEN_SEL (L:VGA H:SYS)
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT }, // SLP_SUS_EC#
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRJ3, GPIO_OUT | GPIO_UP }, // LED_SCROLL#
+    { &GPCRJ4, GPIO_OUT | GPIO_UP }, // LED_NUM#
+    { &GPCRJ5, GPIO_OUT | GPIO_UP }, // LED_CAP#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // POWER_IC_EN
+    { &GPCRJ7, GPIO_OUT }, // VBATT_BOOST#
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-
-    // Set GPIO data
-    // SYS_FAN
-    GPDRA = BIT(3);
-    GPDRB = 0x00;
-    GPDRC = 0x00;
-    // PWR_BTN#, SCI#, SMI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    GPDRE = 0x00;
-    // H_PECI
-    GPDRF = BIT(6);
-    // AIRPLAN_LED#
-    GPDRG = BIT(6);
-    GPDRH = 0x00;
-    GPDRI = 0x00;
-    // LED_CAP#, LED_NUM#, LED_SCROLL#, KBC_MUTE#
-    GPDRJ = BIT(5) | BIT(4) | BIT(3) | BIT(1);
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // SYS_FAN TODO
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRB0 = GPIO_OUT | GPIO_UP;
-    // H_PROCHOT_EC
-    GPCRB1 = GPIO_OUT | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // SMC_BAT
-    GPCRB3 = GPIO_ALT;
-    // SMD_BAT
-    GPCRB4 = GPIO_ALT;
-    // SUSBC_EN#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // AC_IN#
-    GPCRB6 = GPIO_IN | GPIO_UP;
-    // PERKB-DET#
-    GPCRB7 = GPIO_IN | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_OUT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_OUT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#_EC
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // PWR_SW#
-    GPCRD0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRD1 = GPIO_IN | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SMI#
-    GPCRD3 = GPIO_IN;
-    // SCI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // ALL_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SWI#
-    GPCRE0 = GPIO_OUT | GPIO_UP;
-    // OVERT#
-    GPCRE1 = GPIO_IN;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // DGPU_PWR_EN
-    GPCRE3 = GPIO_IN;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_OUT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE7 = GPIO_OUT | GPIO_UP;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // BT_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // USB_PWR_EN#
-    GPCRF7 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRG0 = GPIO_OUT | GPIO_UP;
-    // GC6_FB_EN_PCH
-    GPCRG1 = GPIO_IN;
-    // AUTO_LOAD
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // AIRPLAN_LED#
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // ECCLKRUN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // LED_BAT_CHG
-    GPCRH3 = GPIO_OUT | GPIO_UP;
-    // LED_BAT_FULL
-    GPCRH4 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // MPS_ID
-    GPCRI5 = GPIO_IN;
-    // FANSEN_SEL (L:VGA H:SYS)
-    GPCRI6 = GPIO_OUT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // SLP_SUS_EC#
-    GPCRJ0 = GPIO_OUT;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // WLAN_EN
-    GPCRJ2 = GPIO_OUT | GPIO_UP;
-    // LED_SCROLL#
-    GPCRJ3 = GPIO_OUT | GPIO_UP;
-    // LED_NUM#
-    GPCRJ4 = GPIO_OUT | GPIO_UP;
-    // LED_CAP#
-    GPCRJ5 = GPIO_OUT | GPIO_UP;
-    // POWER_IC_EN
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // VBATT_BOOST#
-    GPCRJ7 = GPIO_OUT;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/addw2/gpio.c
+++ b/src/board/system76/addw2/gpio.c
@@ -42,209 +42,127 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(J, 7);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SCI#, SMI#
+    { &GPDRE, BIT(6) }, // PLVDD_RST_EC
+    { &GPDRF, BIT(6) }, // EC_PECI
+    { &GPDRG, BIT(6) | BIT(0) }, // H_PROCHOT#_EC, LED_NUM#
+    { &GPDRH, BIT(7) }, // AIRPLAN_LED#
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(3) | BIT(2) }, // LED_SCROLL#, LED_CAP#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN }, // BRIGHTNESS
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EN
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#_EC
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT_EC
+    { &GPCRE1, GPIO_OUT | GPIO_DOWN }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // PERKB-DET#
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // BL_PWM_EN_EC
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT | GPIO_UP }, // PLVDD_RST_EC
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT_EC
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // MUX_CTRL_BIOS
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // EC_PECI
+    { &GPCRF7, GPIO_IN | GPIO_UP }, // SLP_S0#
+
+    { &GPCRG0, GPIO_OUT | GPIO_UP }, // LED_NUM#
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // AUTO_LOAD
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT#_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_ALT }, // ECCLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRH4, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT | GPIO_UP }, // AIRPLAN_LED#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRI6, GPIO_IN }, // OVERT#_EC
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_OUT | GPIO_UP }, // LED_CAP#
+    { &GPCRJ3, GPIO_OUT | GPIO_UP }, // LED_SCROLL#
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // POWER_IC_EN
+    { &GPCRJ7, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPIO data
-    GPDRA = 0x00;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0x00;
-    // PWR_BTN#, SCI#, SMI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    // PLVDD_RST_EC
-    GPDRE = BIT(6);
-    // EC_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT#_EC, LED_NUM#
-    GPDRG = BIT(6) | BIT(0);
-    // AIRPLAN_LED#
-    GPDRH = BIT(7);
-    GPDRI = 0x00;
-    // LED_SCROLL#, LED_CAP#
-    GPDRJ = BIT(3) | BIT(2);
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // BRIGHTNESS
-    GPCRA3 = GPIO_IN;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EN
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#_EC
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT_EC
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_DOWN;
-    // PERKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // BL_PWM_EN_EC
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // PLVDD_RST_EC
-    GPCRE6 = GPIO_OUT | GPIO_UP;
-    // SMD_BAT_EC
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // MUX_CTRL_BIOS
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // EC_PECI
-    GPCRF6 = GPIO_ALT;
-    // SLP_S0#
-    GPCRF7 = GPIO_IN | GPIO_UP;
-    // LED_NUM#
-    GPCRG0 = GPIO_OUT | GPIO_UP;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT#_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // ECCLKRUN#
-    GPCRH0 = GPIO_ALT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // GC6_FB_EN_PCH
-    GPCRH3 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // AIRPLAN_LED#
-    GPCRH7 = GPIO_OUT | GPIO_UP;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // RGBKB-DET#
-    GPCRI5 = GPIO_IN | GPIO_UP;
-    // OVERT#_EC
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // LED_CAP#
-    GPCRJ2 = GPIO_OUT | GPIO_UP;
-    // LED_SCROLL#
-    GPCRJ3 = GPIO_OUT | GPIO_UP;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // POWER_IC_EN
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // WLAN_PWR_EN
-    GPCRJ7 = GPIO_OUT | GPIO_UP;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/addw3/gpio.c
+++ b/src/board/system76/addw3/gpio.c
@@ -34,239 +34,136 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(D, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR1, 0 },
+    { &GCR2, 0 },
+    { &GCR10, 0x02 },
+    { &GCR21, 0 },
+    { &GCR22, 0x80 },
+    { &GCR22, 0x80 },
+    { &GCR23, 0x01 },
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(5) | BIT(4) }, // BL_PWM_EN_EC, XLP_OUT
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(4) }, // PLVDD_RST_EC
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(3) }, // PCH_DPWROK_EC
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(7) }, // CC_EN
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN }, // DDS_EC_PWM
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT }, // BL_PWM_EN_EC
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB_SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB_SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRD4, GPIO_OUT }, // PLVDD_RST_EC
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN }, // SINK_CTRL
+
+    { &GPCRG0, GPIO_IN }, // EC_GPG0
+    { &GPCRG1, GPIO_OUT }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_OUT }, // ME_WE
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_OUT }, // MUX_CTRL_BIOS
+    { &GPCRH4, GPIO_IN }, // ACE_I2C_IRQ2Z_EC
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_ALT }, // THERM_VOLT2
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // CC1_DET
+    { &GPCRI6, GPIO_IN }, // CC2_DET
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // EC_GPIO
+    { &GPCRJ7, GPIO_OUT }, // CC_EN
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // SERIRQ_ESPI_ALERT0
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    //TODO: what do these do?
-    GCR1 = 0;
-    GCR2 = 0;
-    GCR10 = 0x02;
-    GCR21 = 0;
-    GCR22 = 0x80;
-    GCR22 = 0x80;
-    GCR23 = 0x01;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // BL_PWM_EN_EC, XLP_OUT
-    GPDRB = BIT(5) | BIT(4);
-    GPDRC = 0;
-    // PLVDD_RST_EC
-    GPDRD = BIT(4);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // PCH_DPWROK_EC
-    GPDRF = BIT(3);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // CC_EN
-    GPDRJ = BIT(7);
-    GPOTA = 0;
-    GPOTB = 0;
-    GPOTD = 0;
-    GPOTE = 0;
-    GPOTF = 0;
-    GPOTH = 0;
-    GPOTJ = 0;
-
-    // Set GPIO control
-
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM
-    GPCRA3 = GPIO_IN;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // BL_PWM_EN_EC
-    GPCRB5 = GPIO_OUT;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB_SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB_SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRD3 = GPIO_OUT;
-    // PLVDD_RST_EC
-    GPCRD4 = GPIO_OUT;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // SINK_CTRL
-    GPCRF7 = GPIO_IN;
-
-    // EC_GPG0
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // ME_WE
-    GPCRH0 = GPIO_OUT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // MUX_CTRL_BIOS
-    GPCRH3 = GPIO_OUT;
-    // ACE_I2C_IRQ2Z_EC
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // SLP_SUS#
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // THERM_VOLT2
-    GPCRI2 = GPIO_ALT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // CC1_DET
-    GPCRI5 = GPIO_IN;
-    // CC2_DET
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_IN;
-    // CC_EN
-    GPCRJ7 = GPIO_OUT;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ_ESPI_ALERT0
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/addw4/gpio.c
+++ b/src/board/system76/addw4/gpio.c
@@ -34,226 +34,130 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(H, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, BIT(3) }, // DDS_EC_PWM
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(3) }, // VGA_HEATSINK_SW
+    { &GPDRE, BIT(3) }, // USB_PWR_EN#
+    { &GPDRF, 0 },
+    { &GPDRG, BIT(6) | BIT(0) }, // H_PROCHOT_EC, BL_PWM_EN_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(7) | BIT(1) }, // PLVDD_RST_EC, KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN_PWM
+    { &GPCRA3, GPIO_IN }, // DDS_EC_PWM
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN_PWM
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN }, // EC_LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_OUT }, // VGA_HEATSINK_SW
+    { &GPCRD4, GPIO_IN }, // 7411_SINK_CTRL
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_HEATSINK_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN# (XXX: Active high, despite pin name)
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_IN }, // EC_SMD_EN#
+    { &GPCRF7, GPIO_OUT }, // MUX_CTRL_BIOS
+
+    { &GPCRG0, GPIO_OUT }, // BL_PWM_EN_EC
+    { &GPCRG1, GPIO_IN }, // EC_WLAN_EN (NC)
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // PM_SLP_S0_CS_N
+    { &GPCRH1, GPIO_IN }, // EC_TEST_R_2
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRH4, GPIO_IN | GPIO_UP }, // OVERT#_EC
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // THERM_VOLT_GPU
+    { &GPCRI6, GPIO_ALT }, // THERM_VOLT_HEATSINK
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE# / USB charger detection
+    { &GPCRJ2, GPIO_ALT }, // PCH_FAN
+    { &GPCRJ3, GPIO_IN }, // HEATSINK_FANSEN_R
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // EC_GPIO
+    { &GPCRJ7, GPIO_OUT }, // PLVDD_RST_EC
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPM6 power domain to VCC
-    GCR23 = BIT(0);
-
-    // Set GPIO data
-    // DDS_EC_PWM
-    GPDRA = BIT(3);
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    // VGA_HEATSINK_SW
-    GPDRD = BIT(3);
-    // USB_PWR_EN#
-    GPDRE = BIT(3);
-    GPDRF = 0;
-    // H_PROCHOT_EC, BL_PWM_EN_EC
-    GPDRG = BIT(6) | BIT(0);
-    GPDRH = 0;
-    GPDRI = 0;
-    // PLVDD_RST_EC, KBC_MUTE#
-    GPDRJ = BIT(7) | BIT(1);
-
-    // Set GPIO control
-
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN_PWM
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM
-    GPCRA3 = GPIO_IN;
-    // VGA_FAN_PWM
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // EC_LAN_WAKEUP#
-    GPCRB2 = GPIO_IN;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // GC6_FB_EN_PCH
-    GPCRB5 = GPIO_IN;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // VGA_HEATSINK_SW
-    GPCRD3 = GPIO_OUT;
-    // 7411_SINK_CTRL
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_HEATSINK_FANSEN
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN# (XXX: Active high, despite pin name)
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // JACK_IN#_EC
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // EC_SMD_EN#
-    GPCRF6 = GPIO_IN;
-    // MUX_CTRL_BIOS
-    GPCRF7 = GPIO_OUT;
-
-    // BL_PWM_EN_EC
-    GPCRG0 = GPIO_OUT;
-    // EC_WLAN_EN (NC)
-    GPCRG1 = GPIO_IN;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // PM_SLP_S0_CS_N
-    GPCRH0 = GPIO_IN;
-    // EC_TEST_R_2
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // WLAN_PWR_EN
-    GPCRH3 = GPIO_OUT;
-    // OVERT#_EC
-    GPCRH4 = GPIO_IN | GPIO_UP;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // DGPU_PWR_EN
-    GPCRH6 = GPIO_IN;
-    // SLP_SUS#
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT_CPU
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // THERM_VOLT_GPU
-    GPCRI5 = GPIO_ALT;
-    // THERM_VOLT_HEATSINK
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE# / USB charger detection
-    GPCRJ1 = GPIO_IN;
-    // PCH_FAN
-    GPCRJ2 = GPIO_ALT;
-    // HEATSINK_FANSEN_R
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_IN;
-    // PLVDD_RST_EC
-    GPCRJ7 = GPIO_OUT;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/bonw14/gpio.c
+++ b/src/board/system76/bonw14/gpio.c
@@ -41,202 +41,127 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4); // renamed to EN_3V
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+
+    // Port data
+    { &GPDRA, 0xA1 },
+    { &GPDRB, 0x18 },
+    { &GPDRC, 0 },
+    { &GPDRD, 0x38 },
+    { &GPDRE, 0 },
+    { &GPDRF, 0xC0 },
+    { &GPDRG, 0 },
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, 0x02 },
+
+    // Port control
+    { &GPCRA0, GPIO_OUT }, // DGPU_PWR_EN
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN_PWM
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN_PWM
+    { &GPCRA5, GPIO_OUT }, // EC_LAN_EN
+    { &GPCRA6, GPIO_OUT | GPIO_UP }, // TODO: TBTA_I2C_IRQ2Z
+    { &GPCRA7, GPIO_OUT }, // TODO: CPU_ID_EC
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKE#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // EN_3V
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // EC_EN
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // KBC_SMBus_CLK1
+    { &GPCRC2, GPIO_ALT }, // KBC_SMBus_DAT1
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // KBC_SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN }, // TODO: GPU_PWR_EN# / TBTA_HRESET
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_IN }, // AC_V2_EC
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // VGA_THROTTLE
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT | GPIO_UP }, // USBVCC_ON#
+
+    { &GPCRG0, GPIO_IN }, // EAPD_MODE
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // 100K pull-up to VDD3
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_ALT }, // PM_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN }, // GC6_FB_EN
+    { &GPCRH4, GPIO_IN }, // TH_OVERT#1
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT }, // TODO: BT_EN / VGA_GATE_CTRL
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // TODO: ECPIN68
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // TODO: CABLE_DET / PCH_SLP_SUS#
+    { &GPCRI6, GPIO_OUT }, // FAN_CLEAN
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // TODO: ECPIN78
+    { &GPCRJ3, GPIO_IN | GPIO_UP }, // PERKB-DET#
+    { &GPCRJ4, GPIO_OUT }, // SLP_SUS#
+    { &GPCRJ5, GPIO_OUT }, // BATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // AC_V1_EC
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPIO data
-    GPDRA = 0xA1;
-    GPDRB = 0x18;
-    GPDRC = 0x00;
-    GPDRD = 0x38;
-    GPDRE = 0x00;
-    GPDRF = 0xC0;
-    GPDRG = 0x00;
-    GPDRH = 0x00;
-    GPDRI = 0x00;
-    GPDRJ = 0x02;
-
-    // Set GPIO control
-    // DGPU_PWR_EN
-    GPCRA0 = GPIO_OUT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN_PWM
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN_PWM
-    GPCRA4 = GPIO_ALT;
-    // EC_LAN_EN
-    GPCRA5 = GPIO_OUT;
-    // TBTA_I2C_IRQ2Z - TODO
-    GPCRA6 = GPIO_OUT | GPIO_UP;
-    // CPU_ID_EC - TODO
-    GPCRA7 = GPIO_OUT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKE#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // EN_3V
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // EC_EN
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // KBC_SMBus_CLK1
-    GPCRC1 = GPIO_ALT;
-    // KBC_SMBus_DAT1
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // KBC_SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // GPU_PWR_EN# and TBTA_HRESET - TODO
-    GPCRE2 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_OUT;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // AC_V2_EC
-    GPCRF1 = GPIO_IN;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // VGA_THROTTLE
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // USBVCC_ON#
-    GPCRF7 = GPIO_OUT | GPIO_UP;
-    // EAPD_MODE
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // 100K pull-up to VDD3
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // PM_CLKRUN#
-    GPCRH0 = GPIO_ALT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // GC6_FB_EN
-    GPCRH3 = GPIO_IN;
-    // TH_OVERT#1
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // BT_EN and VGA_GATE_CTRL - TODO
-    GPCRH7 = GPIO_OUT;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ECPIN68 - TODO
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // CABLE_DET and PCH_SLP_SUS# - TODO
-    GPCRI5 = GPIO_IN;
-    // FAN_CLEAN
-    GPCRI6 = GPIO_OUT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // ECPIN78 - TODO
-    GPCRJ2 = GPIO_IN;
-    // PERKB-DET#
-    GPCRJ3 = GPIO_IN | GPIO_UP;
-    // SLP_SUS#
-    GPCRJ4 = GPIO_OUT;
-    // BATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // AC_V1_EC
-    GPCRJ7 = GPIO_IN;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/bonw15/gpio.c
+++ b/src/board/system76/bonw15/gpio.c
@@ -36,240 +36,135 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(B, 5);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR1, 0 },
+    { &GCR2, 0 },
+    { &GCR10, 0x02 },
+    { &GCR21, 0 },
+    { &GCR22, 0x80 },
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, BIT(6) }, // PLVDD_RST_EC
+    { &GPDRD, BIT(3) }, // BL_PWM_EN_EC
+    { &GPDRE, BIT(3) }, // USB_PWR_EN# (inverted)
+    { &GPDRF, BIT(3) }, // PCH_DPWROK_EC
+    { &GPDRG, BIT(6) }, // H_PROCHOT#_EC
+    { &GPDRH, BIT(6) }, // EC_AMP_EN
+    { &GPDRI, 0 },
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN }, // DDS_EC_PWM
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PLVDD_RST_EC
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET_N
+    { &GPCRD3, GPIO_OUT }, // BL_PWM_EN_EC
+    { &GPCRD4, GPIO_OUT }, // MUX_CTRL_BIOS
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB_DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN }, // CPU_C10_GATE#
+
+    { &GPCRG0, GPIO_IN }, // dGPU_OVERT_EC
+    { &GPCRG1, GPIO_OUT }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // 100k pull up to VDD3
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT#_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // SINK_CTRL
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_IN }, // TBT_I2C_IRQ2Z
+    { &GPCRH4, GPIO_IN }, // BOARD_ID0
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRH7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // SYS_PWROK_EC
+    { &GPCRI6, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI7, GPIO_IN }, // BOARD_ID1
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN | GPIO_DOWN }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // PERKB_DET#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALERT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    //TODO: what do these do?
-    GCR1 = 0;
-    GCR2 = 0;
-    GCR10 = 0x02;
-    GCR21 = 0;
-    GCR22 = 0x80;
-    GCR23 = 0x01;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    // PLVDD_RST_EC
-    GPDRC = BIT(6);
-    // BL_PWM_EN_EC
-    GPDRD = BIT(3);
-    // USB_PWR_EN# (inverted)
-    GPDRE = BIT(3);
-    // PCH_DPWROK_EC
-    GPDRF = BIT(3);
-    // H_PROCHOT#_EC
-    GPDRG = BIT(6);
-    // EC_AMP_EN
-    GPDRH = BIT(6);
-    GPDRI = 0;
-    GPDRJ = 0;
-
-    GPOTA = 0;
-    GPOTB = 0;
-    GPOTD = 0;
-    GPOTE = 0;
-    GPOTF = 0;
-    GPOTH = 0;
-    GPOTJ = 0;
-
-    // Set GPIO control
-
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM
-    GPCRA3 = GPIO_IN;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // EC_LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // WLAN_PWR_EN
-    GPCRB5 = GPIO_OUT;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PLVDD_RST_EC
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET_N
-    GPCRD2 = GPIO_ALT;
-    // BL_PWM_EN_EC
-    GPCRD3 = GPIO_OUT;
-    // MUX_CTRL_BIOS
-    GPCRD4 = GPIO_OUT;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB_DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // JACK_IN#_EC
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRF7 = GPIO_IN;
-
-    // dGPU_OVERT_EC
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT;
-    // 100k pull up to VDD3
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT#_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // SINK_CTRL
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // TBT_I2C_IRQ2Z
-    GPCRH3 = GPIO_IN;
-    // BOARD_ID0
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // EC_AMP_EN
-    GPCRH6 = GPIO_OUT;
-    // SLP_SUS#
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT_CPU
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // SYS_PWROK_EC
-    GPCRI5 = GPIO_OUT;
-    // THERM_VOLT_CPU
-    GPCRI6 = GPIO_ALT;
-    // BOARD_ID1
-    GPCRI7 = GPIO_IN;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_IN | GPIO_DOWN;
-    // PERKB_DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALERT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/darp10-b/gpio.c
+++ b/src/board/system76/darp10-b/gpio.c
@@ -33,230 +33,133 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(E, 1);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(7) | BIT(0) }, // Set GPB5 and GPD2 to 1.8V
+    { &GCR20, BIT(7) }, // Set GPD3 to 1.8V, GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(5) | BIT(2) | BIT(1) }, // Set GPF7, GPH0, and GPH1 to 1.8V
+    { &GCR22, BIT(7) },
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) }, // PWR_BTN#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_IN }, // KBC_BEEP (NC)
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN1
+    { &GPCRA3, GPIO_ALT }, // CPU_FAN2
+    { &GPCRA4, GPIO_IN }, // NC
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_IN }, // SLP_S0#
+    { &GPCRB6, GPIO_OUT }, // SUSBC_EC
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRC7, GPIO_OUT }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET_N
+    { &GPCRD3, GPIO_IN }, // SLP_A#
+    { &GPCRD4, GPIO_OUT }, // PD_POWER_EN
+    { &GPCRD5, GPIO_OUT }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN1
+    { &GPCRD7, GPIO_ALT }, // CPU_FANSEN2
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRE2, GPIO_IN }, // TBT_I2C_IRQ2Z
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT }, // ME_WE
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT }, // AC_PRESENT
+
+    { &GPCRG0, GPIO_IN }, // NC
+    { &GPCRG1, GPIO_IN }, // NC
+    { &GPCRG2, GPIO_IN }, // 100k pull-up to VDD3
+    { &GPCRG3, GPIO_ALT }, // HSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // HSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // HSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // HSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT }, // LED_ACIN
+    { &GPCRH3, GPIO_IN }, // NC
+    { &GPCRH4, GPIO_IN }, // NC
+    { &GPCRH5, GPIO_OUT }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // NC
+    { &GPCRH7, GPIO_IN }, // NC
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_IN | GPIO_UP }, // RGBKB_DET#
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // EC_CCD_WP#
+    { &GPCRI6, GPIO_ALT }, // THERM_VOLT2
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // SINK_CTRL_EC_1
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // SINK_CTRL_EC_2
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // KB-DET
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPB5 and GPD2 to 1.8V
-    GCR19 = BIT(7) | BIT(0);
-    // Set GPD3 to 1.8V, GPF2 and GPF3 to 3.3V
-    GCR20 = BIT(7);
-    // Set GPF7, GPH0, and GPH1 to 1.8V
-    GCR21 = BIT(5) | BIT(2) | BIT(1);
-    // Not documented
-    GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#
-    GPDRD = BIT(5);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP (NC)
-    GPCRA1 = GPIO_IN;
-    // CPU_FAN1
-    GPCRA2 = GPIO_ALT;
-    // CPU_FAN2
-    GPCRA3 = GPIO_ALT;
-    // NC
-    GPCRA4 = GPIO_IN;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // EC_LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SLP_S0#
-    GPCRB5 = GPIO_IN;
-    // SUSBC_EC
-    GPCRB6 = GPIO_OUT;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // JACK_IN#_EC
-    GPCRC6 = GPIO_IN;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET_N
-    GPCRD2 = GPIO_ALT;
-    // SLP_A#
-    GPCRD3 = GPIO_IN;
-    // PD_POWER_EN
-    GPCRD4 = GPIO_OUT;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT;
-    // CPU_FANSEN1
-    GPCRD6 = GPIO_ALT;
-    // CPU_FANSEN2
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // WLAN_PWR_EN
-    GPCRE1 = GPIO_OUT;
-    // TBT_I2C_IRQ2Z
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // ME_WE
-    GPCRE6 = GPIO_OUT;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_IN;
-    // PCH_PWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRF7 = GPIO_OUT;
-
-    // NC
-    GPCRG0 = GPIO_IN;
-    // NC
-    GPCRG1 = GPIO_IN;
-    // 100k pull-up to VDD3
-    GPCRG2 = GPIO_IN;
-    // HSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // HSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // HSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT;
-    // HSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // SUSB#_PCH
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT;
-    // NC
-    GPCRH3 = GPIO_IN;
-    // NC
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT;
-    // NC
-    GPCRH6 = GPIO_IN;
-    // NC
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // RGBKB_DET#
-    GPCRI2 = GPIO_IN | GPIO_UP;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // EC_CCD_WP#
-    GPCRI5 = GPIO_OUT;
-    // THERM_VOLT2
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // SINK_CTRL_EC_1
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // SINK_CTRL_EC_2
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // KB-DET
-    GPCRJ7 = GPIO_IN;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/darp10/gpio.c
+++ b/src/board/system76/darp10/gpio.c
@@ -33,230 +33,133 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(E, 1);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(7) | BIT(0) }, // Set GPB5 and GPD2 to 1.8V
+    { &GCR20, BIT(7) }, // Set GPD3 to 1.8V, GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(5) | BIT(2) | BIT(1) }, // Set GPF7, GPH0, and GPH1 to 1.8V
+    { &GCR22, BIT(7) },
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) }, // PWR_BTN#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_IN }, // KBC_BEEP (NC)
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN1
+    { &GPCRA3, GPIO_ALT }, // CPU_FAN2
+    { &GPCRA4, GPIO_IN }, // NC
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_IN }, // SLP_S0#
+    { &GPCRB6, GPIO_OUT }, // SUSBC_EC
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRC7, GPIO_OUT }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET_N
+    { &GPCRD3, GPIO_IN }, // SLP_A#
+    { &GPCRD4, GPIO_OUT }, // PD_POWER_EN
+    { &GPCRD5, GPIO_OUT }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN1
+    { &GPCRD7, GPIO_ALT }, // CPU_FANSEN2
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRE2, GPIO_IN }, // TBT_I2C_IRQ2Z
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT }, // ME_WE
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT }, // AC_PRESENT
+
+    { &GPCRG0, GPIO_IN }, // NC
+    { &GPCRG1, GPIO_IN }, // NC
+    { &GPCRG2, GPIO_IN }, // 100k pull-up to VDD3
+    { &GPCRG3, GPIO_ALT }, // HSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // HSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // HSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // HSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT }, // LED_ACIN
+    { &GPCRH3, GPIO_IN }, // NC
+    { &GPCRH4, GPIO_IN }, // NC
+    { &GPCRH5, GPIO_OUT }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // NC
+    { &GPCRH7, GPIO_IN }, // NC
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_IN | GPIO_UP }, // RGBKB_DET#
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // EC_CCD_WP#
+    { &GPCRI6, GPIO_ALT }, // THERM_VOLT2
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // SINK_CTRL_EC_1
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // SINK_CTRL_EC_2
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // KB-DET
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPB5 and GPD2 to 1.8V
-    GCR19 = BIT(7) | BIT(0);
-    // Set GPD3 to 1.8V, GPF2 and GPF3 to 3.3V
-    GCR20 = BIT(7);
-    // Set GPF7, GPH0, and GPH1 to 1.8V
-    GCR21 = BIT(5) | BIT(2) | BIT(1);
-    // Not documented
-    GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#
-    GPDRD = BIT(5);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP (NC)
-    GPCRA1 = GPIO_IN;
-    // CPU_FAN1
-    GPCRA2 = GPIO_ALT;
-    // CPU_FAN2
-    GPCRA3 = GPIO_ALT;
-    // NC
-    GPCRA4 = GPIO_IN;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // EC_LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SLP_S0#
-    GPCRB5 = GPIO_IN;
-    // SUSBC_EC
-    GPCRB6 = GPIO_OUT;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // JACK_IN#_EC
-    GPCRC6 = GPIO_IN;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET_N
-    GPCRD2 = GPIO_ALT;
-    // SLP_A#
-    GPCRD3 = GPIO_IN;
-    // PD_POWER_EN
-    GPCRD4 = GPIO_OUT;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT;
-    // CPU_FANSEN1
-    GPCRD6 = GPIO_ALT;
-    // CPU_FANSEN2
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // WLAN_PWR_EN
-    GPCRE1 = GPIO_OUT;
-    // TBT_I2C_IRQ2Z
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // ME_WE
-    GPCRE6 = GPIO_OUT;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_IN;
-    // PCH_PWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRF7 = GPIO_OUT;
-
-    // NC
-    GPCRG0 = GPIO_IN;
-    // NC
-    GPCRG1 = GPIO_IN;
-    // 100k pull-up to VDD3
-    GPCRG2 = GPIO_IN;
-    // HSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // HSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // HSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT;
-    // HSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // SUSB#_PCH
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT;
-    // NC
-    GPCRH3 = GPIO_IN;
-    // NC
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT;
-    // NC
-    GPCRH6 = GPIO_IN;
-    // NC
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // RGBKB_DET#
-    GPCRI2 = GPIO_IN | GPIO_UP;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // EC_CCD_WP#
-    GPCRI5 = GPIO_OUT;
-    // THERM_VOLT2
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // SINK_CTRL_EC_1
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // SINK_CTRL_EC_2
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // KB-DET
-    GPCRJ7 = GPIO_IN;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/darp5/gpio.c
+++ b/src/board/system76/darp5/gpio.c
@@ -45,197 +45,123 @@ struct Gpio __code WLAN_EN =        GPIO(H, 5);
 struct Gpio __code WLAN_PWR_EN =    GPIO(J, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(0) }, // NC
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SCI#, SMI#
+    { &GPDRE, 0 },
+    { &GPDRF, BIT(7) | BIT(6) }, // USB_PWR_EN#, H_PECI
+    { &GPDRG, BIT(6) }, // AIRPLAN_LED#
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_IN }, // EC_SSD_LED#
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN }, // PCH_DPWROK_EC
+    { &GPCRA4, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRA5, GPIO_OUT }, // LED_BAT_CHG
+    { &GPCRA6, GPIO_OUT }, // LED_BAT_FULL
+    { &GPCRA7, GPIO_OUT }, // LED_PWR
+
+    { &GPCRB0, GPIO_OUT }, // NC
+    { &GPCRB1, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_ALT }, // SMC_BAT
+    { &GPCRB4, GPIO_ALT }, // SMD_BAT
+    { &GPCRB5, GPIO_OUT }, // GA20
+    { &GPCRB6, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB7, GPIO_IN }, // FP_RST#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KSO16 (Darter)
+    { &GPCRC4, GPIO_OUT }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KSO17 (Darter)
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT }, // LED_ACIN
+
+    { &GPCRD0, GPIO_IN | GPIO_UP }, // PWR_SW#
+    { &GPCRD1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SMI#
+    { &GPCRD4, GPIO_IN }, // SCI#
+    { &GPCRD5, GPIO_OUT }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // SUSWARN#
+
+    { &GPCRE0, GPIO_OUT }, // SWI#
+    { &GPCRE1, GPIO_OUT }, // EC_EN
+    { &GPCRE2, GPIO_IN }, // PCH_SLP_WLAN#_R
+    { &GPCRE3, GPIO_OUT }, // VA_EC_EN
+    { &GPCRE4, GPIO_OUT }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT }, // SB_KBCRST#
+    { &GPCRE7, GPIO_OUT }, // AC_PRESENT / PM_PWROK
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // BT_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT }, // USB_PWR_EN#
+
+    { &GPCRG0, GPIO_OUT }, // CCD_EN
+    { &GPCRG1, GPIO_OUT }, // 3G_EN
+    { &GPCRG2, GPIO_OUT }, // VDD3
+    { &GPCRG3, GPIO_ALT }, // HSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // HSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // HSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // AIRPLAN_LED#
+    { &GPCRG7, GPIO_ALT }, // HCPI_SCLK
+
+    { &GPCRH0, GPIO_ALT }, // EC_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT }, // BKL_EN
+    { &GPCRH3, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRH4, GPIO_IN }, // VR_ON
+    { &GPCRH5, GPIO_OUT }, // WLAN_EN
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_IN }, // SLP_SUS#
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // AZ_RST#_EC
+    { &GPCRI6, GPIO_IN }, // LIGHT_KB_DET#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_IN | GPIO_DOWN }, // SUS_PWR_ACK
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_OUT }, // ME_WE
+    { &GPCRJ3, GPIO_IN }, // SOC_TYPE
+    { &GPCRJ4, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRJ5, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ6, GPIO_OUT }, // 3G_PWR_EN
+    { &GPCRJ7, GPIO_IN }, // NC
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // NC
-    GPDRB = BIT(0);
-    GPDRC = 0;
-    // PWR_BTN#, SCI#, SMI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    GPDRE = 0;
-    // USB_PWR_EN#, H_PECI
-    GPDRF = BIT(7) | BIT(6);
-    // AIRPLAN_LED#
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    GPDRJ = 0;
-
-    // Set GPIO control
-    // EC_SSD_LED#
-    GPCRA0 = GPIO_IN;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // PCH_DPWROK_EC
-    GPCRA3 = GPIO_IN;
-    // PCH_PWROK_EC
-    GPCRA4 = GPIO_OUT;
-    // LED_BAT_CHG
-    GPCRA5 = GPIO_OUT;
-    // LED_BAT_FULL
-    GPCRA6 = GPIO_OUT;
-    // LED_PWR
-    GPCRA7 = GPIO_OUT;
-    // NC
-    GPCRB0 = GPIO_OUT;
-    // H_PROCHOT_EC
-    GPCRB1 = GPIO_OUT;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // SMC_BAT
-    GPCRB3 = GPIO_ALT;
-    // SMD_BAT
-    GPCRB4 = GPIO_ALT;
-    // GA20
-    GPCRB5 = GPIO_OUT;
-    // AC_IN#
-    GPCRB6 = GPIO_IN | GPIO_UP;
-    // FP_RST#
-    GPCRB7 = GPIO_IN;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KSO16 (Darter)
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_OUT;
-    // KSO17 (Darter)
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT;
-    // PWR_SW#
-    GPCRD0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRD1 = GPIO_IN | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SMI#
-    GPCRD3 = GPIO_IN;
-    // SCI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // SUSWARN#
-    GPCRD7 = GPIO_IN;
-    // SWI#
-    GPCRE0 = GPIO_OUT;
-    // EC_EN
-    GPCRE1 = GPIO_OUT;
-    // PCH_SLP_WLAN#_R
-    GPCRE2 = GPIO_IN;
-    // VA_EC_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_OUT;
-    // AC_PRESENT / PM_PWROK
-    GPCRE7 = GPIO_OUT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // BT_EN
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // USB_PWR_EN#
-    GPCRF7 = GPIO_OUT;
-    // CCD_EN
-    GPCRG0 = GPIO_OUT;
-    // 3G_EN
-    GPCRG1 = GPIO_OUT;
-    // VDD3
-    GPCRG2 = GPIO_OUT;
-    // HSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // HSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // HSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // AIRPLAN_LED#
-    GPCRG6 = GPIO_OUT;
-    // HCPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // EC_CLKRUN#
-    GPCRH0 = GPIO_ALT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT;
-    // RGBKB-DET#
-    GPCRH3 = GPIO_IN | GPIO_UP;
-    // VR_ON
-    GPCRH4 = GPIO_IN;
-    // WLAN_EN
-    GPCRH5 = GPIO_OUT;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // SLP_SUS#
-    GPCRI2 = GPIO_IN;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // AZ_RST#_EC
-    GPCRI5 = GPIO_IN;
-    // LIGHT_KB_DET#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // SUS_PWR_ACK
-    GPCRJ0 = GPIO_IN | GPIO_DOWN;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // ME_WE
-    GPCRJ2 = GPIO_OUT;
-    // SOC_TYPE
-    GPCRJ3 = GPIO_IN;
-    // WLAN_PWR_EN
-    GPCRJ4 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ5 = GPIO_ALT;
-    // 3G_PWR_EN
-    GPCRJ6 = GPIO_OUT;
-    // NC
-    GPCRJ7 = GPIO_IN;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/darp7/gpio.c
+++ b/src/board/system76/darp7/gpio.c
@@ -42,213 +42,130 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(2) }, // Set GPH0 to 1.8V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) | BIT(2) }, // XLP_OUT, PWR_SW#, PCH_DPWROK_EC
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) }, // PWR_BTN#, SMI#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN#
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC#
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_OUT | GPIO_UP }, // PCH_PWROK_EC
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_OUT | GPIO_UP }, // PCH_DPWROK_EC
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EN
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // EC_ERST#
+    { &GPCRD3, GPIO_IN | GPIO_DOWN }, // CPU_C10_GATE#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // SINK_CTRL_EC
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_UP | GPIO_DOWN }, // NC
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN | GPIO_UP }, //TODO: CC_EN
+
+    { &GPCRG0, GPIO_IN }, // VCCIN_AUX_PG
+    { &GPCRG1, GPIO_ALT | GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC#
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // PM_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRH4, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // NC
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // USB_CC1
+    { &GPCRI6, GPIO_ALT }, // USB_CC2
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, //TODO: EC_SDCARD_WAKEUP#
+    { &GPCRJ3, GPIO_IN }, // SLP_S0#
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // PCH_SLP_WLAN#_R
+    { &GPCRJ7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_AD0
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_AD1
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_AD2
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_AD3
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS#
+    { &GPCRM6, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ALERT#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-    // Set GPH0 to 1.8V
-    GCR21 = BIT(2);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#, PCH_DPWROK_EC
-    GPDRB = BIT(4) | BIT(3) | BIT(2);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
-    // USB_PWR_EN#
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC#
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRA4 = GPIO_OUT | GPIO_UP;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRB2 = GPIO_OUT | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EN
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // EC_ERST#
-    GPCRD2 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRD3 = GPIO_IN | GPIO_DOWN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // SINK_CTRL_EC
-    GPCRD7 = GPIO_IN;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // NC
-    GPCRF3 = 0x06;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    //TODO: CC_EN
-    GPCRF7 = GPIO_IN | GPIO_UP;
-    // VCCIN_AUX_PG
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC#
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // PM_CLKRUN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRH3 = GPIO_IN;
-    // EC_LAN_WAKEUP#
-    GPCRH4 = GPIO_IN | GPIO_UP;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // NC
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // USB_CC1
-    GPCRI5 = GPIO_ALT;
-    // USB_CC2
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    //TODO: EC_SDCARD_WAKEUP#
-    GPCRJ2 = GPIO_IN;
-    // SLP_S0#
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // PCH_SLP_WLAN#_R
-    GPCRJ6 = GPIO_IN;
-    // SLP_SUS#
-    GPCRJ7 = GPIO_IN;
-    // ESPI_AD0
-    GPCRM0 = 0x06;
-    // ESPI_AD1
-    GPCRM1 = 0x06;
-    // ESPI_AD2
-    GPCRM2 = 0x06;
-    // ESPI_AD3
-    GPCRM3 = 0x06;
-    // ESPI_CLK_EC
-    GPCRM4 = 0x06;
-    // ESPI_CS#
-    GPCRM5 = GPIO_ALT;
-    // ALERT#
-    GPCRM6 = 0x86;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/darp8/gpio.c
+++ b/src/board/system76/darp8/gpio.c
@@ -39,218 +39,132 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(G, 1);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    //{ &GCR22, BIT(7) },
+    //{ &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) | BIT(2) }, // XLP_OUT, PWR_SW#, PCH_DPWROK_EC
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) }, // PWR_BTN#, SMI#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC#
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN1
+    { &GPCRA3, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRA4, GPIO_OUT | GPIO_UP }, // PCH_PWROK_EC
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_OUT | GPIO_UP }, // PCH_DPWROK_EC
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_IN | GPIO_DOWN }, // Not connected
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // EC_ERST#
+    { &GPCRD3, GPIO_IN | GPIO_DOWN }, // CPU_C10_GATE#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // SINK_CTRL_EC
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN | GPIO_UP }, // CC_EN
+
+    { &GPCRG0, GPIO_IN }, // VCCIN_AUX_PG
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC#
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // EC_GPIO
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRH4, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN | GPIO_DOWN }, // Not connected
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // USB_CC1
+    { &GPCRI6, GPIO_ALT }, // USB_CC2
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // EC_SDCARD_WAKEUP#
+    { &GPCRJ3, GPIO_IN }, // SLP_S0#
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // SLP_WLAN#
+    { &GPCRJ7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#, PCH_DPWROK_EC
-    GPDRB = BIT(4) | BIT(3) | BIT(2);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC#
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // JACK_IN#_EC
-    GPCRA3 = GPIO_IN;
-    // PCH_PWROK_EC
-    GPCRA4 = GPIO_OUT | GPIO_UP;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRB2 = GPIO_OUT | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // Not connected
-    GPCRC6 = GPIO_IN | GPIO_DOWN;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // EC_ERST#
-    GPCRD2 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRD3 = GPIO_IN | GPIO_DOWN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // SINK_CTRL_EC
-    GPCRD7 = GPIO_IN;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // WLAN_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CC_EN
-    GPCRF7 = GPIO_IN | GPIO_UP;
-    // VCCIN_AUX_PG
-    GPCRG0 = GPIO_IN;
-    // WLAN_PWR_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC#
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // EC_GPIO
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRH3 = GPIO_IN;
-    // EC_LAN_WAKEUP#
-    GPCRH4 = GPIO_IN | GPIO_UP;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // Not connected
-    GPCRH7 = GPIO_IN | GPIO_DOWN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT_CPU
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // USB_CC1
-    GPCRI5 = GPIO_ALT;
-    // USB_CC2
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // EC_SDCARD_WAKEUP#
-    GPCRJ2 = GPIO_IN;
-    // SLP_S0#
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // SLP_WLAN#
-    GPCRJ6 = GPIO_IN;
-    // SLP_SUS#
-    GPCRJ7 = GPIO_IN;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/darp9/gpio.c
+++ b/src/board/system76/darp9/gpio.c
@@ -39,228 +39,132 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(G, 1);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    //{ &GCR22, BIT(7) },
+    //{ &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) | BIT(2) }, // XLP_OUT, PWR_SW#, PCH_DPWROK_EC
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) }, // PWR_BTN#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(7) | BIT(6) }, // CC_EN, H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC#
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN }, // NC (JACK_IN#_EC)
+    { &GPCRA4, GPIO_OUT | GPIO_UP }, // PCH_PWROK_EC
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_OUT | GPIO_UP }, // PCH_DPWROK_EC
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_IN | GPIO_DOWN }, // Not connected
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // EC_ERST#
+    { &GPCRD3, GPIO_IN | GPIO_DOWN }, // CPU_C10_GATE#
+    { &GPCRD4, GPIO_OUT }, // ME_WE
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // SINK_CTRL_EC
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN }, // ACE_I2C_IRQ2Z
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT | GPIO_UP }, // CC_EN
+
+    { &GPCRG0, GPIO_IN }, // VCCIN_AUX_PG
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // HSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // HSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // HSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC#
+    { &GPCRG7, GPIO_ALT }, // HSPI_SCLK
+
+    { &GPCRH0, GPIO_OUT | GPIO_UP }, // EC_GPIO
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRH4, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRH5, GPIO_OUT }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT }, // PD_POWER_EN
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN | GPIO_UP }, // NC (USB_CC1)
+    { &GPCRI6, GPIO_IN | GPIO_UP }, // NC (USB_CC2)
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN | GPIO_DOWN }, // NC (EC_SDCARD_WAKEUP#)
+    { &GPCRJ3, GPIO_IN }, // SLP_S0#
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // SLP_WLAN#
+    { &GPCRJ7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#, PCH_DPWROK_EC
-    GPDRB = BIT(4) | BIT(3) | BIT(2);
-    GPDRC = 0;
-    // PWR_BTN#
-    GPDRD = BIT(5);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // CC_EN, H_PECI
-    GPDRF = BIT(7) | BIT(6);
-    // H_PROCHOT_EC#
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // NC (JACK_IN#_EC)
-    GPCRA3 = GPIO_IN;
-    // PCH_PWROK_EC
-    GPCRA4 = GPIO_OUT | GPIO_UP;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRB2 = GPIO_OUT | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // Not connected
-    GPCRC6 = GPIO_IN | GPIO_DOWN;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // EC_ERST#
-    GPCRD2 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRD3 = GPIO_IN | GPIO_DOWN;
-    // ME_WE
-    GPCRD4 = GPIO_OUT;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // SINK_CTRL_EC
-    GPCRD7 = GPIO_IN;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // ACE_I2C_IRQ2Z
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // WLAN_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CC_EN
-    GPCRF7 = GPIO_OUT | GPIO_UP;
-
-    // VCCIN_AUX_PG
-    GPCRG0 = GPIO_IN;
-    // WLAN_PWR_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // HSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // HSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // HSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC#
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // HSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // EC_GPIO
-    GPCRH0 = GPIO_OUT | GPIO_UP;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRH3 = GPIO_IN;
-    // EC_LAN_WAKEUP#
-    GPCRH4 = GPIO_IN | GPIO_UP;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // PD_POWER_EN
-    GPCRH7 = GPIO_OUT;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // RGBKB-DET#
-    GPCRI2 = GPIO_IN | GPIO_UP;
-    // THERM_VOLT_CPU
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // NC (USB_CC1)
-    GPCRI5 = GPIO_IN | GPIO_UP;
-    // NC (USB_CC2)
-    GPCRI6 = GPIO_IN | GPIO_UP;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // NC (EC_SDCARD_WAKEUP#)
-    GPCRJ2 = GPIO_IN | GPIO_DOWN;
-    // SLP_S0#
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // SLP_WLAN#
-    GPCRJ6 = GPIO_IN;
-    // SLP_SUS#
-    GPCRJ7 = GPIO_IN;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/galp3-c/gpio.c
+++ b/src/board/system76/galp3-c/gpio.c
@@ -44,197 +44,123 @@ struct Gpio __code WLAN_EN =        GPIO(H, 5);
 struct Gpio __code WLAN_PWR_EN =    GPIO(J, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(0) }, // NC
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SCI#, SMI#
+    { &GPDRE, 0 },
+    { &GPDRF, BIT(7) | BIT(6) }, // USB_PWR_EN#, H_PECI
+    { &GPDRG, BIT(6) }, // AIRPLAN_LED#
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_IN }, // EC_SSD_LED#
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN }, // PCH_DPWROK_EC
+    { &GPCRA4, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRA5, GPIO_OUT }, // LED_BAT_CHG
+    { &GPCRA6, GPIO_OUT }, // LED_BAT_FULL
+    { &GPCRA7, GPIO_OUT }, // LED_PWR
+
+    { &GPCRB0, GPIO_OUT }, // NC
+    { &GPCRB1, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_ALT }, // SMC_BAT
+    { &GPCRB4, GPIO_ALT }, // SMD_BAT
+    { &GPCRB5, GPIO_OUT }, // GA20
+    { &GPCRB6, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB7, GPIO_IN }, // FP_RST#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_IN | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_IN | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KSO16 (Darter)
+    { &GPCRC4, GPIO_OUT }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KSO17 (Darter)
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT }, // LED_ACIN
+
+    { &GPCRD0, GPIO_IN | GPIO_UP }, // PWR_SW#
+    { &GPCRD1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SMI#
+    { &GPCRD4, GPIO_IN }, // SCI#
+    { &GPCRD5, GPIO_OUT }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // SUSWARN#
+
+    { &GPCRE0, GPIO_OUT }, // SWI#
+    { &GPCRE1, GPIO_OUT }, // EC_EN
+    { &GPCRE2, GPIO_IN }, // PCH_SLP_WLAN#_R
+    { &GPCRE3, GPIO_OUT }, // VA_EC_EN
+    { &GPCRE4, GPIO_OUT }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT }, // SB_KBCRST#
+    { &GPCRE7, GPIO_OUT }, // AC_PRESENT / PM_PWROK
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // BT_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT }, // USB_PWR_EN#
+
+    { &GPCRG0, GPIO_OUT }, // CCD_EN
+    { &GPCRG1, GPIO_OUT }, // 3G_EN
+    { &GPCRG2, GPIO_OUT }, // VDD3
+    { &GPCRG3, GPIO_ALT }, // HSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // HSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // HSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // AIRPLAN_LED#
+    { &GPCRG7, GPIO_ALT }, // HCPI_SCLK
+
+    { &GPCRH0, GPIO_ALT }, // EC_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT }, // BKL_EN
+    { &GPCRH3, GPIO_OUT }, // NC
+    { &GPCRH4, GPIO_IN }, // VR_ON
+    { &GPCRH5, GPIO_OUT }, // WLAN_EN
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_IN }, // SLP_SUS#
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // AZ_RST#_EC
+    { &GPCRI6, GPIO_IN }, // LIGHT_KB_DET#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_IN | GPIO_DOWN }, // SUS_PWR_ACK
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_OUT }, // ME_WE
+    { &GPCRJ3, GPIO_IN }, // SOC_TYPE
+    { &GPCRJ4, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRJ5, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ6, GPIO_OUT }, // 3G_PWR_EN
+    { &GPCRJ7, GPIO_IN }, // NC
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // NC
-    GPDRB = BIT(0);
-    GPDRC = 0;
-    // PWR_BTN#, SCI#, SMI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    GPDRE = 0;
-    // USB_PWR_EN#, H_PECI
-    GPDRF = BIT(7) | BIT(6);
-    // AIRPLAN_LED#
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    GPDRJ = 0;
-
-    // Set GPIO control
-    // EC_SSD_LED#
-    GPCRA0 = GPIO_IN;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // PCH_DPWROK_EC
-    GPCRA3 = GPIO_IN;
-    // PCH_PWROK_EC
-    GPCRA4 = GPIO_OUT;
-    // LED_BAT_CHG
-    GPCRA5 = GPIO_OUT;
-    // LED_BAT_FULL
-    GPCRA6 = GPIO_OUT;
-    // LED_PWR
-    GPCRA7 = GPIO_OUT;
-    // NC
-    GPCRB0 = GPIO_OUT;
-    // H_PROCHOT_EC
-    GPCRB1 = GPIO_OUT;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // SMC_BAT
-    GPCRB3 = GPIO_ALT;
-    // SMD_BAT
-    GPCRB4 = GPIO_ALT;
-    // GA20
-    GPCRB5 = GPIO_OUT;
-    // AC_IN#
-    GPCRB6 = GPIO_IN | GPIO_UP;
-    // FP_RST#
-    GPCRB7 = GPIO_IN;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_IN | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_IN | GPIO_UP;
-    // KSO16 (Darter)
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_OUT;
-    // KSO17 (Darter)
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT;
-    // PWR_SW#
-    GPCRD0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRD1 = GPIO_IN | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SMI#
-    GPCRD3 = GPIO_IN;
-    // SCI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // SUSWARN#
-    GPCRD7 = GPIO_IN;
-    // SWI#
-    GPCRE0 = GPIO_OUT;
-    // EC_EN
-    GPCRE1 = GPIO_OUT;
-    // PCH_SLP_WLAN#_R
-    GPCRE2 = GPIO_IN;
-    // VA_EC_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_OUT;
-    // AC_PRESENT / PM_PWROK
-    GPCRE7 = GPIO_OUT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // BT_EN
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // USB_PWR_EN#
-    GPCRF7 = GPIO_OUT;
-    // CCD_EN
-    GPCRG0 = GPIO_OUT;
-    // 3G_EN
-    GPCRG1 = GPIO_OUT;
-    // VDD3
-    GPCRG2 = GPIO_OUT;
-    // HSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // HSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // HSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // AIRPLAN_LED#
-    GPCRG6 = GPIO_OUT;
-    // HCPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // EC_CLKRUN#
-    GPCRH0 = GPIO_ALT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT;
-    // NC
-    GPCRH3 = GPIO_OUT;
-    // VR_ON
-    GPCRH4 = GPIO_IN;
-    // WLAN_EN
-    GPCRH5 = GPIO_OUT;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // SLP_SUS#
-    GPCRI2 = GPIO_IN;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // AZ_RST#_EC
-    GPCRI5 = GPIO_IN;
-    // LIGHT_KB_DET#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // SUS_PWR_ACK
-    GPCRJ0 = GPIO_IN | GPIO_DOWN;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // ME_WE
-    GPCRJ2 = GPIO_OUT;
-    // SOC_TYPE
-    GPCRJ3 = GPIO_IN;
-    // WLAN_PWR_EN
-    GPCRJ4 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ5 = GPIO_ALT;
-    // 3G_PWR_EN
-    GPCRJ6 = GPIO_OUT;
-    // NC
-    GPCRJ7 = GPIO_IN;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/galp5/gpio.c
+++ b/src/board/system76/galp5/gpio.c
@@ -43,213 +43,130 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(2) }, // Set GPH0 to 1.8V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, BIT(5) }, // PCH_DPWROK_EC
+    { &GPDRD, BIT(5) | BIT(4) }, // PWR_BTN#, SMI#
+    { &GPDRE, 0 },
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_OUT }, // ME_WE
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_IN | GPIO_DOWN }, // SLP_S0#
+    { &GPCRA6, GPIO_OUT | GPIO_UP }, // PCH_PWROK_EC
+    { &GPCRA7, GPIO_IN }, // PCH_SLP_WLAN#_R
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_IN }, // SINK_CTRL_EC
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_OUT | GPIO_UP }, // PCH_DPWROK_EC
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // EC_ERST#
+    { &GPCRD3, GPIO_IN | GPIO_DOWN }, // CPU_C10_GATE#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // KB-DET
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN | GPIO_UP }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // BT_EN: Not connected
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN | GPIO_UP }, // TODO: CC_EN
+
+    { &GPCRG0, GPIO_IN }, // dGPU_GPIO8_OVERT
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // 10K pull-up
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // PM_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRH4, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // d_GPIO9_ALERT_FAN
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_ALT }, // THERM_VOLT2
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // ASM1543_CC1
+    { &GPCRI6, GPIO_ALT }, // ASM1543_CC2
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRM0, GPIO_ALT }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP }, // ALERT#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-    // Set GPH0 to 1.8V
-    GCR21 = BIT(2);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    // PCH_DPWROK_EC
-    GPDRC = BIT(5);
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
-    GPDRE = 0;
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-    // ME_WE
-    GPCRA0 = GPIO_OUT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // SLP_S0#
-    GPCRA5 = GPIO_IN | GPIO_DOWN;
-    // PCH_PWROK_EC
-    GPCRA6 = GPIO_OUT | GPIO_UP;
-    // PCH_SLP_WLAN#_R
-    GPCRA7 = GPIO_IN;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // EC_LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // SINK_CTRL_EC
-    GPCRC3 = GPIO_IN;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRC5 = GPIO_OUT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // EC_ERST#
-    GPCRD2 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRD3 = GPIO_IN | GPIO_DOWN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // KB-DET
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-    // 80CLK
-    GPCRF0 = GPIO_IN | GPIO_UP;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // BT_EN: Not connected
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CC_EN: TODO!
-    GPCRF7 = GPIO_IN | GPIO_UP;
-    // dGPU_GPIO8_OVERT
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // 10K pull-up
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // PM_CLKRUN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRH3 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // d_GPIO9_ALERT_FAN
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // THERM_VOLT2
-    GPCRI2 = GPIO_ALT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // ASM1543_CC1
-    GPCRI5 = GPIO_ALT;
-    // ASM1543_CC2
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // GC6_FB_EN
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // SLP_SUS#
-    GPCRJ7 = GPIO_IN;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ALERT#
-    GPCRM6 = GPIO_IN | GPIO_UP;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/galp6/gpio.c
+++ b/src/board/system76/galp6/gpio.c
@@ -41,219 +41,132 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    //{ &GCR22, BIT(7) },
+    //{ &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, BIT(5) }, // PCH_DPWROK_EC
+    { &GPDRD, BIT(5) | BIT(4) }, // PWR_BTN#, SMI#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_OUT }, // ME_WE
+    { &GPCRA1, GPIO_ALT }, // KBC_KEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_IN }, // SLP_S0#
+    { &GPCRA6, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRA7, GPIO_OUT }, // PCH_SLP_WLAN#_R
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_IN }, // SWI#
+    { &GPCRB6, GPIO_OUT }, // SUSBC_EC
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_IN }, // SINK_CTRL_EC
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // EC_ERST#
+    { &GPCRD3, GPIO_IN }, // CPU_C10_GATE#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // KB-DET
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN# (Actually active high)
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PD_EN
+    { &GPCRF4, GPIO_OUT | GPIO_DOWN }, // TP_CLK
+    { &GPCRF5, GPIO_OUT | GPIO_DOWN }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT }, // M2M_SSD_PLN# (Not connected)
+
+    { &GPCRG0, GPIO_IN }, // dGPU_GPIO8_OVERT
+    { &GPCRG1, GPIO_OUT }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // 100k pull-up
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // PM_CLKRUN# (Not connected)
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT }, // BKL_EN
+    { &GPCRH3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRH4, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH5, GPIO_OUT }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // d_GPIO9_ALERT_FAN
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_ALT }, // THERM_VOLT2
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // Not connected
+    { &GPCRI6, GPIO_IN }, // Not connected
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT }, //  LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    // PCH_DPWROK_EC
-    GPDRC = BIT(5);
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-    // ME_WE
-    GPCRA0 = GPIO_OUT;
-    // KBC_KEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // SLP_S0#
-    GPCRA5 = GPIO_IN;
-    // PCH_PWROK_EC
-    GPCRA6 = GPIO_OUT;
-    // PCH_SLP_WLAN#_R
-    GPCRA7 = GPIO_OUT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // EC_LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_IN;
-    // SUSBC_EC
-    GPCRB6 = GPIO_OUT;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // SINK_CTRL_EC
-    GPCRC3 = GPIO_IN;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRC5 = GPIO_OUT;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // EC_ERST#
-    GPCRD2 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT;
-    // KB-DET
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN# (Actually active high)
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // JACK_IN#_EC
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PD_EN
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_OUT | GPIO_DOWN;
-    // TP_DATA
-    GPCRF5 = GPIO_OUT | GPIO_DOWN;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // M2M_SSD_PLN# (Not connected)
-    GPCRF7 = GPIO_OUT;
-    // dGPU_GPIO8_OVERT
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT;
-    // 100k pull-up
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // PM_CLKRUN# (Not connected)
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT;
-    // PCIE_WAKE#
-    GPCRH3 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // d_GPIO9_ALERT_FAN
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // THERM_VOLT2
-    GPCRI2 = GPIO_ALT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // Not connected
-    GPCRI5 = GPIO_IN;
-    // Not connected
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    //  LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // SLP_SUS#
-    GPCRJ7 = GPIO_IN;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/gaze15/gpio.c
+++ b/src/board/system76/gaze15/gpio.c
@@ -40,206 +40,127 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(6) | BIT(4) | BIT(3) }, // H_PROCHOT_EC, XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SMI#, SCI#
+    { &GPDRE, 0 },
+    { &GPDRF, BIT(6) }, // EC_PECI
+    { &GPDRG, 0 },
+    { &GPDRH, BIT(7) }, // AIRPLAN_LED#
+    { &GPDRI, 0 },
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_PIN_24
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#_EC
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN# (on 1650/1650Ti), NC (on 1660Ti)
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // BT_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // EC_PECI
+    { &GPCRF7, GPIO_IN }, // SUS_PWR_ACK#
+
+    { &GPCRG0, GPIO_IN | GPIO_UP }, // dGPU_GPIO8_OVERT
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT#_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // SUS_WARN#
+    { &GPCRH1, GPIO_IN }, // SUSC#
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN }, // LIGHT_KB_DET#
+    { &GPCRH4, GPIO_IN | GPIO_UP }, // d_GPIO9_ALERT_FAN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#
+    { &GPCRH7, GPIO_OUT | GPIO_UP }, // AIRPLAN_LED#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // PERKB_ID#_R
+    { &GPCRI6, GPIO_IN }, // PERKB_ID2#_R
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // SLP_SUS#
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // PERKB-DET#_R
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // H_PROCHOT_EC, XLP_OUT, PWR_SW#
-    GPDRB = BIT(6) | BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#, SCI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    GPDRE = 0;
-    // EC_PECI
-    GPDRF = BIT(6);
-    GPDRG = 0;
-    // AIRPLAN_LED#
-    GPDRH = BIT(7);
-    GPDRI = 0;
-    GPDRJ = 0;
-
-    // Set GPIO control
-    // EC_PWM_PIN_24
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // H_PROCHOT_EC
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#_EC
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN# (on 1650/1650Ti), NC (on 1660Ti)
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // BT_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // EC_PECI
-    GPCRF6 = GPIO_ALT;
-    // SUS_PWR_ACK#
-    GPCRF7 = GPIO_IN;
-    // dGPU_GPIO8_OVERT
-    GPCRG0 = GPIO_IN | GPIO_UP;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT#_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // SUS_WARN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // LIGHT_KB_DET#
-    GPCRH3 = GPIO_IN;
-    // d_GPIO9_ALERT_FAN
-    GPCRH4 = GPIO_IN | GPIO_UP;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#
-    GPCRH6 = GPIO_IN;
-    // AIRPLAN_LED#
-    GPCRH7 = GPIO_OUT | GPIO_UP;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // PERKB_ID#_R
-    GPCRI5 = GPIO_IN;
-    // PERKB_ID2#_R
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // SLP_SUS#
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // PERKB-DET#_R
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/gaze16-3050/gpio.c
+++ b/src/board/system76/gaze16-3050/gpio.c
@@ -38,213 +38,130 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(2) }, // Set GPH0 to 1.8V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(5) | BIT(4) | BIT(3) }, // SWI#, XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SMI#, SCI#
+    { &GPDRE, 0 },
+    { &GPDRF, BIT(7) }, // CC_EN
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, BIT(7) }, // AIRPLAN_LED#
+    { &GPDRI, 0 },
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FANPWM
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN_PWM
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKE#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // EC_SYS_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT | GPIO_UP }, // CC_EN
+
+    { &GPCRG0, GPIO_IN | GPIO_UP }, // dGPU_GPIO8_OVERT
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // EC_WLAN_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#_L
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI_L
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MS0_L
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK_L
+
+    { &GPCRH0, GPIO_IN }, // CPU_C10_GATE#_R
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_IN }, // SLP_SUS#
+    { &GPCRH4, GPIO_IN }, // d_GPIO9_ALERT_FAN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT | GPIO_UP }, // AIRPLAN_LED#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // CC1_DET
+    { &GPCRI6, GPIO_ALT }, // CC2_DET
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // EC_VA_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // VR_ON
+
+    { &GPCRM0, GPIO_ALT }, // ESPI_AD0
+    { &GPCRM1, GPIO_ALT }, // ESPI_AD1
+    { &GPCRM2, GPIO_ALT }, // ESPI_AD2
+    { &GPCRM3, GPIO_ALT }, // ESPI_AD3
+    { &GPCRM4, GPIO_ALT }, // ESPI_KBC
+    { &GPCRM5, GPIO_ALT }, // ESPI_FRAME#
+    { &GPCRM6, GPIO_IN | GPIO_UP }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-    // Set GPH0 to 1.8V
-    GCR21 = BIT(2);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // SWI#, XLP_OUT, PWR_SW#
-    GPDRB = BIT(5) | BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#, SCI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    GPDRE = 0;
-    // CC_EN
-    GPDRF = BIT(7);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    // AIRPLAN_LED#
-    GPDRH = BIT(7);
-    GPDRI = 0;
-    GPDRJ = 0;
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FANPWM
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN_PWM
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKE#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // EC_SYS_PWROK
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CC_EN
-    GPCRF7 = GPIO_OUT | GPIO_UP;
-    // dGPU_GPIO8_OVERT
-    GPCRG0 = GPIO_IN | GPIO_UP;
-    // EC_WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#_L
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI_L
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MS0_L
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK_L
-    GPCRG7 = GPIO_ALT;
-    // CPU_C10_GATE#_R
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // SLP_SUS#
-    GPCRH3 = GPIO_IN;
-    // d_GPIO9_ALERT_FAN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // AIRPLAN_LED#
-    GPCRH7 = GPIO_OUT | GPIO_UP;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // CC1_DET
-    GPCRI5 = GPIO_ALT;
-    // CC2_DET
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // EC_VA_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // VR_ON
-    GPCRJ7 = GPIO_IN;
-    // ESPI_AD0
-    GPCRM0 = GPIO_ALT;
-    // ESPI_AD1
-    GPCRM1 = GPIO_ALT;
-    // ESPI_AD2
-    GPCRM2 = GPIO_ALT;
-    // ESPI_AD3
-    GPCRM3 = GPIO_ALT;
-    // ESPI_KBC
-    GPCRM4 = GPIO_ALT;
-    // ESPI_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_IN | GPIO_UP;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/gaze16-3060/gpio.c
+++ b/src/board/system76/gaze16-3060/gpio.c
@@ -39,212 +39,130 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(2) }, // Set GPH0 to 1.8V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(5) | BIT(4) | BIT(3) }, // SWI#, XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SMI#, SCI#
+    { &GPDRE, 0 },
+    { &GPDRF, 0 },
+    { &GPDRG, BIT(6) }, // H_PROCHOT#_EC
+    { &GPDRH, BIT(7) }, // AIRPLAN_LED#
+    { &GPDRI, 0 },
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // EC_LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // EC_SYS_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST# / ESPI_RESET_N
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_IN }, // XXX: M2M_SSD1_PLN# / M2M_SSD2_PLN#
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT }, // PCH_DPWROK_EC
+
+    { &GPCRG0, GPIO_IN | GPIO_UP }, // dGPU_OVERT_EC
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT#_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // SLP_S0#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH4, GPIO_IN }, // d_GPIO9_ALERT_FAN
+    { &GPCRH5, GPIO_OUT }, // VR_ON
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT | GPIO_UP }, // AIRPLAN_LED#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // SLP_A# / CPU_C10_GATE#_EC
+    { &GPCRI6, GPIO_IN }, // SLP_SUS#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // PERKB-DET#_R
+
+    { &GPCRM0, GPIO_ALT }, // ESPI_IO0
+    { &GPCRM1, GPIO_ALT }, // ESPI_IO1
+    { &GPCRM2, GPIO_ALT }, // ESPI_IO2
+    { &GPCRM3, GPIO_ALT }, // ESPI_IO3
+    { &GPCRM4, GPIO_ALT }, // ESPI_CLK
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS#
+    { &GPCRM6, GPIO_IN | GPIO_UP }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-    // Set GPH0 to 1.8V
-    GCR21 = BIT(2);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // SWI#, XLP_OUT, PWR_SW#
-    GPDRB = BIT(5) | BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#, SCI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    GPDRE = 0;
-    GPDRF = 0;
-    // H_PROCHOT#_EC
-    GPDRG = BIT(6);
-    // AIRPLAN_LED#
-    GPDRH = BIT(7);
-    GPDRI = 0;
-    GPDRJ = 0;
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // EC_LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // EC_SYS_PWROK
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // BUF_PLT_RST# / ESPI_RESET_N
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // XXX: M2M_SSD1_PLN# / M2M_SSD2_PLN#
-    GPCRF3 = GPIO_IN;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // PCH_DPWROK_EC
-    GPCRF7 = GPIO_OUT;
-    // dGPU_OVERT_EC
-    GPCRG0 = GPIO_IN | GPIO_UP;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT#_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // SLP_S0#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // LED_BAT_CHG
-    GPCRH3 = GPIO_OUT | GPIO_UP;
-    // d_GPIO9_ALERT_FAN
-    GPCRH4 = GPIO_IN;
-    // VR_ON
-    GPCRH5 = GPIO_OUT;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // AIRPLAN_LED#
-    GPCRH7 = GPIO_OUT | GPIO_UP;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // SLP_A# / CPU_C10_GATE#_EC
-    GPCRI5 = GPIO_IN;
-    // SLP_SUS#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // PERKB-DET#_R
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-    // ESPI_IO0
-    GPCRM0 = GPIO_ALT;
-    // ESPI_IO1
-    GPCRM1 = GPIO_ALT;
-    // ESPI_IO2
-    GPCRM2 = GPIO_ALT;
-    // ESPI_IO3
-    GPCRM3 = GPIO_ALT;
-    // ESPI_CLK
-    GPCRM4 = GPIO_ALT;
-    // ESPI_CS#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/gaze17-3050/gpio.c
+++ b/src/board/system76/gaze17-3050/gpio.c
@@ -38,211 +38,129 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) }, // XLP_OUT
+    { &GPDRC, 0 },
+    { &GPDRD, 0 },
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(7) }, // CC_EN
+    { &GPDRG, BIT(6) }, // H_PROCHOT#_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_PIN_24
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB_SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB_SO17
+    { &GPCRC6, GPIO_IN }, // CPU_C10_GATE#
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET_N
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT }, // ME_WE
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_DOWN }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_DOWN }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT | GPIO_UP }, // CC_EN
+
+    { &GPCRG0, GPIO_IN }, // dGPU_GPIO8_OVERT
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT#_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // PM_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_IN | GPIO_UP }, // LIGHT_KB_DET#
+    { &GPCRH4, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT | GPIO_UP }, // VA_EC_EN
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_ALT }, // THERM_VOLT2
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // CC1_DET
+    { &GPCRI6, GPIO_ALT }, // CC2_DET
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_IN }, // SLP_SUS#
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // SLP_S0# (not connected)
+
+    { &GPCRM0, GPIO_ALT }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT
-    GPDRB = BIT(4);
-    GPDRC = 0;
-    GPDRD = 0;
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // CC_EN
-    GPDRF = BIT(7);
-    // H_PROCHOT#_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-
-    // Set GPIO control
-    // EC_PWM_PIN_24
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB_SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB_SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // CPU_C10_GATE#
-    GPCRC6 = GPIO_IN;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET_N
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // ME_WE
-    GPCRE6 = GPIO_OUT;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_DOWN;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_DOWN;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CC_EN
-    GPCRF7 = GPIO_OUT | GPIO_UP;
-    // dGPU_GPIO8_OVERT
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT#_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // PM_CLKRUN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // LIGHT_KB_DET#
-    GPCRH3 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRH4 = GPIO_OUT;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // VA_EC_EN
-    GPCRH7 = GPIO_OUT | GPIO_UP;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // THERM_VOLT2
-    GPCRI2 = GPIO_ALT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // CC1_DET
-    GPCRI5 = GPIO_ALT;
-    // CC2_DET
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // SLP_SUS#
-    GPCRJ4 = GPIO_IN;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_IN;
-    // SLP_S0# (not connected)
-    GPCRJ7 = GPIO_IN;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/gaze17-3060/gpio.c
+++ b/src/board/system76/gaze17-3060/gpio.c
@@ -38,217 +38,129 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(D, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) }, // XLP_OUT
+    { &GPDRC, 0 },
+    { &GPDRD, 0 },
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, 0 },
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_PIN_24
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN | GPIO_UP }, // DDS_EC_PWM
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_IN | GPIO_UP }, // BL_PWM_EN_EC
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB_SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB_SO17
+    { &GPCRC6, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRD4, GPIO_IN | GPIO_UP }, // PLVDD_RST_EC
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN | GPIO_UP }, // CC_EN: TODO!
+
+    { &GPCRG0, GPIO_IN }, // OVERT#_EC
+    { &GPCRG1, GPIO_OUT }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_OUT }, // ME_WE
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_IN | GPIO_DOWN }, // MUX_CTRL_BIOS
+    { &GPCRH4, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // d_GPIO9_ALERT_FAN
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_ALT }, // THERM_VOLT2
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // CC1_DET
+    { &GPCRI6, GPIO_ALT }, // CC2_DET
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // CPU_C10_GATE#
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRM0, GPIO_ALT }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT
-    GPDRB = BIT(4);
-    GPDRC = 0;
-    GPDRD = 0;
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    GPDRF = 0;
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPOTA = 0;
-    GPOTB = 0;
-    GPOTD = 0;
-    GPOTE = 0;
-    GPOTF = 0;
-    GPOTH = 0;
-    GPOTJ = 0;
-
-    // Set GPIO control
-    // EC_PWM_PIN_24
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM
-    GPCRA3 = GPIO_IN | GPIO_UP;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // BL_PWM_EN_EC
-    GPCRB5 = GPIO_IN | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB_SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB_SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRD3 = GPIO_OUT;
-    // PLVDD_RST_EC
-    GPCRD4 = GPIO_IN | GPIO_UP;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CC_EN: TODO!
-    GPCRF7 = GPIO_IN | GPIO_UP;
-    // OVERT#_EC
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // ME_WE
-    GPCRH0 = GPIO_OUT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // MUX_CTRL_BIOS
-    GPCRH3 = GPIO_IN | GPIO_DOWN;
-    // DGPU_PWR_EN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // d_GPIO9_ALERT_FAN
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // THERM_VOLT2
-    GPCRI2 = GPIO_ALT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // CC1_DET
-    GPCRI5 = GPIO_ALT;
-    // CC2_DET
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // CPU_C10_GATE#
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // SLP_SUS#
-    GPCRJ7 = GPIO_IN;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/gaze18/gpio.c
+++ b/src/board/system76/gaze18/gpio.c
@@ -35,227 +35,133 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    //{ &GCR22, BIT(7) },
+    { &GCR10, 0x02 },
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    //{ &GCR22, BIT(7) },
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) }, // XLP_OUT
+    { &GPDRC, 0 },
+    { &GPDRD, 0 },
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(7) }, // CC_EN
+    { &GPDRG, BIT(6) }, // H_PROCHOT#_EC
+    { &GPDRH, BIT(4) }, // PCH_DPWROK_EC
+    { &GPDRI, 0 },
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_PIN_24
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB_SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB_SO17
+    { &GPCRC6, GPIO_IN }, // CPU_C10_GATE#
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET_N
+    { &GPCRD3, GPIO_OUT }, // SCI#
+    { &GPCRD4, GPIO_OUT }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT }, // ME_WE
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRF4, GPIO_OUT | GPIO_DOWN }, // TP_CLK
+    { &GPCRF5, GPIO_OUT | GPIO_DOWN }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT | GPIO_UP }, // CC_EN
+
+    { &GPCRG0, GPIO_IN }, // OVERT#_EC
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // Not connected
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT#_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // PM_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_IN | GPIO_UP }, // LIGHT_KB_DET#
+    { &GPCRH4, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT | GPIO_UP }, // VA_EC_EN
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_ALT }, // THERM_VOLT2
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // CC1_DET
+    { &GPCRI6, GPIO_ALT }, // CC2_DET
+    { &GPCRI7, GPIO_ALT }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_IN }, // SLP_SUS#
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // SLP_S0#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // Not documented
-    //GCR22 = BIT(7);
-    GCR10 = 0x02;
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Not documented
-    //GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    GCR23 = BIT(0);
-
-    GPDRA = 0;
-    // XLP_OUT
-    GPDRB = BIT(4);
-    GPDRC = 0;
-    GPDRD = 0;
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // CC_EN
-    GPDRF = BIT(7);
-    // H_PROCHOT#_EC
-    GPDRG = BIT(6);
-    // PCH_DPWROK_EC
-    GPDRH = BIT(4);
-    GPDRI = 0;
-    GPDRJ = 0;
-
-    // Set GPIO control
-
-    // EC_PWM_PIN_24
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB_SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB_SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // CPU_C10_GATE#
-    GPCRC6 = GPIO_IN;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // ESPI_RESET_N
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_OUT;
-    // SMI#
-    GPCRD4 = GPIO_OUT;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // ME_WE
-    GPCRE6 = GPIO_OUT;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_OUT | GPIO_DOWN;
-    // TP_DATA
-    GPCRF5 = GPIO_OUT | GPIO_DOWN;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CC_EN
-    GPCRF7 = GPIO_OUT | GPIO_UP;
-
-    // OVERT#_EC
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT#_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // PM_CLKRUN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // LIGHT_KB_DET#
-    GPCRH3 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRH4 = GPIO_OUT;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // VA_EC_EN
-    GPCRH7 = GPIO_OUT | GPIO_UP;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // THERM_VOLT2
-    GPCRI2 = GPIO_ALT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // CC1_DET
-    GPCRI5 = GPIO_ALT;
-    // CC2_DET
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_ALT;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // SLP_SUS#
-    GPCRJ4 = GPIO_IN;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // SLP_S0#
-    GPCRJ7 = GPIO_IN;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/lemp10/gpio.c
+++ b/src/board/system76/lemp10/gpio.c
@@ -41,212 +41,130 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(2) }, // Set GPH0 to 1.8V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) }, // PWR_BTN#, SMI#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN#
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, 0 },
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_IN }, // AC/BATL#
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_IN }, // NC
+    { &GPCRA5, GPIO_OUT | GPIO_UP }, // NC
+    { &GPCRA6, GPIO_OUT | GPIO_UP }, // PCH_PWROK_EC
+    { &GPCRA7, GPIO_OUT | GPIO_UP }, // PCH_DPWROK_EC
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // PCH_SLP_WLAN#_R
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_IN }, // EC_FORCE_POWER
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMB_CLK_EC
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMB_DATA_EC
+    { &GPCRC3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_OUT | GPIO_UP }, // 3G_PWR_EN
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN | GPIO_UP }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // NC
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN }, // LEDKB_DET#
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN | GPIO_UP }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // EC_BT_EN
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN | GPIO_DOWN }, // CPU_C10_GATE#
+
+    { &GPCRG0, GPIO_IN }, // VCCIN_AUX_PG
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // Pull up to VDD3?
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // EC_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_OUT | GPIO_UP }, // 3G_EN
+    { &GPCRH4, GPIO_IN }, // VR_ON
+    { &GPCRH5, GPIO_IN }, // SINK_CTRL_EC
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // ACE_I2C_IRQ2Z
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // NC
+    { &GPCRI6, GPIO_IN }, // NC
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_IN | GPIO_DOWN }, // SLP_S0#
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // SLP_SUS#
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // EC_EN
+    { &GPCRJ7, GPIO_IN }, // NC
+
+    { &GPCRM0, GPIO_ALT }, // ESPI_IO_0
+    { &GPCRM1, GPIO_ALT }, // ESPI_IO_1
+    { &GPCRM2, GPIO_ALT }, // ESPI_IO_2
+    { &GPCRM3, GPIO_ALT }, // ESPI_IO_3
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_N
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-    // Set GPH0 to 1.8V
-    GCR21 = BIT(2);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
-    // USB_PWR_EN#
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    GPDRG = 0;
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-    // AC/BATL#
-    GPCRA0 = GPIO_IN;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // NC
-    GPCRA4 = GPIO_IN;
-    // NC
-    GPCRA5 = GPIO_OUT | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRA6 = GPIO_OUT | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRA7 = GPIO_OUT | GPIO_UP;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // PCH_SLP_WLAN#_R
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // EC_FORCE_POWER
-    GPCRB6 = GPIO_IN;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMB_CLK_EC
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMB_DATA_EC
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRC3 = GPIO_IN;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // 3G_PWR_EN
-    GPCRC5 = GPIO_OUT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN | GPIO_UP;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // NC
-    GPCRD7 = GPIO_IN;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // LEDKB_DET#
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN | GPIO_UP;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // EC_BT_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRF7 = GPIO_IN | GPIO_DOWN;
-    // VCCIN_AUX_PG
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // Pull up to VDD3?
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // EC_CLKRUN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // 3G_EN
-    GPCRH3 = GPIO_OUT | GPIO_UP;
-    // VR_ON
-    GPCRH4 = GPIO_IN;
-    // SINK_CTRL_EC
-    GPCRH5 = GPIO_IN;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // ACE_I2C_IRQ2Z
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // NC
-    GPCRI5 = GPIO_IN;
-    // NC
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // SLP_S0#
-    GPCRJ0 = GPIO_IN | GPIO_DOWN;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // SLP_SUS#
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_EN
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // NC
-    GPCRJ7 = GPIO_IN;
-    // ESPI_IO_0
-    GPCRM0 = GPIO_ALT;
-    // ESPI_IO_1
-    GPCRM1 = GPIO_ALT;
-    // ESPI_IO_2
-    GPCRM2 = GPIO_ALT;
-    // ESPI_IO_3
-    GPCRM3 = GPIO_ALT;
-    // ESPI_CLK
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_N
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/lemp11/gpio.c
+++ b/src/board/system76/lemp11/gpio.c
@@ -38,222 +38,133 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    //{ &GCR22, BIT(7) },
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    //{ &GCR22, BIT(7) },
+    //{ &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, BIT(7) }, // PCH_DPWROK_EC
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) }, // PWR_BTN#, SMI#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_IN }, // Not connected
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_IN | GPIO_UP }, // Not connected
+    { &GPCRA5, GPIO_IN | GPIO_UP }, // Not connected
+    { &GPCRA6, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRA7, GPIO_OUT }, // PCH_DPWROK_EC
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN }, // SLP_WLAN#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMB_CLK_EC
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMB_DATA_EC
+    { &GPCRC3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_OUT | GPIO_UP }, // 3G_PWR_EN
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // SINK_CTRL_EC
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN }, // Not connected?
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_OUT | GPIO_UP }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_OUT | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // EC_BT_EN
+    { &GPCRF4, GPIO_ALT | GPIO_DOWN }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_DOWN }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN | GPIO_DOWN }, // CPU_C10_GATE#
+
+    { &GPCRG0, GPIO_OUT }, // VCCIN_AUX_PG
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // Pull up to VDD3
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // EC_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_OUT | GPIO_UP }, // 3G_EN
+    { &GPCRH4, GPIO_IN }, // Not connected
+    { &GPCRH5, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // ACE_I2C_IRQ2Z
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN | GPIO_UP }, // Not connected
+    { &GPCRI6, GPIO_IN }, // PM_BATLOW#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_IN }, // SLP_S0#
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // SLP_SUS#
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // LEDKB_DET#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // Not documented
-    //GCR22 = BIT(7);
-
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
-
-    // Set GPIO data
-    // PCH_DPWROK_EC
-    GPDRA = BIT(7);
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-    // Not connected
-    GPCRA0 = GPIO_IN;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRA4 = GPIO_IN | GPIO_UP;
-    // Not connected
-    GPCRA5 = GPIO_IN | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRA6 = GPIO_OUT;
-    // PCH_DPWROK_EC
-    GPCRA7 = GPIO_OUT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // SLP_WLAN#
-    GPCRB2 = GPIO_IN;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMB_CLK_EC
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMB_DATA_EC
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRC3 = GPIO_IN;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // 3G_PWR_EN
-    GPCRC5 = GPIO_OUT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // SINK_CTRL_EC
-    GPCRD7 = GPIO_IN;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT;
-    // Not connected?
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-    // 80CLK
-    GPCRF0 = GPIO_OUT | GPIO_UP;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_OUT | GPIO_UP;
-    // EC_BT_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_DOWN;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_DOWN;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRF7 = GPIO_IN | GPIO_DOWN;
-    // VCCIN_AUX_PG
-    GPCRG0 = GPIO_OUT;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // Pull up to VDD3
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // EC_CLKRUN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // 3G_EN
-    GPCRH3 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRH4 = GPIO_IN;
-    // JACK_IN#_EC
-    GPCRH5 = GPIO_IN;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // ACE_I2C_IRQ2Z
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT_CPU
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // Not connected
-    GPCRI5 = GPIO_IN | GPIO_UP;
-    // PM_BATLOW#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // SLP_S0#
-    GPCRJ0 = GPIO_IN;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // SLP_SUS#
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // LEDKB_DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/lemp12/gpio.c
+++ b/src/board/system76/lemp12/gpio.c
@@ -39,220 +39,133 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR10, BIT(1) }, // PWRSW counter 12 seconds
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    //{ &GCR22, BIT(7) },
+    //{ &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, BIT(7) }, // PCH_DPWROK_EC
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) }, // PWR_BTN#, SMI#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_IN }, // Not connected
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_IN | GPIO_UP }, // Not connected
+    { &GPCRA5, GPIO_IN | GPIO_UP }, // Not connected
+    { &GPCRA6, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRA7, GPIO_OUT }, // PCH_DPWROK_EC
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN }, // SLP_WLAN#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMB_CLK_EC
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMB_DATA_EC
+    { &GPCRC3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_OUT | GPIO_UP }, // 3G_PWR_EN
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // SINK_CTRL_EC
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN }, // Not connected?
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_OUT | GPIO_UP }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_OUT | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // EC_BT_EN
+    { &GPCRF4, GPIO_ALT | GPIO_DOWN }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_DOWN }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN | GPIO_DOWN }, // CPU_C10_GATE#
+
+    { &GPCRG0, GPIO_OUT }, // VCCIN_AUX_PG
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // Pull up to VDD3
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // EC_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_OUT | GPIO_UP }, // 3G_EN
+    { &GPCRH4, GPIO_OUT }, // PD_POWER_EN
+    { &GPCRH5, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // ACE_I2C_IRQ2Z
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN | GPIO_UP }, // Not connected
+    { &GPCRI6, GPIO_IN }, // PM_BATLOW#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_IN }, // SLP_S0#
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // SLP_SUS#
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // LEDKB_DET#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW counter 12 seconds
-    GCR10 = BIT(1);
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
-
-    // Set GPIO data
-    // PCH_DPWROK_EC
-    GPDRA = BIT(7);
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#
-    GPDRD = BIT(5) | BIT(4);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-    // Not connected
-    GPCRA0 = GPIO_IN;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // Not connected
-    GPCRA4 = GPIO_IN | GPIO_UP;
-    // Not connected
-    GPCRA5 = GPIO_IN | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRA6 = GPIO_OUT;
-    // PCH_DPWROK_EC
-    GPCRA7 = GPIO_OUT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // SLP_WLAN#
-    GPCRB2 = GPIO_IN;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMB_CLK_EC
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMB_DATA_EC
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRC3 = GPIO_IN;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // 3G_PWR_EN
-    GPCRC5 = GPIO_OUT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // SINK_CTRL_EC
-    GPCRD7 = GPIO_IN;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT;
-    // Not connected?
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-    // 80CLK
-    GPCRF0 = GPIO_OUT | GPIO_UP;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_OUT | GPIO_UP;
-    // EC_BT_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_DOWN;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_DOWN;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRF7 = GPIO_IN | GPIO_DOWN;
-    // VCCIN_AUX_PG
-    GPCRG0 = GPIO_OUT;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // Pull up to VDD3
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // EC_CLKRUN#
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // 3G_EN
-    GPCRH3 = GPIO_OUT | GPIO_UP;
-    // PD_POWER_EN
-    GPCRH4 = GPIO_OUT;
-    // JACK_IN#_EC
-    GPCRH5 = GPIO_IN;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // ACE_I2C_IRQ2Z
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT_CPU
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // Not connected
-    GPCRI5 = GPIO_IN | GPIO_UP;
-    // PM_BATLOW#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // SLP_S0#
-    GPCRJ0 = GPIO_IN;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // SLP_SUS#
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // LEDKB_DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/lemp13-b/gpio.c
+++ b/src/board/system76/lemp13-b/gpio.c
@@ -30,233 +30,135 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR2, 0 }, // Disable PECI
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR10, BIT(1) }, // PWRSW counter 12 seconds
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(7) | BIT(0) }, // Set GPB5 and GPD2 to 1.8V
+    { &GCR20, BIT(7) }, // Set GPD3 to 1.8V, GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(5) | BIT(2) | BIT(1) }, // Set GPF7, GPH0, and GPH1 to 1.8V
+    { &GCR22, BIT(7) },
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) }, // XLP_OUT
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) }, // PWR_BTN#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_OUT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_IN }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_OUT }, // AC_PRESENT_EC
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_IN }, // TBTA_VBUS_2_EN#
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_IN }, // SLP_S0#
+    { &GPCRB6, GPIO_OUT }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMB_CLK_EC
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMB_DATA_EC
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_IN }, // TMRI1-TEST
+    { &GPCRC7, GPIO_OUT }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT }, // PD_POWER_EN
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_IN }, // SLP_A#
+    { &GPCRD4, GPIO_OUT }, // LED_PWR
+    { &GPCRD5, GPIO_OUT }, // EC_PWR_BTN#
+    { &GPCRD6, GPIO_ALT | GPIO_DOWN }, // CPU_FANSEN
+    { &GPCRD7, GPIO_OUT }, // EC_ME_WE
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_IN }, // GPE1_TEST
+    { &GPCRE2, GPIO_IN }, // ACE_I2C_IRQ2Z
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_OUT }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_OUT }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN }, // CPU_C10_GATE#
+
+    { &GPCRG0, GPIO_IN }, // 10k pull-down
+    { &GPCRG1, GPIO_IN }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // Pull up to VDD3
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT }, // LED_ACIN
+    { &GPCRH3, GPIO_OUT }, // 3G_EN
+    { &GPCRH4, GPIO_OUT }, // 3G_PWR_EN
+    { &GPCRH5, GPIO_IN }, // TBTA_VBUS_1_EN#
+    { &GPCRH6, GPIO_IN }, // Not connected
+    { &GPCRH7, GPIO_IN }, // Not connected
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU_1
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // Not connected
+    { &GPCRI6, GPIO_ALT }, // THERM_VOLT_CPU_2
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_IN }, // SINK_CTRL_EC_1
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // SINK_CTRL_EC_2
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // LEDKB_DET#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable PECI
-    GCR2 = 0;
-    // Disable UARTs
-    GCR6 = 0;
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW counter 12 seconds
-    GCR10 = BIT(1);
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPB5 and GPD2 to 1.8V
-    GCR19 = BIT(7) | BIT(0);
-    // Set GPD3 to 1.8V, GPF2 and GPF3 to 3.3V
-    GCR20 = BIT(7);
-    // Set GPF7, GPH0, and GPH1 to 1.8V
-    GCR21 = BIT(5) | BIT(2) | BIT(1);
-    // Not documented
-    GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT
-    GPDRB = BIT(4);
-    GPDRC = 0;
-    // PWR_BTN#
-    GPDRD = BIT(5);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_OUT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_IN;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT;
-    // AC_PRESENT_EC
-    GPCRA4 = GPIO_OUT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // TBTA_VBUS_2_EN#
-    GPCRA7 = GPIO_IN;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRB2 = GPIO_IN;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SLP_S0#
-    GPCRB5 = GPIO_IN;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMB_CLK_EC
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMB_DATA_EC
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // TMRI1-TEST
-    GPCRC6 = GPIO_IN;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT;
-
-    // PD_POWER_EN
-    GPCRD0 = GPIO_OUT;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // SLP_A#
-    GPCRD3 = GPIO_IN;
-    // LED_PWR
-    GPCRD4 = GPIO_OUT;
-    // EC_PWR_BTN#
-    GPCRD5 = GPIO_OUT;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT | GPIO_DOWN;
-    // EC_ME_WE
-    GPCRD7 = GPIO_OUT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // GPE1_TEST
-    GPCRE1 = GPIO_IN;
-    // ACE_I2C_IRQ2Z
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // JACK_IN#_EC
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_OUT;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_OUT;
-    // PCH_PWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRF7 = GPIO_IN;
-
-    // 10k pull-down
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_IN;
-    // Pull up to VDD3
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // SUSB#_PCH
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT;
-    // 3G_EN
-    GPCRH3 = GPIO_OUT;
-    // 3G_PWR_EN
-    GPCRH4 = GPIO_OUT;
-    // TBTA_VBUS_1_EN#
-    GPCRH5 = GPIO_IN;
-    // Not connected
-    GPCRH6 = GPIO_IN;
-    // Not connected
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // RGBKB-DET#
-    GPCRI2 = GPIO_IN | GPIO_UP;
-    // THERM_VOLT_CPU_1
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // Not connected
-    GPCRI5 = GPIO_IN;
-    // THERM_VOLT_CPU_2
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // SINK_CTRL_EC_1
-    GPCRJ0 = GPIO_IN;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // SINK_CTRL_EC_2
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // LEDKB_DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/lemp13/gpio.c
+++ b/src/board/system76/lemp13/gpio.c
@@ -30,233 +30,135 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR2, 0 }, // Disable PECI
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR10, BIT(1) }, // PWRSW counter 12 seconds
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(7) | BIT(0) }, // Set GPB5 and GPD2 to 1.8V
+    { &GCR20, BIT(7) }, // Set GPD3 to 1.8V, GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(5) | BIT(2) | BIT(1) }, // Set GPF7, GPH0, and GPH1 to 1.8V
+    { &GCR22, BIT(7) },
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) }, // XLP_OUT
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) }, // PWR_BTN#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+    { &GPDRM, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_OUT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_IN }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_OUT }, // AC_PRESENT_EC
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_IN }, // TBTA_VBUS_2_EN#
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_IN }, // SLP_S0#
+    { &GPCRB6, GPIO_OUT }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMB_CLK_EC
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMB_DATA_EC
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_IN }, // TMRI1-TEST
+    { &GPCRC7, GPIO_OUT }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT }, // PD_POWER_EN
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_IN }, // SLP_A#
+    { &GPCRD4, GPIO_OUT }, // LED_PWR
+    { &GPCRD5, GPIO_OUT }, // EC_PWR_BTN#
+    { &GPCRD6, GPIO_ALT | GPIO_DOWN }, // CPU_FANSEN
+    { &GPCRD7, GPIO_OUT }, // EC_ME_WE
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_IN }, // GPE1_TEST
+    { &GPCRE2, GPIO_IN }, // ACE_I2C_IRQ2Z
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_OUT }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_OUT }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN }, // CPU_C10_GATE#
+
+    { &GPCRG0, GPIO_IN }, // 10k pull-down
+    { &GPCRG1, GPIO_IN }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // Pull up to VDD3
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT }, // LED_ACIN
+    { &GPCRH3, GPIO_OUT }, // 3G_EN
+    { &GPCRH4, GPIO_OUT }, // 3G_PWR_EN
+    { &GPCRH5, GPIO_IN }, // TBTA_VBUS_1_EN#
+    { &GPCRH6, GPIO_IN }, // Not connected
+    { &GPCRH7, GPIO_IN }, // Not connected
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU_1
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // Not connected
+    { &GPCRI6, GPIO_ALT }, // THERM_VOLT_CPU_2
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_IN }, // SINK_CTRL_EC_1
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // SINK_CTRL_EC_2
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // LEDKB_DET#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable PECI
-    GCR2 = 0;
-    // Disable UARTs
-    GCR6 = 0;
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW counter 12 seconds
-    GCR10 = BIT(1);
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPB5 and GPD2 to 1.8V
-    GCR19 = BIT(7) | BIT(0);
-    // Set GPD3 to 1.8V, GPF2 and GPF3 to 3.3V
-    GCR20 = BIT(7);
-    // Set GPF7, GPH0, and GPH1 to 1.8V
-    GCR21 = BIT(5) | BIT(2) | BIT(1);
-    // Not documented
-    GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT
-    GPDRB = BIT(4);
-    GPDRC = 0;
-    // PWR_BTN#
-    GPDRD = BIT(5);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-    GPDRM = 0;
-
-    // Set GPIO control
-
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_OUT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_IN;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT;
-    // AC_PRESENT_EC
-    GPCRA4 = GPIO_OUT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // TBTA_VBUS_2_EN#
-    GPCRA7 = GPIO_IN;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRB2 = GPIO_IN;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SLP_S0#
-    GPCRB5 = GPIO_IN;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMB_CLK_EC
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMB_DATA_EC
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // TMRI1-TEST
-    GPCRC6 = GPIO_IN;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT;
-
-    // PD_POWER_EN
-    GPCRD0 = GPIO_OUT;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // SLP_A#
-    GPCRD3 = GPIO_IN;
-    // LED_PWR
-    GPCRD4 = GPIO_OUT;
-    // EC_PWR_BTN#
-    GPCRD5 = GPIO_OUT;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT | GPIO_DOWN;
-    // EC_ME_WE
-    GPCRD7 = GPIO_OUT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // GPE1_TEST
-    GPCRE1 = GPIO_IN;
-    // ACE_I2C_IRQ2Z
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // JACK_IN#_EC
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_OUT;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_OUT;
-    // PCH_PWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRF7 = GPIO_IN;
-
-    // 10k pull-down
-    GPCRG0 = GPIO_IN;
-    // WLAN_EN
-    GPCRG1 = GPIO_IN;
-    // Pull up to VDD3
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // SUSB#_PCH
-    GPCRH0 = GPIO_IN;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT;
-    // 3G_EN
-    GPCRH3 = GPIO_OUT;
-    // 3G_PWR_EN
-    GPCRH4 = GPIO_OUT;
-    // TBTA_VBUS_1_EN#
-    GPCRH5 = GPIO_IN;
-    // Not connected
-    GPCRH6 = GPIO_IN;
-    // Not connected
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // RGBKB-DET#
-    GPCRI2 = GPIO_IN | GPIO_UP;
-    // THERM_VOLT_CPU_1
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // Not connected
-    GPCRI5 = GPIO_IN;
-    // THERM_VOLT_CPU_2
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // SINK_CTRL_EC_1
-    GPCRJ0 = GPIO_IN;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // SINK_CTRL_EC_2
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // LEDKB_DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/lemp9/gpio.c
+++ b/src/board/system76/lemp9/gpio.c
@@ -42,197 +42,125 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) },
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) },
+    { &GPDRE, BIT(3) },
+    { &GPDRF, BIT(6) },
+    { &GPDRG, 0 },
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_IN }, // AC/BATL#
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_IN }, // NC
+    { &GPCRA5, GPIO_IN }, // NC
+    { &GPCRA6, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRA7, GPIO_OUT }, // PCH_DPWROK_EC
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // PCH_SLP_WLAN#_R
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT }, // SWI#
+    { &GPCRB6, GPIO_IN }, // NC
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMB_CLK_EC
+    { &GPCRC2, GPIO_ALT }, // SMB_DATA_EC
+    { &GPCRC3, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_IN }, // NC
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_IN }, // SUSWARN#
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN }, // LEDKB_DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // EC_BT_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN }, // CPU_C10_GATE#
+
+    { &GPCRG0, GPIO_OUT }, // NC
+    { &GPCRG1, GPIO_OUT }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // Pull up to VDD3?
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_ALT }, // EC_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT }, // BKL_EN
+    { &GPCRH3, GPIO_OUT }, // EC_GPIO
+    { &GPCRH4, GPIO_IN }, // VR_ON
+    { &GPCRH5, GPIO_IN }, // SINK_CTRL_EC
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // NC
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_IN }, // NC
+    { &GPCRI6, GPIO_IN }, // EC_SMD_EN#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_IN }, // SLP_S0#
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN }, // SLP_SUS#
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_EN
+    { &GPCRJ7, GPIO_IN }, // SUS_PWR_ACK
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPIO data
-    GPDRA = 0;
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    GPDRE = BIT(3);
-    GPDRF = BIT(6);
-    GPDRG = 0;
-    GPDRH = 0;
-    GPDRI = 0;
-    GPDRJ = 0;
-
-    // Set GPIO control
-    // AC/BATL#
-    GPCRA0 = GPIO_IN;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT;
-    // NC
-    GPCRA4 = GPIO_IN;
-    // NC
-    GPCRA5 = GPIO_IN;
-    // PCH_PWROK_EC
-    GPCRA6 = GPIO_OUT;
-    // PCH_DPWROK_EC
-    GPCRA7 = GPIO_OUT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // PCH_SLP_WLAN#_R
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT;
-    // NC
-    GPCRB6 = GPIO_IN;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMB_CLK_EC
-    GPCRC1 = GPIO_ALT;
-    // SMB_DATA_EC
-    GPCRC2 = GPIO_ALT;
-    // PCIE_WAKE#
-    GPCRC3 = GPIO_IN;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // NC
-    GPCRC5 = GPIO_IN;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // SUSWARN#
-    GPCRD7 = GPIO_IN;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT;
-    // LEDKB_DET#
-    GPCRE2 = GPIO_IN;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // EC_BT_EN
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRF7 = GPIO_IN;
-    // NC
-    GPCRG0 = GPIO_OUT;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT;
-    // Pull up to VDD3?
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // EC_CLKRUN#
-    GPCRH0 = GPIO_ALT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT;
-    // EC_GPIO
-    GPCRH3 = GPIO_OUT;
-    // VR_ON
-    GPCRH4 = GPIO_IN;
-    // SINK_CTRL_EC
-    GPCRH5 = GPIO_IN;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // NC
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // NC
-    GPCRI5 = GPIO_IN;
-    // EC_SMD_EN#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // SLP_S0#
-    GPCRJ0 = GPIO_IN;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // SLP_SUS#
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_EN
-    GPCRJ6 = GPIO_OUT;
-    // SUS_PWR_ACK
-    GPCRJ7 = GPIO_IN;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/oryp11/gpio.c
+++ b/src/board/system76/oryp11/gpio.c
@@ -36,240 +36,136 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(D, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR1, 0 },
+    { &GCR2, 0 },
+    { &GCR10, 0x02 },
+    { &GCR21, 0 },
+    { &GCR22, 0x80 },
+    { &GCR22, 0x80 },
+    { &GCR23, 0x01 },
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(5) | BIT(4) }, // BL_PWM_EN_EC, XLP_OUT
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(4) }, // PLVDD_RST_EC
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(7) | BIT(3) }, // CC_EN, PCH_DPWROK_EC
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, BIT(2) }, // LAN_PWR_EN
+    { &GPDRJ, BIT(2) }, // EC_AMP_EN
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_PIN_24
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN }, // DDS_EC_PWM
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT }, // BL_PWM_EN_EC
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB_SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB_SO17
+    { &GPCRC6, GPIO_OUT }, // SYS_PWROK_EC
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRD4, GPIO_OUT }, // PLVDD_RST_EC
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // ACE_I2C_IRQ2Z
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_OUT }, // PD_POWER_EN
+    { &GPCRF7, GPIO_OUT | GPIO_UP }, // CC_EN
+
+    { &GPCRG0, GPIO_IN }, // dGPU_OVERT_EC
+    { &GPCRG1, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#_L
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI_L
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO_L
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK_L
+
+    { &GPCRH0, GPIO_OUT }, // ME_WE
+    { &GPCRH1, GPIO_IN }, // SINK_CTRL
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_OUT }, // MUX_CTRL_BIOS
+    { &GPCRH4, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // d_GPIO9_ALERT_FAN
+    { &GPCRH7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // LAN_PWR_EN
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // CC1_DET
+    { &GPCRI6, GPIO_ALT }, // CC2_DET
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // PERKB_DET#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // SERIRQ_ESPI_ALERT0
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    //TODO: what do these do?
-    GCR1 = 0;
-    GCR2 = 0;
-    GCR10 = 0x02;
-    GCR21 = 0;
-    GCR22 = 0x80;
-    GCR22 = 0x80;
-    GCR23 = 0x01;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // BL_PWM_EN_EC, XLP_OUT
-    GPDRB = BIT(5) | BIT(4);
-    GPDRC = 0;
-    // PLVDD_RST_EC
-    GPDRD = BIT(4);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // CC_EN, PCH_DPWROK_EC
-    GPDRF = BIT(7) | BIT(3);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    // LAN_PWR_EN
-    GPDRI = BIT(2);
-    // EC_AMP_EN
-    GPDRJ = BIT(2);
-    GPOTA = 0;
-    GPOTB = 0;
-    GPOTD = 0;
-    GPOTE = 0;
-    GPOTF = 0;
-    GPOTH = 0;
-    GPOTJ = 0;
-
-    // Set GPIO control
-
-    // EC_PWM_PIN_24
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM
-    GPCRA3 = GPIO_IN;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // BL_PWM_EN_EC
-    GPCRB5 = GPIO_OUT;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB_SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB_SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // SYS_PWROK_EC
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRD3 = GPIO_OUT;
-    // PLVDD_RST_EC
-    GPCRD4 = GPIO_OUT;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // ACE_I2C_IRQ2Z
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // PD_POWER_EN
-    GPCRF6 = GPIO_OUT;
-    // CC_EN
-    GPCRF7 = GPIO_OUT | GPIO_UP;
-
-    // dGPU_OVERT_EC
-    GPCRG0 = GPIO_IN;
-    // JACK_IN#_EC
-    GPCRG1 = GPIO_IN;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#_L
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI_L
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO_L
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK_L
-    GPCRG7 = GPIO_ALT;
-
-    // ME_WE
-    GPCRH0 = GPIO_OUT;
-    // SINK_CTRL
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // MUX_CTRL_BIOS
-    GPCRH3 = GPIO_OUT;
-    // DGPU_PWR_EN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // d_GPIO9_ALERT_FAN
-    GPCRH6 = GPIO_IN;
-    // SLP_SUS#
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // LAN_PWR_EN
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // CC1_DET
-    GPCRI5 = GPIO_ALT;
-    // CC2_DET
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // EC_AMP_EN
-    GPCRJ2 = GPIO_OUT;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_IN;
-    // PERKB_DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ_ESPI_ALERT0
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/oryp12/gpio.c
+++ b/src/board/system76/oryp12/gpio.c
@@ -37,227 +37,130 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(J, 0);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, BIT(3) }, // DDS_EC_PWM
+    { &GPDRB, BIT(5) | BIT(4) | BIT(3) }, // BL_PWM_EN_EC, XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(0) }, // PWR_BTN#, PLVDD_RST_EC
+    { &GPDRE, BIT(3) }, // USB_PWR_EN
+    { &GPDRF, BIT(3) }, // PCH_DPWROK_EC
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC
+    { &GPDRH, 0 },
+    { &GPDRI, 0 },
+    { &GPDRJ, BIT(2) | BIT(1) }, // EC_AMP_EN, KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_PIN_24
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_IN }, // DDS_EC_PWM (NC)
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT }, // BL_PWM_EN_EC
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB_SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB_SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT }, // PLVDD_RST_EC
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRD4, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // ACE_I2C_IRQ2Z_EC
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT | GPIO_UP }, // TP_CLK
+    { &GPCRF5, GPIO_ALT | GPIO_UP }, // TP_DATA
+    { &GPCRF6, GPIO_IN }, // SINK_CTRL
+    { &GPCRF7, GPIO_IN | GPIO_UP }, // PM_SLP_S0_CS_N (NC)
+
+    { &GPCRG0, GPIO_IN }, // dGPU_OVERT_EC_SLG
+    { &GPCRG1, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_OUT }, // ME_WE
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_OUT }, // MUX_CTRL_BIOS
+    { &GPCRH4, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_IN | GPIO_UP }, // NC
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_ALT }, // THERM_VOLT_GPU
+    { &GPCRI6, GPIO_ALT }, // THERM_VOLT_HEATSINK
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN }, // d_GPIO9_ALERT_FAN
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // SERIRQ_ESPI_ALERT0
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPM6 power domain to VCC
-    GCR23 = BIT(0);
-
-    // Set GPIO data
-    // DDS_EC_PWM
-    GPDRA = BIT(3);
-    // BL_PWM_EN_EC, XLP_OUT, PWR_SW#
-    GPDRB = BIT(5) | BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, PLVDD_RST_EC
-    GPDRD = BIT(5) | BIT(0);
-    // USB_PWR_EN
-    GPDRE = BIT(3);
-    // PCH_DPWROK_EC
-    GPDRF = BIT(3);
-    // H_PROCHOT_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    GPDRI = 0;
-    // EC_AMP_EN, KBC_MUTE#
-    GPDRJ = BIT(2) | BIT(1);
-
-    // Set GPIO control
-
-    // EC_PWM_PIN_24
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM (NC)
-    GPCRA3 = GPIO_IN;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // BL_PWM_EN_EC
-    GPCRB5 = GPIO_OUT;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB_SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB_SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // PLVDD_RST_EC
-    GPCRD0 = GPIO_OUT;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // LED_BAT_FULL
-    GPCRD3 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD4 = GPIO_OUT | GPIO_UP;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // ACE_I2C_IRQ2Z_EC
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT | GPIO_UP;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT | GPIO_UP;
-    // SINK_CTRL
-    GPCRF6 = GPIO_IN;
-    // PM_SLP_S0_CS_N (NC)
-    GPCRF7 = GPIO_IN | GPIO_UP;
-
-    // dGPU_OVERT_EC_SLG
-    GPCRG0 = GPIO_IN;
-    // JACK_IN#_EC
-    GPCRG1 = GPIO_IN;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // ME_WE
-    GPCRH0 = GPIO_OUT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // MUX_CTRL_BIOS
-    GPCRH3 = GPIO_OUT;
-    // DGPU_PWR_EN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // SLP_SUS#
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // NC
-    GPCRI2 = GPIO_IN | GPIO_UP;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // THERM_VOLT_GPU
-    GPCRI5 = GPIO_ALT;
-    // THERM_VOLT_HEATSINK
-    GPCRI6 = GPIO_ALT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // WLAN_PWR_EN
-    GPCRJ0 = GPIO_OUT;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // EC_AMP_EN
-    GPCRJ2 = GPIO_OUT;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_IN;
-    // d_GPIO9_ALERT_FAN
-    GPCRJ7 = GPIO_IN;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ_ESPI_ALERT0
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/oryp5/gpio.c
+++ b/src/board/system76/oryp5/gpio.c
@@ -40,207 +40,123 @@ struct Gpio __code WLAN_EN =        GPIO(J, 7);
 struct Gpio __code WLAN_PWR_EN =    GPIO(B, 0);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, 0 },
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SCI#, SMI#
+    { &GPDRE, BIT(1) }, // AMP_EN
+    { &GPDRF, BIT(7) | BIT(6) }, // USB_PWR_EN#, H_PECI
+    { &GPDRG, BIT(6) }, // AIRPLAN_LED#
+    { &GPDRH, 0 },
+    { &GPDRI, BIT(5) }, // EC_AMP_EN
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_IN }, // EC_SSD_LED#
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN_PWM
+    { &GPCRA3, GPIO_ALT }, // VGA_FAN_PWM1
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN_PWM2
+    { &GPCRA5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRA6, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRA7, GPIO_OUT | GPIO_UP }, // LED_PWR
+
+    { &GPCRB0, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRB1, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_ALT }, // SMC_BAT
+    { &GPCRB4, GPIO_ALT }, // SMD_BAT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SUSBC_EN#
+    { &GPCRB6, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB7, GPIO_OUT }, // VBATT_BOOST#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_WIGIG_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_IN | GPIO_UP }, // PWR_SW#
+    { &GPCRD1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SMI#
+    { &GPCRD4, GPIO_IN }, // SCI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AMP_EN
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // PERKB_DET#
+    { &GPCRE3, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // BT_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT | GPIO_UP }, // USB_PWR_EN#
+
+    { &GPCRG0, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // 3G_EN
+    { &GPCRG2, GPIO_OUT }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // AIRPLAN_LED#
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_OUT | GPIO_UP }, // NV_POWER_IC_EN
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN | GPIO_UP }, // dGPU_GPIO8_OVERT
+    { &GPCRH4, GPIO_IN | GPIO_UP }, // d_GPIO9_ALERT_FAN / 3G_RST#
+    { &GPCRH5, GPIO_IN | GPIO_UP }, // WL_KB_DET#
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRI6, GPIO_OUT }, // VGASEN_SEL
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT }, // EC_SLP_SUS#
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE# / PERKB_ID1#
+    { &GPCRJ2, GPIO_ALT }, // KBLIGHT_ADJ
+    { &GPCRJ3, GPIO_IN | GPIO_UP }, // RGBKB_DET#
+    { &GPCRJ4, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ5, GPIO_IN }, // MCU_GPE2 / PERKB_ID2#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // 3G_PWR_EN
+    { &GPCRJ7, GPIO_OUT | GPIO_UP }, // WLAN_EN
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-
-    // Set GPIO data
-    GPDRA = 0x00;
-    GPDRB = 0x00;
-    GPDRC = 0x00;
-    // PWR_BTN#, SCI#, SMI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    // AMP_EN
-    GPDRE = BIT(1);
-    // USB_PWR_EN#, H_PECI
-    GPDRF = BIT(7) | BIT(6);
-    // AIRPLAN_LED#
-    GPDRG = BIT(6);
-    GPDRH = 0x00;
-    // EC_AMP_EN
-    GPDRI = BIT(5);
-    GPDRJ = 0x00;
-
-    // EC_SSD_LED#
-    GPCRA0 = GPIO_IN;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN_PWM
-    GPCRA2 = GPIO_ALT;
-    // VGA_FAN_PWM1
-    GPCRA3 = GPIO_ALT;
-    // VGA_FAN_PWM2
-    GPCRA4 = GPIO_ALT;
-    // LED_BAT_CHG
-    GPCRA5 = GPIO_OUT | GPIO_UP;
-    // LED_BAT_FULL
-    GPCRA6 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRA7 = GPIO_OUT | GPIO_UP;
-
-    // WLAN_PWR_EN
-    GPCRB0 = GPIO_OUT | GPIO_UP;
-    // H_PROCHOT_EC
-    GPCRB1 = GPIO_OUT | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // SMC_BAT
-    GPCRB3 = GPIO_ALT;
-    // SMD_BAT
-    GPCRB4 = GPIO_ALT;
-    // SUSBC_EN#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // AC_IN#
-    GPCRB6 = GPIO_IN | GPIO_UP;
-    // VBATT_BOOST#
-    GPCRB7 = GPIO_OUT;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_WIGIG_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // PWR_SW#
-    GPCRD0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRD1 = GPIO_IN | GPIO_UP;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SMI#
-    GPCRD3 = GPIO_IN;
-    // SCI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-
-    // SWI#
-    GPCRE0 = GPIO_OUT | GPIO_UP;
-    // AMP_EN
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // PERKB_DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // DGPU_PWR_EN
-    GPCRE3 = GPIO_IN;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // AC_PRESENT
-    GPCRE7 = GPIO_OUT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // BT_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // USB_PWR_EN#
-    GPCRF7 = GPIO_OUT | GPIO_UP;
-
-    // CCD_EN
-    GPCRG0 = GPIO_OUT | GPIO_UP;
-    // 3G_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // AIRPLAN_LED#
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // NV_POWER_IC_EN
-    GPCRH0 = GPIO_OUT | GPIO_UP;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // dGPU_GPIO8_OVERT
-    GPCRH3 = GPIO_IN | GPIO_UP;
-    // d_GPIO9_ALERT_FAN / 3G_RST#
-    GPCRH4 = GPIO_IN | GPIO_UP;
-    // WL_KB_DET#
-    GPCRH5 = GPIO_IN | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // EC_AMP_EN
-    GPCRI5 = GPIO_OUT;
-    // VGASEN_SEL
-    GPCRI6 = GPIO_OUT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-
-    // EC_SLP_SUS#
-    GPCRJ0 = GPIO_OUT;
-    // KBC_MUTE# / PERKB_ID1#
-    GPCRJ1 = GPIO_IN;
-    // KBLIGHT_ADJ
-    GPCRJ2 = GPIO_ALT;
-    // RGBKB_DET#
-    GPCRJ3 = GPIO_IN | GPIO_UP;
-    // GC6_FB_EN_PCH
-    GPCRJ4 = GPIO_IN;
-    // MCU_GPE2 / PERKB_ID2#
-    GPCRJ5 = GPIO_IN;
-    // 3G_PWR_EN
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // WLAN_EN
-    GPCRJ7 = GPIO_OUT | GPIO_UP;
-
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/oryp6/gpio.c
+++ b/src/board/system76/oryp6/gpio.c
@@ -40,209 +40,127 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(A, 3);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SMI#, SCI#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN#
+    { &GPDRF, BIT(6) }, // EC_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT#_EC
+    { &GPDRH, 0 },
+    { &GPDRI, BIT(5) }, // EC_AMP_EN
+    { &GPDRJ, BIT(1) }, // KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_PIN_24
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN
+    { &GPCRA3, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EN#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_DOWN }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // PERKB_DET#
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT | GPIO_UP }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT | GPIO_UP }, // BT_EN
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // EC_PECI
+    { &GPCRF7, GPIO_IN }, // DGPU_PWR_EN
+
+    { &GPCRG0, GPIO_OUT | GPIO_UP }, //TODO: NV_POWER_IC_EN
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT#_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_ALT }, // PM_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN | GPIO_UP }, // dGPU_GPIO8_OVERT
+    { &GPCRH4, GPIO_IN }, // PCIE_WAKE#
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // VCCIO_3P3_PWRGATE
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRI6, GPIO_IN }, // SLP_S0#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN | GPIO_UP }, // NC
+    { &GPCRJ3, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRJ4, GPIO_OUT }, // EC_SLP_SUS#
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_IN }, // SLP_S5#
+    { &GPCRJ7, GPIO_IN }, // GC6_FB_EN_PCH
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#, SCI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    // USB_PWR_EN#
-    GPDRE = BIT(3);
-    // EC_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT#_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    // EC_AMP_EN
-    GPDRI = BIT(5);
-    // KBC_MUTE#
-    GPDRJ = BIT(1);
-
-    // Set GPIO control
-    // EC_PWM_PIN_24
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN
-    GPCRA2 = GPIO_ALT;
-    // WLAN_PWR_EN
-    GPCRA3 = GPIO_OUT | GPIO_UP;
-    // VGA_FAN
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EN#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_DOWN;
-    // PERKB_DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_OUT | GPIO_UP;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // BT_EN
-    GPCRF3 = GPIO_OUT | GPIO_UP;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // EC_PECI
-    GPCRF6 = GPIO_ALT;
-    // DGPU_PWR_EN
-    GPCRF7 = GPIO_IN;
-    //TODO NV_POWER_IC_EN
-    GPCRG0 = GPIO_OUT | GPIO_UP;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT#_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // PM_CLKRUN#
-    GPCRH0 = GPIO_ALT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // dGPU_GPIO8_OVERT
-    GPCRH3 = GPIO_IN | GPIO_UP;
-    // PCIE_WAKE#
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // VCCIO_3P3_PWRGATE
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // EC_AMP_EN
-    GPCRI5 = GPIO_OUT;
-    // SLP_S0#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // NC
-    GPCRJ2 = GPIO_IN | GPIO_UP;
-    // RGBKB-DET#
-    GPCRJ3 = GPIO_IN | GPIO_UP;
-    // EC_SLP_SUS#
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // SLP_S5#
-    GPCRJ6 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ7 = GPIO_IN;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/oryp7/gpio.c
+++ b/src/board/system76/oryp7/gpio.c
@@ -39,209 +39,127 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(H, 4);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) | BIT(4) | BIT(3) }, // PWR_BTN#, SMI#, SCI#
+    { &GPDRE, BIT(3) }, // USB_PWR_EN#
+    { &GPDRF, BIT(6) }, // H_PECI
+    { &GPDRG, BIT(6) }, // H_PROCHOT_EC#
+    { &GPDRH, 0 },
+    { &GPDRI, BIT(5) }, // EC_AMP_EN
+    { &GPDRJ, BIT(6) | BIT(2) | BIT(1) }, // PLVDD_RST_EC, BL_PWM_EN_EC, KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN_PWM
+    { &GPCRA3, GPIO_IN }, // DDS_EC_PWM
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN_PWM1
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EN#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PM_PWROK
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // LED_ACIN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // BUF_PLT_RST#
+    { &GPCRD3, GPIO_IN }, // SCI#
+    { &GPCRD4, GPIO_IN }, // SMI#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_DOWN }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // PERKB_DET#
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_OUT | GPIO_UP }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // MUX_CTRL_BIOS
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN }, // DGPU_PWR_EN
+
+    { &GPCRG0, GPIO_OUT | GPIO_UP }, //TODO: NV_POWER_IC_EN
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_OUT }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC#
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_ALT }, // PM_CLKRUN#
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // BKL_EN
+    { &GPCRH3, GPIO_IN | GPIO_UP }, // dGPU_OVERT
+    { &GPCRH4, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // VCCIO_3P3_PWRGATE
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // ME_WE
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRI6, GPIO_IN }, // SLP_S0#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_OUT }, // BL_PWM_EN_EC
+    { &GPCRJ3, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRJ4, GPIO_OUT }, // EC_SLP_SUS#
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // PLVDD_RST_EC
+    { &GPCRJ7, GPIO_IN }, // GC6_FB_EN_PCH
+
+    { &GPCRM0, GPIO_ALT }, // LPC_AD0
+    { &GPCRM1, GPIO_ALT }, // LPC_AD1
+    { &GPCRM2, GPIO_ALT }, // LPC_AD2
+    { &GPCRM3, GPIO_ALT }, // LPC_AD3
+    { &GPCRM4, GPIO_ALT }, // PCLK_KBC
+    { &GPCRM5, GPIO_ALT }, // LPC_FRAME#
+    { &GPCRM6, GPIO_ALT }, // SERIRQ
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#, SMI#, SCI#
-    GPDRD = BIT(5) | BIT(4) | BIT(3);
-    // USB_PWR_EN#
-    GPDRE = BIT(3);
-    // H_PECI
-    GPDRF = BIT(6);
-    // H_PROCHOT_EC#
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    // EC_AMP_EN
-    GPDRI = BIT(5);
-    // PLVDD_RST_EC, BL_PWM_EN_EC, KBC_MUTE#
-    GPDRJ = BIT(6) | BIT(2) | BIT(1);
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN_PWM
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM
-    GPCRA3 = GPIO_IN;
-    // VGA_FAN_PWM1
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EN#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PM_PWROK
-    GPCRC6 = GPIO_OUT;
-    // LED_ACIN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT;
-    // BUF_PLT_RST#
-    GPCRD2 = GPIO_ALT;
-    // SCI#
-    GPCRD3 = GPIO_IN;
-    // SMI#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_DOWN;
-    // PERKB_DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_OUT | GPIO_UP;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // MUX_CTRL_BIOS
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // DGPU_PWR_EN
-    GPCRF7 = GPIO_IN;
-    //TODO NV_POWER_IC_EN
-    GPCRG0 = GPIO_OUT | GPIO_UP;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_OUT;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC#
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // PM_CLKRUN#
-    GPCRH0 = GPIO_ALT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // BKL_EN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // dGPU_OVERT
-    GPCRH3 = GPIO_IN | GPIO_UP;
-    // WLAN_PWR_EN
-    GPCRH4 = GPIO_OUT | GPIO_UP;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // VCCIO_3P3_PWRGATE
-    GPCRH7 = GPIO_IN;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // ME_WE
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // EC_AMP_EN
-    GPCRI5 = GPIO_OUT;
-    // SLP_S0#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // BL_PWM_EN_EC
-    GPCRJ2 = GPIO_OUT;
-    // RGBKB-DET#
-    GPCRJ3 = GPIO_IN | GPIO_UP;
-    // EC_SLP_SUS#
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // PLVDD_RST_EC
-    GPCRJ6 = GPIO_OUT;
-    // GC6_FB_EN_PCH
-    GPCRJ7 = GPIO_IN;
-    // LPC_AD0
-    GPCRM0 = GPIO_ALT;
-    // LPC_AD1
-    GPCRM1 = GPIO_ALT;
-    // LPC_AD2
-    GPCRM2 = GPIO_ALT;
-    // LPC_AD3
-    GPCRM3 = GPIO_ALT;
-    // PCLK_KBC
-    GPCRM4 = GPIO_ALT;
-    // LPC_FRAME#
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ
-    GPCRM6 = GPIO_ALT;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/oryp8/gpio.c
+++ b/src/board/system76/oryp8/gpio.c
@@ -37,214 +37,130 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(H, 4);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0x04 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    { &GCR21, BIT(2) }, // Set GPH0 to 1.8V
+
+    // Port data
+    { &GPDRA, BIT(3) }, // DDS_EC_PWM
+    { &GPDRB, BIT(5) | BIT(4) | BIT(3) }, // SWI#, XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) }, // PWR_BTN#
+    { &GPDRE, 0 },
+    { &GPDRF, BIT(7) | BIT(3) }, // BL_PWM_EN_EC, PCH_DPWROK_EC
+    { &GPDRG, BIT(6) }, // H_PROCHOT#_EC
+    { &GPDRH, 0 },
+    { &GPDRI, BIT(6) | BIT(5) }, // PLVDD_RST_EC, EC_AMP_EN
+    { &GPDRJ, 0 },
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN_PWM
+    { &GPCRA3, GPIO_IN }, // DDS_EC_PWM
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN_PWM1
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_IN }, // SLP_A#
+    { &GPCRD4, GPIO_IN }, // SLP_SUS#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // PERKB_DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_OUT }, // BL_PWM_EN_EC
+
+    { &GPCRG0, GPIO_IN | GPIO_UP }, // dGPU_OVERT_EC
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_OUT }, // ME_WE
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH4, GPIO_OUT }, // WLAN_PWR_EN
+    { &GPCRH5, GPIO_OUT }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT | GPIO_UP }, // ACE_I2C_IRQ2Z_EC
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // MUX_CTRL_BIOS
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRI6, GPIO_OUT }, // PLVDD_RST_EC
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_IN }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_IN }, // CPU_C10_GATE#
+    { &GPCRJ3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRJ4, GPIO_OUT }, // EC_SLP_SUS#
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+
+    { &GPCRM0, GPIO_ALT }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS#_EC
+    { &GPCRM6, GPIO_IN | GPIO_UP }, // SERIRQ_ESPI_ALERT0
+};
+
 void gpio_init(void) {
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0x04;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-    // Set GPH0 to 1.8V
-    GCR21 = BIT(2);
-
-    // Set GPIO data
-    // DDS_EC_PWM
-    GPDRA = BIT(3);
-    // SWI#, XLP_OUT, PWR_SW#
-    GPDRB = BIT(5) | BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#
-    GPDRD = BIT(5);
-    GPDRE = 0;
-    // BL_PWM_EN_EC, PCH_DPWROK_EC
-    GPDRF = BIT(7) | BIT(3);
-    // H_PROCHOT#_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    // PLVDD_RST_EC, EC_AMP_EN
-    GPDRI = BIT(6) | BIT(5);
-    GPDRJ = 0;
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN_PWM
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM
-    GPCRA3 = GPIO_IN;
-    // VGA_FAN_PWM1
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // SLP_A#
-    GPCRD3 = GPIO_IN;
-    // SLP_SUS#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // PERKB_DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // BL_PWM_EN_EC
-    GPCRF7 = GPIO_OUT;
-    // dGPU_OVERT_EC
-    GPCRG0 = GPIO_IN | GPIO_UP;
-    // WLAN_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // ME_WE
-    GPCRH0 = GPIO_OUT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // DGPU_PWR_EN
-    GPCRH3 = GPIO_IN;
-    // WLAN_PWR_EN
-    GPCRH4 = GPIO_OUT;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // ACE_I2C_IRQ2Z_EC
-    GPCRH7 = GPIO_OUT | GPIO_UP;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // MUX_CTRL_BIOS
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // EC_AMP_EN
-    GPCRI5 = GPIO_OUT;
-    // PLVDD_RST_EC
-    GPCRI6 = GPIO_OUT;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_IN;
-    // CPU_C10_GATE#
-    GPCRJ2 = GPIO_IN;
-    // GC6_FB_EN_PCH
-    GPCRJ3 = GPIO_IN;
-    // EC_SLP_SUS#
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // RGBKB-DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT;
-    // ESPI_CS#_EC
-    GPCRM5 = GPIO_ALT;
-    // SERIRQ_ESPI_ALERT0
-    GPCRM6 = GPIO_IN | GPIO_UP;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/oryp9/gpio.c
+++ b/src/board/system76/oryp9/gpio.c
@@ -40,220 +40,132 @@ struct Gpio __code WLAN_PWR_EN =    GPIO(G, 1);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    //{ &GCR22, BIT(7) },
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    //{ &GCR22, BIT(7) },
+    //{ &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Port data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(5) | BIT(4) | BIT(3) }, // SWI#, XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, BIT(5) }, // PWR_BTN#
+    { &GPDRE, 0 },
+    { &GPDRF, BIT(3) }, // PCH_DPWROK_EC
+    { &GPDRG, BIT(6) }, // H_PROCHOT#_EC
+    { &GPDRH, 0 },
+    { &GPDRI, BIT(5) }, // EC_AMP_EN
+    { &GPDRJ, BIT(3) | BIT(2) | BIT(1) }, // PLVDD_RST_EC, BL_PWM_EN_EC, KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN_PWM
+    { &GPCRA3, GPIO_IN | GPIO_UP }, // DDS_EC_PWM
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN_PWM1
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT | GPIO_UP }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRD4, GPIO_IN }, // SLP_SUS#
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT | GPIO_UP }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // SB_KBCRST#
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN }, // CPU_C10_GATE#
+
+    { &GPCRG0, GPIO_IN | GPIO_UP }, // dGPU_OVERT_EC
+    { &GPCRG1, GPIO_OUT | GPIO_UP }, // WLAN_PWR_EN
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT#_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_OUT }, // ME_WE
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_IN }, // SLP_S0#
+    { &GPCRH4, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_OUT | GPIO_UP }, // ACE_I2C_IRQ2Z_EC
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // MUX_CTRL_BIOS
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRI6, GPIO_IN }, // PM_BATLOW#
+    { &GPCRI7, GPIO_IN }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE#
+    { &GPCRJ2, GPIO_OUT }, // BL_PWM_EN_EC
+    { &GPCRJ3, GPIO_OUT }, // PLVDD_RST_EC
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_OUT }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // PERKB_DET#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // Not documented
-    //GCR22 = BIT(7);
-
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-
-    // Not documented
-    //GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    //GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // SWI#, XLP_OUT, PWR_SW#
-    GPDRB = BIT(5) | BIT(4) | BIT(3);
-    GPDRC = 0;
-    // PWR_BTN#
-    GPDRD = BIT(5);
-    GPDRE = 0;
-    // PCH_DPWROK_EC
-    GPDRF = BIT(3);
-    // H_PROCHOT#_EC
-    GPDRG = BIT(6);
-    GPDRH = 0;
-    // EC_AMP_EN
-    GPDRI = BIT(5);
-    // PLVDD_RST_EC, BL_PWM_EN_EC, KBC_MUTE#
-    GPDRJ = BIT(3) | BIT(2) | BIT(1);
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN_PWM
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM
-    GPCRA3 = GPIO_IN | GPIO_UP;
-    // VGA_FAN_PWM1
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT | GPIO_UP;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // GC6_FB_EN_PCH
-    GPCRD3 = GPIO_IN;
-    // SLP_SUS#
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT | GPIO_UP;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // SB_KBCRST#
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // CPU_C10_GATE#
-    GPCRF7 = GPIO_IN;
-    // dGPU_OVERT_EC
-    GPCRG0 = GPIO_IN | GPIO_UP;
-    // WLAN_PWR_EN
-    GPCRG1 = GPIO_OUT | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT#_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-    // ME_WE
-    GPCRH0 = GPIO_OUT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // SLP_S0#
-    GPCRH3 = GPIO_IN;
-    // DGPU_PWR_EN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // ACE_I2C_IRQ2Z_EC
-    GPCRH7 = GPIO_OUT | GPIO_UP;
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // MUX_CTRL_BIOS
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT_CPU
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // EC_AMP_EN
-    GPCRI5 = GPIO_OUT;
-    // PM_BATLOW#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_IN;
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE#
-    GPCRJ1 = GPIO_OUT;
-    // BL_PWM_EN_EC
-    GPCRJ2 = GPIO_OUT;
-    // PLVDD_RST_EC
-    GPCRJ3 = GPIO_OUT;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_OUT;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT;
-    // PERKB_DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/board/system76/serw13/gpio.c
+++ b/src/board/system76/serw13/gpio.c
@@ -36,228 +36,132 @@ struct Gpio __code VA_EC_EN =       GPIO(J, 4);
 struct Gpio __code XLP_OUT =        GPIO(B, 4);
 // uncrustify:on
 
+static const struct GpioInit __code gpio_cfg_init[] = {
+    // General control
+    //{ &GCR22, BIT(7) },
+    { &GCR9, BIT(5) }, // PWRSW WDT 2 Enable 2
+    { &GCR8, BIT(4) }, // PWRSW WDT 2 Enable 1
+    { &GCR, 0b10 << 1 }, // Enable LPC reset on GPD2
+    { &GCR6, 0 }, // Disable UARTs
+    { &GCR15, BIT(4) }, // Enable SMBus channel 4
+    { &GCR19, BIT(0) }, // Set GPD2 to 1.8V
+    { &GCR20, 0 }, // Set GPF2 and GPF3 to 3.3V
+    //{ &GCR22, BIT(7) },
+    { &GCR23, BIT(0) }, // Set GPM6 power domain to VCC
+
+    // Porto data
+    { &GPDRA, 0 },
+    { &GPDRB, BIT(4) | BIT(3) }, // XLP_OUT, PWR_SW#
+    { &GPDRC, 0 },
+    { &GPDRD, 0 },
+    { &GPDRE, BIT(3) }, // USB_PWR_EN#
+    { &GPDRF, BIT(3) }, // PCH_DPWROK_EC
+    { &GPDRG, BIT(6) }, // H_PROCHOT_N_EC
+    { &GPDRH, BIT(3) }, // LAN_PWR_EN
+    { &GPDRI, BIT(5) }, // EC_AMP_EN
+    { &GPDRJ, BIT(3) | BIT(2) | BIT(1) }, // PLVDD_RST_EC, BL_PWM_EN_EC, KBC_MUTE#
+
+    // Port control
+    { &GPCRA0, GPIO_ALT }, // EC_PWM_LEDKB_P
+    { &GPCRA1, GPIO_ALT }, // KBC_BEEP
+    { &GPCRA2, GPIO_ALT }, // CPU_FAN_PWM
+    { &GPCRA3, GPIO_IN | GPIO_UP }, // DDS_EC_PWM (Not connected)
+    { &GPCRA4, GPIO_ALT }, // VGA_FAN_PWM1
+    { &GPCRA5, GPIO_ALT }, // EC_PWM_LEDKB_R
+    { &GPCRA6, GPIO_ALT }, // EC_PWM_LEDKB_G
+    { &GPCRA7, GPIO_ALT }, // EC_PWM_LEDKB_B
+
+    { &GPCRB0, GPIO_IN | GPIO_UP }, // AC_IN#
+    { &GPCRB1, GPIO_IN | GPIO_UP }, // LID_SW#
+    { &GPCRB2, GPIO_IN | GPIO_UP }, // LAN_WAKEUP#
+    { &GPCRB3, GPIO_IN }, // PWR_SW#
+    { &GPCRB4, GPIO_OUT }, // XLP_OUT
+    { &GPCRB5, GPIO_OUT }, // SWI#
+    { &GPCRB6, GPIO_OUT | GPIO_UP }, // SUSBC_EC#
+
+    { &GPCRC0, GPIO_IN }, // ALL_SYS_PWRGD
+    { &GPCRC1, GPIO_ALT | GPIO_UP }, // SMC_VGA_THERM
+    { &GPCRC2, GPIO_ALT | GPIO_UP }, // SMD_VGA_THERM
+    { &GPCRC3, GPIO_ALT | GPIO_UP }, // KB-SO16
+    { &GPCRC4, GPIO_IN | GPIO_UP }, // CNVI_DET#
+    { &GPCRC5, GPIO_ALT | GPIO_UP }, // KB-SO17
+    { &GPCRC6, GPIO_OUT }, // PCH_PWROK_EC
+    { &GPCRC7, GPIO_OUT | GPIO_UP }, // BKL_EN
+
+    { &GPCRD0, GPIO_OUT | GPIO_UP }, // LED_PWR
+    { &GPCRD1, GPIO_OUT | GPIO_UP }, // CCD_EN
+    { &GPCRD2, GPIO_ALT }, // ESPI_RESET#
+    { &GPCRD3, GPIO_IN }, // GC6_FB_EN_PCH
+    { &GPCRD4, GPIO_IN }, // ACE_I2C_IRQ2Z_EC
+    { &GPCRD5, GPIO_OUT | GPIO_UP }, // PWR_BTN#
+    { &GPCRD6, GPIO_ALT }, // CPU_FANSEN
+    { &GPCRD7, GPIO_ALT }, // VGA_FANSEN
+
+    { &GPCRE0, GPIO_ALT | GPIO_UP }, // SMC_BAT
+    { &GPCRE1, GPIO_OUT | GPIO_UP }, // AC_PRESENT
+    { &GPCRE2, GPIO_IN | GPIO_UP }, // RGBKB-DET#
+    { &GPCRE3, GPIO_OUT }, // USB_PWR_EN#
+    { &GPCRE4, GPIO_OUT | GPIO_DOWN }, // DD_ON
+    { &GPCRE5, GPIO_OUT }, // EC_RSMRST#
+    { &GPCRE6, GPIO_IN }, // JACK_IN#_EC
+    { &GPCRE7, GPIO_ALT | GPIO_UP }, // SMD_BAT
+
+    { &GPCRF0, GPIO_IN }, // 80CLK
+    { &GPCRF1, GPIO_OUT | GPIO_UP }, // USB_CHARGE_EN
+    { &GPCRF2, GPIO_IN | GPIO_UP }, // 3IN1
+    { &GPCRF3, GPIO_OUT }, // PCH_DPWROK_EC
+    { &GPCRF4, GPIO_ALT }, // TP_CLK
+    { &GPCRF5, GPIO_ALT }, // TP_DATA
+    { &GPCRF6, GPIO_ALT }, // H_PECI
+    { &GPCRF7, GPIO_IN }, // SINK_CTRL
+
+    { &GPCRG0, GPIO_IN | GPIO_UP }, // Not connected
+    { &GPCRG1, GPIO_IN | GPIO_UP }, // Not connected
+    { &GPCRG2, GPIO_IN }, // AUTO_LOAD_PWR
+    { &GPCRG3, GPIO_ALT }, // ALSPI_CE#
+    { &GPCRG4, GPIO_ALT }, // ALSPI_MSI
+    { &GPCRG5, GPIO_ALT }, // ALSPI_MSO
+    { &GPCRG6, GPIO_OUT | GPIO_UP }, // H_PROCHOT_N_EC
+    { &GPCRG7, GPIO_ALT }, // ALSPI_SCLK
+
+    { &GPCRH0, GPIO_OUT }, // ME_WE
+    { &GPCRH1, GPIO_IN }, // SUSC#_PCH
+    { &GPCRH2, GPIO_OUT | GPIO_UP }, // LED_ACIN
+    { &GPCRH3, GPIO_OUT }, // LAN_PWR_EN
+    { &GPCRH4, GPIO_IN }, // DGPU_PWR_EN
+    { &GPCRH5, GPIO_OUT | GPIO_UP }, // LED_BAT_CHG
+    { &GPCRH6, GPIO_IN }, // SUSB#_PCH
+    { &GPCRH7, GPIO_IN }, // SLP_SUS#
+
+    { &GPCRI0, GPIO_ALT }, // BAT_DET
+    { &GPCRI1, GPIO_ALT }, // BAT_VOLT
+    { &GPCRI2, GPIO_OUT }, // MUX_CTRL_BIOS
+    { &GPCRI3, GPIO_ALT }, // THERM_VOLT_CPU
+    { &GPCRI4, GPIO_ALT }, // TOTAL_CUR
+    { &GPCRI5, GPIO_OUT }, // EC_AMP_EN
+    { &GPCRI6, GPIO_IN }, // PM_BATLOW#
+    { &GPCRI7, GPIO_ALT }, // MODEL_ID
+
+    { &GPCRJ0, GPIO_OUT | GPIO_UP }, // LED_BAT_FULL
+    { &GPCRJ1, GPIO_OUT }, // KBC_MUTE# / USB charger detection
+    { &GPCRJ2, GPIO_OUT }, // BL_PWM_EN_EC
+    { &GPCRJ3, GPIO_OUT }, // PLVDD_RST_EC
+    { &GPCRJ4, GPIO_OUT }, // VA_EC_EN
+    { &GPCRJ5, GPIO_IN }, // VBATT_BOOST#
+    { &GPCRJ6, GPIO_OUT | GPIO_UP }, // EC_GPIO
+    { &GPCRJ7, GPIO_IN | GPIO_UP }, // PERKB_DET#
+
+    { &GPCRM0, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO0_EC
+    { &GPCRM1, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO1_EC
+    { &GPCRM2, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO2_EC
+    { &GPCRM3, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_IO3_EC
+    { &GPCRM4, GPIO_ALT | GPIO_UP | GPIO_DOWN }, // ESPI_CLK_EC
+    { &GPCRM5, GPIO_ALT }, // ESPI_CS_EC#
+    { &GPCRM6, GPIO_IN | GPIO_UP | GPIO_DOWN }, // ESPI_ALRT0#
+};
+
 void gpio_init(void) {
-    // Not documented
-    //GCR22 = BIT(7);
-    // PWRSW WDT 2 Enable 2
-    GCR9 = BIT(5);
-    // PWRSW WDT 2 Enable 1
-    GCR8 = BIT(4);
-    // Enable LPC reset on GPD2
-    GCR = 0b10 << 1;
-    // Disable UARTs
-    GCR6 = 0;
-    // Enable SMBus channel 4
-    GCR15 = BIT(4);
-    // Set GPD2 to 1.8V
-    GCR19 = BIT(0);
-    // Set GPF2 and GPF3 to 3.3V
-    GCR20 = 0;
-    // Not documented
-    //GCR22 = BIT(7);
-    // Set GPM6 power domain to VCC
-    GCR23 = BIT(0);
-
-    // Set GPIO data
-    GPDRA = 0;
-    // XLP_OUT, PWR_SW#
-    GPDRB = BIT(4) | BIT(3);
-    GPDRC = 0;
-    GPDRD = 0;
-    // USB_PWR_EN#
-    GPDRE = BIT(3);
-    // PCH_DPWROK_EC
-    GPDRF = BIT(3);
-    // H_PROCHOT_N_EC
-    GPDRG = BIT(6);
-    // LAN_PWR_EN
-    GPDRH = BIT(3);
-    // EC_AMP_EN
-    GPDRI = BIT(5);
-    // PLVDD_RST_EC, BL_PWM_EN_EC, KBC_MUTE#
-    GPDRJ = BIT(3) | BIT(2) | BIT(1);
-
-    // Set GPIO control
-    // EC_PWM_LEDKB_P
-    GPCRA0 = GPIO_ALT;
-    // KBC_BEEP
-    GPCRA1 = GPIO_ALT;
-    // CPU_FAN_PWM
-    GPCRA2 = GPIO_ALT;
-    // DDS_EC_PWM (Not connected)
-    GPCRA3 = GPIO_IN | GPIO_UP;
-    // VGA_FAN_PWM1
-    GPCRA4 = GPIO_ALT;
-    // EC_PWM_LEDKB_R
-    GPCRA5 = GPIO_ALT;
-    // EC_PWM_LEDKB_G
-    GPCRA6 = GPIO_ALT;
-    // EC_PWM_LEDKB_B
-    GPCRA7 = GPIO_ALT;
-
-    // AC_IN#
-    GPCRB0 = GPIO_IN | GPIO_UP;
-    // LID_SW#
-    GPCRB1 = GPIO_IN | GPIO_UP;
-    // LAN_WAKEUP#
-    GPCRB2 = GPIO_IN | GPIO_UP;
-    // PWR_SW#
-    GPCRB3 = GPIO_IN;
-    // XLP_OUT
-    GPCRB4 = GPIO_OUT;
-    // SWI#
-    GPCRB5 = GPIO_OUT;
-    // SUSBC_EC#
-    GPCRB6 = GPIO_OUT | GPIO_UP;
-
-    // ALL_SYS_PWRGD
-    GPCRC0 = GPIO_IN;
-    // SMC_VGA_THERM
-    GPCRC1 = GPIO_ALT | GPIO_UP;
-    // SMD_VGA_THERM
-    GPCRC2 = GPIO_ALT | GPIO_UP;
-    // KB-SO16
-    GPCRC3 = GPIO_ALT | GPIO_UP;
-    // CNVI_DET#
-    GPCRC4 = GPIO_IN | GPIO_UP;
-    // KB-SO17
-    GPCRC5 = GPIO_ALT | GPIO_UP;
-    // PCH_PWROK_EC
-    GPCRC6 = GPIO_OUT;
-    // BKL_EN
-    GPCRC7 = GPIO_OUT | GPIO_UP;
-
-    // LED_PWR
-    GPCRD0 = GPIO_OUT | GPIO_UP;
-    // CCD_EN
-    GPCRD1 = GPIO_OUT | GPIO_UP;
-    // ESPI_RESET#
-    GPCRD2 = GPIO_ALT;
-    // GC6_FB_EN_PCH
-    GPCRD3 = GPIO_IN;
-    // ACE_I2C_IRQ2Z_EC
-    GPCRD4 = GPIO_IN;
-    // PWR_BTN#
-    GPCRD5 = GPIO_OUT | GPIO_UP;
-    // CPU_FANSEN
-    GPCRD6 = GPIO_ALT;
-    // VGA_FANSEN
-    GPCRD7 = GPIO_ALT;
-
-    // SMC_BAT
-    GPCRE0 = GPIO_ALT | GPIO_UP;
-    // AC_PRESENT
-    GPCRE1 = GPIO_OUT | GPIO_UP;
-    // RGBKB-DET#
-    GPCRE2 = GPIO_IN | GPIO_UP;
-    // USB_PWR_EN#
-    GPCRE3 = GPIO_OUT;
-    // DD_ON
-    GPCRE4 = GPIO_OUT | GPIO_DOWN;
-    // EC_RSMRST#
-    GPCRE5 = GPIO_OUT;
-    // JACK_IN#_EC
-    GPCRE6 = GPIO_IN;
-    // SMD_BAT
-    GPCRE7 = GPIO_ALT | GPIO_UP;
-
-    // 80CLK
-    GPCRF0 = GPIO_IN;
-    // USB_CHARGE_EN
-    GPCRF1 = GPIO_OUT | GPIO_UP;
-    // 3IN1
-    GPCRF2 = GPIO_IN | GPIO_UP;
-    // PCH_DPWROK_EC
-    GPCRF3 = GPIO_OUT;
-    // TP_CLK
-    GPCRF4 = GPIO_ALT;
-    // TP_DATA
-    GPCRF5 = GPIO_ALT;
-    // H_PECI
-    GPCRF6 = GPIO_ALT;
-    // SINK_CTRL
-    GPCRF7 = GPIO_IN;
-
-    // Not connected
-    GPCRG0 = GPIO_IN | GPIO_UP;
-    // Not connected
-    GPCRG1 = GPIO_IN | GPIO_UP;
-    // AUTO_LOAD_PWR
-    GPCRG2 = GPIO_IN;
-    // ALSPI_CE#
-    GPCRG3 = GPIO_ALT;
-    // ALSPI_MSI
-    GPCRG4 = GPIO_ALT;
-    // ALSPI_MSO
-    GPCRG5 = GPIO_ALT;
-    // H_PROCHOT_N_EC
-    GPCRG6 = GPIO_OUT | GPIO_UP;
-    // ALSPI_SCLK
-    GPCRG7 = GPIO_ALT;
-
-    // ME_WE
-    GPCRH0 = GPIO_OUT;
-    // SUSC#_PCH
-    GPCRH1 = GPIO_IN;
-    // LED_ACIN
-    GPCRH2 = GPIO_OUT | GPIO_UP;
-    // LAN_PWR_EN
-    GPCRH3 = GPIO_OUT;
-    // DGPU_PWR_EN
-    GPCRH4 = GPIO_IN;
-    // LED_BAT_CHG
-    GPCRH5 = GPIO_OUT | GPIO_UP;
-    // SUSB#_PCH
-    GPCRH6 = GPIO_IN;
-    // SLP_SUS#
-    GPCRH7 = GPIO_IN;
-
-    // BAT_DET
-    GPCRI0 = GPIO_ALT;
-    // BAT_VOLT
-    GPCRI1 = GPIO_ALT;
-    // MUX_CTRL_BIOS
-    GPCRI2 = GPIO_OUT;
-    // THERM_VOLT_CPU
-    GPCRI3 = GPIO_ALT;
-    // TOTAL_CUR
-    GPCRI4 = GPIO_ALT;
-    // EC_AMP_EN
-    GPCRI5 = GPIO_OUT;
-    // PM_BATLOW#
-    GPCRI6 = GPIO_IN;
-    // MODEL_ID
-    GPCRI7 = GPIO_ALT;
-
-    // LED_BAT_FULL
-    GPCRJ0 = GPIO_OUT | GPIO_UP;
-    // KBC_MUTE# / USB charger detection
-    GPCRJ1 = GPIO_OUT;
-    // BL_PWM_EN_EC
-    GPCRJ2 = GPIO_OUT;
-    // PLVDD_RST_EC
-    GPCRJ3 = GPIO_OUT;
-    // VA_EC_EN
-    GPCRJ4 = GPIO_OUT;
-    // VBATT_BOOST#
-    GPCRJ5 = GPIO_IN;
-    // EC_GPIO
-    GPCRJ6 = GPIO_OUT | GPIO_UP;
-    // PERKB_DET#
-    GPCRJ7 = GPIO_IN | GPIO_UP;
-
-    // ESPI_IO0_EC
-    GPCRM0 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO1_EC
-    GPCRM1 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO2_EC
-    GPCRM2 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_IO3_EC
-    GPCRM3 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CLK_EC
-    GPCRM4 = GPIO_ALT | GPIO_UP | GPIO_DOWN;
-    // ESPI_CS_EC#
-    GPCRM5 = GPIO_ALT;
-    // ESPI_ALRT0#
-    GPCRM6 = GPIO_IN | GPIO_UP | GPIO_DOWN;
+    for (uint8_t i = 0; i < ARRAY_SIZE(gpio_cfg_init); i++) {
+        *gpio_cfg_init[i].reg = gpio_cfg_init[i].data;
+    }
 }

--- a/src/ec/ite/include/ec/gpio.h
+++ b/src/ec/ite/include/ec/gpio.h
@@ -14,6 +14,11 @@
 #define GPIO_UP     BIT(2)
 #define GPIO_DOWN   BIT(1)
 
+struct GpioInit {
+    volatile uint8_t __xdata *const reg;
+    uint8_t data;
+};
+
 struct Gpio {
     volatile uint8_t __xdata *data;
     volatile uint8_t __xdata *mirror;


### PR DESCRIPTION
`gpio_init()` is now the same for every board, and only requires an array that defines the init data for GPIOs.

The idea is to be able to support tooling for generating and validating the GPIO configs.