### PR TITLE
Remove GPH7 on IT8587E

### DIFF
--- a/src/board/system76/addw1/gpio.c
+++ b/src/board/system76/addw1/gpio.c
@@ -192,8 +192,6 @@ void gpio_init(void) {
     GPCRH5 = GPIO_OUT | GPIO_UP;
     // SUSB#_PCH
     GPCRH6 = GPIO_IN;
-    // TODO
-    GPCRH7 = GPIO_IN;
     // BAT_DET
     GPCRI0 = GPIO_ALT;
     // BAT_VOLT

--- a/src/board/system76/darp5/gpio.c
+++ b/src/board/system76/darp5/gpio.c
@@ -192,8 +192,6 @@ void gpio_init(void) {
     GPCRH5 = GPIO_OUT;
     // SUSB#_PCH
     GPCRH6 = GPIO_IN;
-    // Unknown
-    GPCRH7 = GPIO_IN;
     // BAT_DET
     GPCRI0 = GPIO_ALT;
     // BAT_VOLT

--- a/src/board/system76/galp3-c/gpio.c
+++ b/src/board/system76/galp3-c/gpio.c
@@ -191,8 +191,6 @@ void gpio_init(void) {
     GPCRH5 = GPIO_OUT;
     // SUSB#_PCH
     GPCRH6 = GPIO_IN;
-    // Unknown
-    GPCRH7 = GPIO_IN;
     // BAT_DET
     GPCRI0 = GPIO_ALT;
     // BAT_VOLT

--- a/src/board/system76/oryp5/gpio.c
+++ b/src/board/system76/oryp5/gpio.c
@@ -194,8 +194,6 @@ void gpio_init(void) {
     GPCRH5 = GPIO_IN | GPIO_UP;
     // SUSB#_PCH
     GPCRH6 = GPIO_IN;
-    // Unknown
-    GPCRH7 = GPIO_IN;
 
     // BAT_DET
     GPCRI0 = GPIO_ALT;

--- a/src/ec/ite/include/ec/gpio.h
+++ b/src/ec/ite/include/ec/gpio.h
@@ -170,7 +170,9 @@ volatile uint8_t __xdata __at(0x164B) GPCRH3;
 volatile uint8_t __xdata __at(0x164C) GPCRH4;
 volatile uint8_t __xdata __at(0x164D) GPCRH5;
 volatile uint8_t __xdata __at(0x164E) GPCRH6;
+#if CONFIG_EC_ITE_IT5570E || CONFIG_EC_ITE_IT5571E
 volatile uint8_t __xdata __at(0x164F) GPCRH7;
+#endif
 
 volatile uint8_t __xdata __at(0x1650) GPCRI0;
 volatile uint8_t __xdata __at(0x1651) GPCRI1;


### PR DESCRIPTION
On IT8587E, pin 3 is VBAT and not a GPIO pin.

Ref: Table 4-1. Pins Listed in Numeric Order (128-pin LQFP)
Ref: Table 7-14. GPIO Alternate Function