### PR TITLE
Save battery thresholds to flash

### DIFF
--- a/src/board/system76/common/acpi.c
+++ b/src/board/system76/common/acpi.c
@@ -221,6 +221,7 @@ void acpi_write(uint8_t addr, uint8_t data) {
 
     case 0xBD:
         battery_set_end_threshold(data);
+        (void)battery_save_thresholds();
         break;
 
 #if HAVE_LED_AIRPLANE_N

--- a/src/board/system76/common/flash/main.c
+++ b/src/board/system76/common/flash/main.c
@@ -48,8 +48,8 @@ void flash_write_enable(void);
  */
 void flash_entry(uint32_t addr, uint8_t *data, uint32_t length,
                  uint8_t command) __reentrant __critical {
-    // Only allow access from 64KB to 128KB.
-    if ((addr < 0x10000) || (length > 0x10000) || ((addr + length) > 0x20000))
+    // Only allow access from 64 KiB to the end of flash.
+    if ((addr < 0x10000) || (length > 0x10000) || ((addr + length) > CONFIG_EC_FLASH_SIZE))
         return;
 
     if (command == FLASH_COMMAND_READ) {

--- a/src/board/system76/common/include/board/battery.h
+++ b/src/board/system76/common/include/board/battery.h
@@ -43,6 +43,9 @@ bool battery_set_start_threshold(uint8_t value);
 uint8_t battery_get_end_threshold(void);
 bool battery_set_end_threshold(uint8_t value);
 
+bool battery_load_thresholds(void);
+bool battery_save_thresholds(void);
+
 int16_t battery_charger_configure(void);
 void battery_event(void);
 void battery_reset(void);

--- a/src/board/system76/common/keymap.c
+++ b/src/board/system76/common/keymap.c
@@ -8,7 +8,7 @@ bool keymap_fnlock = false;
 uint16_t __xdata DYNAMIC_KEYMAP[KM_LAY][KM_OUT][KM_IN];
 
 // Config is in the last sector of flash
-const uint32_t CONFIG_ADDR = 0x1FC00;
+const uint32_t CONFIG_ADDR = CONFIG_EC_FLASH_SIZE - 1024;
 // Signature is the size of the keymap
 const uint16_t CONFIG_SIGNATURE = sizeof(DYNAMIC_KEYMAP);
 

--- a/src/board/system76/common/main.c
+++ b/src/board/system76/common/main.c
@@ -90,6 +90,7 @@ void init(void) {
     // Must happen last
     power_init();
     board_init();
+    (void)battery_load_thresholds();
 }
 
 void main(void) {

--- a/src/ec/ite/ec.mk
+++ b/src/ec/ite/ec.mk
@@ -45,3 +45,5 @@ CONFIG_EC_FLASH_SIZE = 262144
 else
 $(error flash size not specified)
 endif
+
+CFLAGS += -DCONFIG_EC_FLASH_SIZE=$(CONFIG_EC_FLASH_SIZE)


### PR DESCRIPTION
Make battery thresholds persistent by saving them in flash space. This allows configuring them after EC reset (system powered-off, unplugged) but before any system firmware or OS policy can be applied.

As part of this, the dynamic keymap is moved from the hard-coded address of 0x1FC00 to "the last sector"; Models with 256 KiB flash (`CONFIG_EC_FLASH_SIZE_256K=y`) will lose their layout and need to reconfigure it.

### Test

- When not configured, default values (90, 100) are used across multiple EC resets
- When configured, the profile/custom values are used across multiple EC resets
  - If flash is dumped, the values are present in the ROM image

Check values with:

- `system76-power charge-thresholds`
- `cat /sys/class/power_supply/BAT0/charge_control_{start,end}_threshold`