### PR TITLE
Use a 16-bit system tick

### DIFF
--- a/src/arch/8051/include/arch/time.h
+++ b/src/arch/8051/include/arch/time.h
@@ -5,7 +5,9 @@
 
 #include <stdint.h>
 
+typedef uint16_t systick_t;
+
 void time_init(void);
-uint32_t time_get(void);
+systick_t time_get(void);
 
 #endif // _ARCH_TIME_H

--- a/src/arch/8051/time.c
+++ b/src/arch/8051/time.c
@@ -10,7 +10,7 @@
 // Value to reload into the timer when the overflow interrupt is triggered.
 #define TIMER_RELOAD (0xFFFF - (TICK_INTERVAL_MS * (CONFIG_CLOCK_FREQ_KHZ / OSC_DIVISOR)))
 
-static volatile uint32_t time_overflows = 0;
+static volatile systick_t time_overflows = 0;
 
 void timer_0(void) __interrupt(1) {
     // Hardware automatically clears the the interrupt
@@ -52,6 +52,6 @@ void time_init(void) __critical {
     TR0 = 1;
 }
 
-uint32_t time_get(void) __critical {
+systick_t time_get(void) __critical {
     return time_overflows;
 }

--- a/src/board/system76/common/kbscan.c
+++ b/src/board/system76/common/kbscan.c
@@ -284,15 +284,15 @@ void kbscan_event(void) {
     uint8_t matrix_curr[KM_OUT];
 
     static bool debounce = false;
-    static uint32_t debounce_time = 0;
+    static systick_t debounce_time = 0;
 
     static bool repeat = false;
     static uint16_t repeat_key = 0;
-    static uint32_t repeat_key_time = 0;
+    static systick_t repeat_key_time = 0;
 
     // If debounce complete
     if (debounce) {
-        uint32_t time = time_get();
+        systick_t time = time_get();
         if ((time - debounce_time) >= DEBOUNCE_DELAY) {
             // Debounce time elapsed: Read new state
             debounce = false;
@@ -384,8 +384,8 @@ void kbscan_event(void) {
             kbscan_matrix[i] = new;
         } else if (new && repeat_key != 0 && key_should_repeat(repeat_key)) {
             // A key is being pressed
-            uint32_t time = time_get();
-            static uint32_t repeat_start = 0;
+            systick_t time = time_get();
+            static systick_t repeat_start = 0;
 
             if (!repeat) {
                 if (time < repeat_key_time) {

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -98,8 +98,8 @@ void main(void) {
 
     INFO("System76 EC board '%s', version '%s'\n", board(), version());
 
-    uint32_t last_time_battery = 0;
-    uint32_t last_time_fan = 0;
+    systick_t last_time_battery = 0;
+    systick_t last_time_fan = 0;
 
     for (main_cycle = 0;; main_cycle++) {
         // NOTE: Do note use modulo to avoid expensive call to SDCC library
@@ -128,7 +128,7 @@ void main(void) {
         }
 
         if (main_cycle == 0) {
-            uint32_t time = time_get();
+            systick_t time = time_get();
             // Only run the following once per interval
             if ((time - last_time_fan) >= fan_interval) {
                 last_time_fan = time;

--- a/src/board/system76/common/parallel.c
+++ b/src/board/system76/common/parallel.c
@@ -32,7 +32,7 @@
 bool parallel_debug = false;
 
 static bool parallel_wait_peripheral(uint8_t mask, uint8_t value) {
-    uint32_t start = time_get();
+    systick_t start = time_get();
 
     while ((time_get() - start) < PARALLEL_TIMEOUT) {
         if ((KSOHGDMRR & mask) == value) {

--- a/src/board/system76/common/peci.c
+++ b/src/board/system76/common/peci.c
@@ -131,7 +131,7 @@ bool peci_get_temp(int16_t *const data) {
     ESUCTRL0 |= ESUCTRL0_GO;
 
     // Wait until upstream done
-    uint32_t start = time_get();
+    systick_t start = time_get();
     while (!(ESUCTRL0 & ESUCTRL0_DONE)) {
         if ((time_get() - start) >= PECI_ESPI_TIMEOUT) {
             DEBUG("peci_get_temp: upstream timeout\n");
@@ -224,7 +224,7 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
     ESUCTRL0 |= ESUCTRL0_GO;
 
     // Wait until upstream done
-    uint32_t start = time_get();
+    systick_t start = time_get();
     while (!(ESUCTRL0 & ESUCTRL0_DONE)) {
         DEBUG("peci_wr_pkg_config: wait upstream\n");
         if ((time_get() - start) >= PECI_ESPI_TIMEOUT) {
@@ -289,7 +289,7 @@ void peci_init(void) {
 // Returns true on success, false on error
 bool peci_get_temp(int16_t *const data) {
     // Wait for any in-progress transaction to complete
-    uint32_t start = time_get();
+    systick_t start = time_get();
     while (HOSTAR & BIT(0)) {
         if ((time_get() - start) >= PECI_ESPI_TIMEOUT) {
             DEBUG("%s: host timeout\n", __func__);
@@ -344,7 +344,7 @@ bool peci_get_temp(int16_t *const data) {
 // negative (0x1000 | status register) on PECI hardware error
 int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
     // Wait for any in-progress transaction to complete
-    uint32_t start = time_get();
+    systick_t start = time_get();
     while (HOSTAR & BIT(0)) {
         if ((time_get() - start) >= PECI_ESPI_TIMEOUT) {
             DEBUG("%s: host timeout\n", __func__);

--- a/src/board/system76/common/power.c
+++ b/src/board/system76/common/power.c
@@ -572,8 +572,8 @@ void power_event(void) {
     wake_last = wake_new;
 #endif // HAVE_LAN_WAKEUP_N
 
-    static uint32_t last_time = 0;
-    uint32_t time = time_get();
+    static systick_t last_time = 0;
+    systick_t time = time_get();
     if (power_state == POWER_STATE_S0) {
 #if CONFIG_BUS_ESPI
         // HOST_C10 virtual wire is high when CPU is in C10 sleep state


### PR DESCRIPTION
The maximum interval when configured for a 1ms tick:

- 16-bit: ~65 seconds
- 32-bit: ~49.7 days

The value is used for scheduling and timeouts, and not to track the uptime of the system, so the 32-bit value is excessive.

<details>

<summary>oryp6 <code>ec.mem</code> diff</summary>

```diff
--- 0/ec.mem	2024-07-12 06:53:03.449950127 -0600
+++ 1/ec.mem	2024-07-12 06:53:15.068179591 -0600
@@ -1,11 +1,11 @@
 Internal RAM layout:
       0 1 2 3 4 5 6 7 8 9 A B C D E F
-0x00:|0|0|0|0|0|0|0|0|a|a|a|a|b|b|b|b|
-0x10:|b|b|c|c|c|c|c|c|c|c|c|c|c|e|g| |
-0x20:|B|B|B|d|d|d|d|f|f|f|f|f|f|f|f|f|
-0x30:|f|f|f|f|f|f|f|f|f|f|f|f|f|f|f|f|
-0x40:|f|f|f|f|f|f|h|h|h|h|h|h|h|h|h|h|
-0x50:|Q|Q|Q|Q|Q|S|S|S|S|S|S|S|S|S|S|S|
+0x00:|0|0|0|0|0|0|0|0|a|a|a|a|a|a|b|b|
+0x10:|b|b|b|b|b|b|b|b|b|c|c|c|c|e| | |
+0x20:|B|B|B|d|d|d|d|d|d|d|d|d|d|d|d|d|
+0x30:|d|d|d|d|d|d|d|d|d|d|d|d|d|d|d|d|
+0x40:|d|d|f|f|f|f|f|f|f|f|f|f|Q|Q|Q|Q|
+0x50:|Q|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
 0x60:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
 0x70:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
 0x80:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
@@ -18,12 +18,12 @@
 0xf0:|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|S|
 0-3:Reg Banks, T:Bit regs, a-z:Data, B:Bits, Q:Overlay, I:iData, S:Stack, A:Absolute

-Stack starts at: 0x55 (sp set to 0x54) with 171 bytes available.
-The largest spare internal RAM space starts at 0x1f with 1 byte available.
+Stack starts at: 0x51 (sp set to 0x50) with 175 bytes available.
+The largest spare internal RAM space starts at 0x1e with 2 bytes available.

 Other memory:
    Name             Start    End      Size     Max
    ---------------- -------- -------- -------- --------
    PAGED EXT. RAM                         0      256
-   EXTERNAL RAM     0x0001   0x0526    1318     2048
-   ROM/EPROM/FLASH  0x0000   0x9113   36750    65536
+   EXTERNAL RAM     0x0001   0x0518    1304     2048
+   ROM/EPROM/FLASH  0x0000   0x8f8d   36206    65536
```

</details>