### PR TITLE
main: Run events at time intervals

### DIFF
--- a/src/board/system76/addw1/board.c
+++ b/src/board/system76/addw1/board.c
@@ -5,8 +5,6 @@
 #include <board/kbc.h>
 #include <common/debug.h>
 
-extern uint8_t main_cycle;
-
 void board_init(void) {
     // Allow CPU to boot
     gpio_set(&SB_KBCRST_N, true);
@@ -23,14 +21,12 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    if (main_cycle == 0) {
-        // Set keyboard LEDs
-        static uint8_t last_kbc_leds = 0;
-        if (kbc_leds != last_kbc_leds) {
-            gpio_set(&LED_SCROLL_N, (kbc_leds & 1) == 0);
-            gpio_set(&LED_NUM_N, (kbc_leds & 2) == 0);
-            gpio_set(&LED_CAP_N, (kbc_leds & 4) == 0);
-            last_kbc_leds = kbc_leds;
-        }
+    // Set keyboard LEDs
+    static uint8_t last_kbc_leds = 0;
+    if (kbc_leds != last_kbc_leds) {
+        gpio_set(&LED_SCROLL_N, (kbc_leds & 1) == 0);
+        gpio_set(&LED_NUM_N, (kbc_leds & 2) == 0);
+        gpio_set(&LED_CAP_N, (kbc_leds & 4) == 0);
+        last_kbc_leds = kbc_leds;
     }
 }

--- a/src/board/system76/addw2/board.c
+++ b/src/board/system76/addw2/board.c
@@ -7,8 +7,6 @@
 #include <common/debug.h>
 #include <ec/ec.h>
 
-extern uint8_t main_cycle;
-
 void board_init(void) {
     // Allow backlight to be turned on
     gpio_set(&BKL_EN, true);
@@ -23,14 +21,12 @@ void board_init(void) {
 void board_event(void) {
     ec_read_post_codes();
 
-    if (main_cycle == 0) {
-        // Set keyboard LEDs
-        static uint8_t last_kbc_leds = 0;
-        if (kbc_leds != last_kbc_leds) {
-            gpio_set(&LED_SCROLL_N, (kbc_leds & 1) == 0);
-            gpio_set(&LED_NUM_N, (kbc_leds & 2) == 0);
-            gpio_set(&LED_CAP_N, (kbc_leds & 4) == 0);
-            last_kbc_leds = kbc_leds;
-        }
+    // Set keyboard LEDs
+    static uint8_t last_kbc_leds = 0;
+    if (kbc_leds != last_kbc_leds) {
+        gpio_set(&LED_SCROLL_N, (kbc_leds & 1) == 0);
+        gpio_set(&LED_NUM_N, (kbc_leds & 2) == 0);
+        gpio_set(&LED_CAP_N, (kbc_leds & 4) == 0);
+        last_kbc_leds = kbc_leds;
     }
 }

--- a/src/board/system76/common/power/intel.c
+++ b/src/board/system76/common/power/intel.c
@@ -388,9 +388,6 @@ void power_event(void) {
         }
         battery_debug();
 
-        // Reset main loop cycle to force reading PECI and battery
-        main_cycle = 0;
-
         // Send SCI to update AC and battery information
         ac_send_sci = true;
     }


### PR DESCRIPTION
Rewrite the main loop to run all its events at certain intervals of the systick instead of running most on every loop.

- `usbpd_event`: Every 4 cycles -> 1ms
- `power_event`: Every 4 cycles -> 1ms
- `kbscan_event`: Every 4 cycles- > 5ms
- `lid_event`: Every 4 cycles -> 500ms
- `board_event`: Every cycle -> 1ms
- `kbc_event`: Every cycle -> 1ms
- `pmc_event`: Every cycle -> 1ms
- `smfi_event`: Every cycle -> 1ms
- `battery_event`: Every 1000ms


Ref: #209, Time-triggered architecture