### PR TITLE
Use a moving average for temperatures

### DIFF
--- a/src/board/system76/common/dgpu.c
+++ b/src/board/system76/common/dgpu.c
@@ -9,6 +9,9 @@
 
 int16_t dgpu_temp = 0;
 
+// Update interval is 250ms, so average over 1s period
+static int16_t dgpu_temps[4] = { 0 };
+
 void dgpu_init(void) {
     // Set up for i2c usage
     i2c_reset(&I2C_DGPU, true);
@@ -33,11 +36,18 @@ bool dgpu_get_temp(int16_t *const data) {
 }
 
 void dgpu_read_temp(void) {
+    dgpu_temps[0] = dgpu_temps[1];
+    dgpu_temps[1] = dgpu_temps[2];
+    dgpu_temps[2] = dgpu_temps[3];
+
     if (power_state == POWER_STATE_S0) {
-        if (dgpu_get_temp(&dgpu_temp)) {
-            return;
+        if (!dgpu_get_temp(&dgpu_temps[3])) {
+            dgpu_temps[3] = 0;
         }
+    } else {
+        dgpu_temps[3] = 0;
     }
 
-    dgpu_temp = 0;
+    dgpu_temp = (dgpu_temps[0] + dgpu_temps[1] + dgpu_temps[2] + dgpu_temps[3]) /
+        ARRAY_SIZE(dgpu_temps);
 }

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -17,6 +17,9 @@
 bool peci_on = false;
 int16_t peci_temp = 0;
 
+// Update interval is 250ms, so average over 1s period
+static int16_t peci_temps[4] = { 0 };
+
 // Tjunction = 100C for i7-8565U (and probably the same for all WHL-U)
 #define T_JUNCTION ((int16_t)100)
 
@@ -382,12 +385,19 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
 #endif // CONFIG_PECI_OVER_ESPI
 
 void peci_read_temp(void) {
+    peci_temps[0] = peci_temps[1];
+    peci_temps[1] = peci_temps[2];
+    peci_temps[2] = peci_temps[3];
+
     peci_on = peci_available();
     if (peci_on) {
-        if (peci_get_temp(&peci_temp)) {
-            return;
+        if (!peci_get_temp(&peci_temps[3])) {
+            peci_temps[3] = 0;
         }
+    } else {
+        peci_temps[3] = 0;
     }
 
-    peci_temp = 0;
+    peci_temp = (peci_temps[0] + peci_temps[1] + peci_temps[2] + peci_temps[3]) /
+        ARRAY_SIZE(peci_temps);
 }


### PR DESCRIPTION
Mitigate some fan noise by using a moving average instead of instantaneous points for thermal logic.

When starting a load, CPU will report rapid jumps in temp temperature. These spikes end up getting recorded by the cooldown table, and will cause the fans to run at higher than necessary duties for the actual loads.

Current logic is set to update every 250ms, so use 4 points to average over 1s.

TODO:

- Evaluate interaction with `HEATUP`/`COOLDOWN`, and if that needs to change as well.

Resolves: #480