### PR TITLE
Use distro provided rustup

### DIFF
--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -20,11 +20,10 @@ toolset.
 
 A complete list of dependencies can be seen in `scripts/deps.sh`.
 
-### Cargo
+### Cargo (Rust)
 
 rustup manages the [Rust] toolchain, which includes cargo. Cargo is required
-for building the tools. It is the only part of the development toolset that is
-not installed through distro packages.
+for building the tools.
 
 ### GNU Make
 


### PR DESCRIPTION
This removes the need to download and run a shell script to set up the environment. The distro is instead trusted to provide a valid binary.

Fedora has a package called "rustup", but it really is just the rustup-init binary [\[1\]].

Additionally handle the behavior changes for rustup 1.28.0, which removes implicit toolchain installation but adds support for installing from `rust-toolchain.toml`.

[\[1\]]: https://src.fedoraproject.org/rpms/rustup