### PR TITLE
Update Rust toolchain config

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2024-05-11"
-components = ["rust-src"]
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
Remove rust-src as it is not required. Use a minimal profile with clippy and rustfmt installed, instead of the default profile, as rust-docs is not needed.