### PR TITLE
Sync fans based on temp instead of duty

### DIFF
--- a/src/board/system76/common/fan.c
+++ b/src/board/system76/common/fan.c
@@ -220,18 +220,15 @@ static uint8_t fan_get_duty(const struct Fan *const fan, int16_t temp) {
 }
 
 void fan_update_duty(void) {
-#if defined(FAN2_PWM) && !CONFIG_HAVE_DGPU
-    int16_t dgpu_temp = peci_temp;
+#if CONFIG_HAVE_DGPU
+    int16_t sys_temp = MAX(peci_temp, dgpu_temp);
+#else
+    int16_t sys_temp = peci_temp;
 #endif
 
-    uint8_t fan1_duty = fan_get_duty(&FAN1, peci_temp);
+    uint8_t fan1_duty = fan_get_duty(&FAN1, sys_temp);
 #ifdef FAN2_PWM
-    uint8_t fan2_duty = fan_get_duty(&FAN2, dgpu_temp);
-
-#if SYNC_FANS != 0
-    fan1_duty = MAX(fan1_duty, fan2_duty);
-    fan2_duty = MAX(fan1_duty, fan2_duty);
-#endif // SYNC_FANS
+    uint8_t fan2_duty = fan_get_duty(&FAN2, sys_temp);
 #endif // FAN2_PWM
 
     // set FAN1 duty

--- a/src/board/system76/common/include/board/fan.h
+++ b/src/board/system76/common/include/board/fan.h
@@ -14,10 +14,6 @@
 #define SMOOTH_FANS 1 // default to fan smoothing
 #endif
 
-#ifndef SYNC_FANS
-#define SYNC_FANS 1 // default to syncing fan speeds
-#endif
-
 #if SMOOTH_FANS != 0
 #ifndef SMOOTH_FANS_UP
 #define SMOOTH_FANS_UP 45 // default to ~11 seconds for full ramp-up


### PR DESCRIPTION
Fans may be different sizes, placed in asymmetrical positions, or have different amounts of venting through the chassis. These characteristics affect the ability for each fan, separately, to dissipate heat and generate noise.

Replace syncing fans to the highest duty calculated for each fan, based on separate thermal sensors, to using the highest reported temperature across all sensors to calculate each fan's duty for that highest temperature.

In other words: The old behavior synced fans based on the *output* value (duty), while this new behavior syncs fans based on the *input* value (temperature).

This allows tuning fans separately to better manage total system thermals and mitigate noise.

Tested by modifying FAN2 points on oryp6 to always run at 80% and then verifying that "CPU fan" spins up/down to different values than "GPU fan".

Resolves: #390.