### PR TITLE
tool: Restrict port IO interfaces to x86

### DIFF
--- a/tool/Cargo.lock
+++ b/tool/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -19,33 +19,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -53,18 +53,18 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
- "libc",
+ "shlex",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.8"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.8"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -96,21 +96,21 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "heck"
@@ -132,36 +132,36 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -173,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb516ad341a84372b5b15a5a35cf136ba901a639c8536f521b108253d7fce74"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,9 +186,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -202,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "utf8parse"
@@ -236,9 +242,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -20,8 +20,10 @@ clap = { version = "4.5", features = ["derive"], optional = true }
 libc = { version = "0.2", optional = true }
 # NOTE: Upgrading to 2.x blocked on Ubuntu shipping newer hidapi
 hidapi = { version = "1.5", default-features = false, features = ["linux-shared-hidraw"], optional = true }
-redox_hwio = { version = "0.1.6", default-features = false, optional = true }
 downcast-rs = { version = "1.2.0", default-features = false }
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+redox_hwio = { version = "0.1.6", default-features = false, optional = true }
 
 [features]
 default = ["std", "hidapi", "clap"]

--- a/tool/src/access/hid.rs
+++ b/tool/src/access/hid.rs
@@ -2,10 +2,7 @@
 
 use hidapi::HidDevice;
 
-use crate::{
-    Access,
-    Error,
-};
+use crate::{Access, Error};
 
 /// Use USB HID access, only for USB ECs
 pub struct AccessHid {

--- a/tool/src/access/lpc/direct.rs
+++ b/tool/src/access/lpc/direct.rs
@@ -2,13 +2,7 @@
 
 use hwio::{Io, Pio};
 
-use crate::{
-    Access,
-    Error,
-    SuperIo,
-    Timeout,
-    timeout,
-};
+use crate::{timeout, Access, Error, SuperIo, Timeout};
 
 use super::*;
 
@@ -24,9 +18,7 @@ impl<T: Timeout + Send> AccessLpcDirect<T> {
     pub unsafe fn new(timeout: T) -> Result<Self, Error> {
         // Make sure EC ID matches
         let mut sio = SuperIo::new(0x2E);
-        let id =
-            (sio.read(0x20) as u16) << 8 |
-            (sio.read(0x21) as u16);
+        let id = (sio.read(0x20) as u16) << 8 | (sio.read(0x21) as u16);
         match id {
             0x5570 | 0x8587 => (),
             _ => return Err(Error::SuperIoId(id)),
@@ -41,24 +33,18 @@ impl<T: Timeout + Send> AccessLpcDirect<T> {
 
     /// Read from the command space
     unsafe fn read_cmd(&mut self, addr: u8) -> u8 {
-        Pio::<u8>::new(
-            self.cmd + (addr as u16)
-        ).read()
+        Pio::<u8>::new(self.cmd + (addr as u16)).read()
     }
 
     /// Write to the command space
     unsafe fn write_cmd(&mut self, addr: u8, data: u8) {
-        Pio::<u8>::new(
-            self.cmd + (addr as u16)
-        ).write(data)
+        Pio::<u8>::new(self.cmd + (addr as u16)).write(data)
     }
 
     /// Read from the debug space
     //TODO: better public interface
     pub unsafe fn read_debug(&mut self, addr: u8) -> u8 {
-        Pio::<u8>::new(
-            self.dbg + (addr as u16)
-        ).read()
+        Pio::<u8>::new(self.dbg + (addr as u16)).read()
     }
 
     /// Returns Ok if a command can be sent

--- a/tool/src/access/lpc/linux.rs
+++ b/tool/src/access/lpc/linux.rs
@@ -2,25 +2,13 @@
 
 use std::{
     fs,
-    io::{
-        self,
-        Read,
-        Write,
-        Seek,
-        SeekFrom,
-    },
+    io::{self, Read, Seek, SeekFrom, Write},
     os::unix::io::AsRawFd,
     path::Path,
     time::Duration,
 };
 
-use crate::{
-    Access,
-    Error,
-    StdTimeout,
-    Timeout,
-    timeout,
-};
+use crate::{timeout, Access, Error, StdTimeout, Timeout};
 
 use super::*;
 
@@ -35,7 +23,7 @@ impl PortLock {
         if end < start {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "PortLock::new: end < start"
+                "PortLock::new: end < start",
             ));
         }
         let len = (end - start) + 1;
@@ -57,18 +45,14 @@ impl PortLock {
             return Err(io::Error::last_os_error());
         }
 
-        Ok(Self {
-            start,
-            len,
-            file,
-        })
+        Ok(Self { start, len, file })
     }
 
     fn seek(&mut self, offset: u16) -> io::Result<()> {
         if offset >= self.len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "PortLock::seek: offset >= len"
+                "PortLock::seek: offset >= len",
             ));
         }
         let port = self.start + offset;
@@ -76,7 +60,7 @@ impl PortLock {
         if pos != port as u64 {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
-                "PortLock::seek: failed to seek to port"
+                "PortLock::seek: failed to seek to port",
             ));
         }
         Ok(())
@@ -106,7 +90,7 @@ impl AccessLpcLinux {
     /// Locks ports and then returns access object
     pub unsafe fn new(timeout: Duration) -> Result<Self, Error> {
         // TODO: is there a better way to probe before running a command?
-        if ! Path::new("/sys/bus/acpi/devices/17761776:00").is_dir() {
+        if !Path::new("/sys/bus/acpi/devices/17761776:00").is_dir() {
             return Err(Error::Io(io::Error::new(
                 io::ErrorKind::NotFound,
                 "Failed to find System76 ACPI device",

--- a/tool/src/access/lpc/sim.rs
+++ b/tool/src/access/lpc/sim.rs
@@ -1,18 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-use std::{
-    io,
-    net::UdpSocket,
-    time::Duration,
-};
+use std::{io, net::UdpSocket, time::Duration};
 
-use crate::{
-    Access,
-    Error,
-    StdTimeout,
-    Timeout,
-    timeout,
-};
+use crate::{timeout, Access, Error, StdTimeout, Timeout};
 
 use super::*;
 
@@ -39,7 +29,7 @@ impl AccessLpcSim {
         if self.socket.send(&request)? != request.len() {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
-                "Socket request incorrect size"
+                "Socket request incorrect size",
             ));
         }
 
@@ -47,7 +37,7 @@ impl AccessLpcSim {
         if self.socket.recv(&mut response)? != response.len() {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
-                "Socket response incorrect size"
+                "Socket response incorrect size",
             ));
         }
 

--- a/tool/src/access/mod.rs
+++ b/tool/src/access/mod.rs
@@ -11,15 +11,9 @@ pub use self::hid::AccessHid;
 #[cfg(feature = "hidapi")]
 mod hid;
 
-#[cfg(any(
-    feature = "redox_hwio",
-    all(feature = "std", target_os = "linux")
-))]
+#[cfg(any(feature = "redox_hwio", all(feature = "std", target_os = "linux")))]
 pub use self::lpc::*;
-#[cfg(any(
-    feature = "redox_hwio",
-    all(feature = "std", target_os = "linux")
-))]
+#[cfg(any(feature = "redox_hwio", all(feature = "std", target_os = "linux")))]
 mod lpc;
 
 /// Access method for running an EC command

--- a/tool/src/access/mod.rs
+++ b/tool/src/access/mod.rs
@@ -11,9 +11,15 @@ pub use self::hid::AccessHid;
 #[cfg(feature = "hidapi")]
 mod hid;
 
-#[cfg(any(feature = "redox_hwio", all(feature = "std", target_os = "linux")))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    any(feature = "redox_hwio", all(feature = "std", target_os = "linux"))
+))]
 pub use self::lpc::*;
-#[cfg(any(feature = "redox_hwio", all(feature = "std", target_os = "linux")))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    any(feature = "redox_hwio", all(feature = "std", target_os = "linux"))
+))]
 mod lpc;
 
 /// Access method for running an EC command

--- a/tool/src/ec.rs
+++ b/tool/src/ec.rs
@@ -1,18 +1,10 @@
 // SPDX-License-Identifier: MIT
 
 #[cfg(not(feature = "std"))]
-use alloc::{
-    boxed::Box,
-    vec,
-};
+use alloc::{boxed::Box, vec};
 use core::convert::TryFrom;
 
-use crate::{
-    Access,
-    Error,
-    Spi,
-    SpiTarget,
-};
+use crate::{Access, Error, Spi, SpiTarget};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
@@ -83,10 +75,7 @@ impl<A: Access> Ec<A> {
     /// Probes for a compatible EC
     pub unsafe fn new(access: A) -> Result<Self, Error> {
         // Create EC struct with provided access method and timeout
-        let mut ec = Ec {
-            access,
-            version: 0,
-        };
+        let mut ec = Ec { access, version: 0 };
 
         // Read version of protocol
         ec.version = ec.probe()?;
@@ -188,117 +177,76 @@ impl<A: Access> Ec<A> {
 
     /// Read fan duty cycle by fan index
     pub unsafe fn fan_get(&mut self, index: u8) -> Result<u8, Error> {
-        let mut data = [
-            index,
-            0
-        ];
+        let mut data = [index, 0];
         self.command(Cmd::FanGet, &mut data)?;
         Ok(data[1])
     }
 
     /// Set fan duty cycle by fan index
     pub unsafe fn fan_set(&mut self, index: u8, duty: u8) -> Result<(), Error> {
-        let mut data = [
-            index,
-            duty
-        ];
+        let mut data = [index, duty];
         self.command(Cmd::FanSet, &mut data)
     }
 
     /// Read keymap data by layout, output pin, and input pin
     pub unsafe fn keymap_get(&mut self, layer: u8, output: u8, input: u8) -> Result<u16, Error> {
-        let mut data = [
-            layer,
-            output,
-            input,
-            0,
-            0
-        ];
+        let mut data = [layer, output, input, 0, 0];
         self.command(Cmd::KeymapGet, &mut data)?;
-        Ok(
-            (data[3] as u16) |
-            ((data[4] as u16) << 8)
-        )
+        Ok((data[3] as u16) | ((data[4] as u16) << 8))
     }
 
     /// Set keymap data by layout, output pin, and input pin
-    pub unsafe fn keymap_set(&mut self, layer: u8, output: u8, input: u8, value: u16) -> Result<(), Error> {
-        let mut data = [
-            layer,
-            output,
-            input,
-            value as u8,
-            (value >> 8) as u8
-        ];
+    pub unsafe fn keymap_set(
+        &mut self,
+        layer: u8,
+        output: u8,
+        input: u8,
+        value: u16,
+    ) -> Result<(), Error> {
+        let mut data = [layer, output, input, value as u8, (value >> 8) as u8];
         self.command(Cmd::KeymapSet, &mut data)
     }
 
     // Get LED value by index
     pub unsafe fn led_get_value(&mut self, index: u8) -> Result<(u8, u8), Error> {
-        let mut data = [
-            index,
-            0,
-            0,
-        ];
+        let mut data = [index, 0, 0];
         self.command(Cmd::LedGetValue, &mut data)?;
         Ok((data[1], data[2]))
     }
 
     // Set LED value by index
     pub unsafe fn led_set_value(&mut self, index: u8, value: u8) -> Result<(), Error> {
-        let mut data = [
-            index,
-            value,
-        ];
+        let mut data = [index, value];
         self.command(Cmd::LedSetValue, &mut data)
     }
 
     // Get LED color by index
     pub unsafe fn led_get_color(&mut self, index: u8) -> Result<(u8, u8, u8), Error> {
-        let mut data = [
-            index,
-            0,
-            0,
-            0,
-        ];
+        let mut data = [index, 0, 0, 0];
         self.command(Cmd::LedGetColor, &mut data)?;
-        Ok((
-            data[1],
-            data[2],
-            data[3],
-        ))
+        Ok((data[1], data[2], data[3]))
     }
 
     // Set LED color by index
-    pub unsafe fn led_set_color(&mut self, index: u8, red: u8, green: u8, blue: u8) -> Result<(), Error> {
-        let mut data = [
-            index,
-            red,
-            green,
-            blue,
-        ];
+    pub unsafe fn led_set_color(
+        &mut self,
+        index: u8,
+        red: u8,
+        green: u8,
+        blue: u8,
+    ) -> Result<(), Error> {
+        let mut data = [index, red, green, blue];
         self.command(Cmd::LedSetColor, &mut data)
     }
 
     pub unsafe fn led_get_mode(&mut self, layer: u8) -> Result<(u8, u8), Error> {
-        let mut data = [
-            layer,
-            0,
-            0,
-        ];
+        let mut data = [layer, 0, 0];
         self.command(Cmd::LedGetMode, &mut data)?;
-        Ok((
-            data[1],
-            data[2]
-        ))
+        Ok((data[1], data[2]))
     }
 
     pub unsafe fn led_set_mode(&mut self, layer: u8, mode: u8, speed: u8) -> Result<(), Error> {
-        let mut data = [
-            layer,
-            mode,
-            speed,
-        ];
+        let mut data = [layer, mode, speed];
         self.command(Cmd::LedSetMode, &mut data)
     }
 
@@ -316,23 +264,24 @@ impl<A: Access> Ec<A> {
 
     /// Get security state
     pub unsafe fn security_get(&mut self) -> Result<SecurityState, Error> {
-       let mut data = [0];
-       self.command(Cmd::SecurityGet, &mut data)?;
-       SecurityState::try_from(data[0])
+        let mut data = [0];
+        self.command(Cmd::SecurityGet, &mut data)?;
+        SecurityState::try_from(data[0])
     }
 
     /// Set security state
     pub unsafe fn security_set(&mut self, state: SecurityState) -> Result<(), Error> {
-       let mut data = [state as u8];
-       self.command(Cmd::SecuritySet, &mut data)
+        let mut data = [state as u8];
+        self.command(Cmd::SecuritySet, &mut data)
     }
 
     pub fn into_dyn(self) -> Ec<Box<dyn Access>>
-    where A: 'static {
+    where
+        A: 'static,
+    {
         Ec {
             access: Box::new(self.access),
             version: self.version,
-
         }
     }
 }
@@ -364,7 +313,7 @@ impl<'a, A: Access> EcSpi<'a, A> {
             SpiTarget::Main => (),
             SpiTarget::Backup => {
                 flags |= CMD_SPI_FLAG_BACKUP;
-            },
+            }
         }
 
         flags
@@ -394,7 +343,8 @@ impl<'a, A: Access> Spi for EcSpi<'a, A> {
         for chunk in data.chunks_mut(self.buffer.len() - 2) {
             self.buffer[0] = flags;
             self.buffer[1] = chunk.len() as u8;
-            self.ec.command(Cmd::Spi, &mut self.buffer[..(chunk.len() + 2)])?;
+            self.ec
+                .command(Cmd::Spi, &mut self.buffer[..(chunk.len() + 2)])?;
             if self.buffer[1] != chunk.len() as u8 {
                 return Err(Error::Verify);
             }
@@ -414,7 +364,8 @@ impl<'a, A: Access> Spi for EcSpi<'a, A> {
             for i in 0..chunk.len() {
                 self.buffer[i + 2] = chunk[i];
             }
-            self.ec.command(Cmd::Spi, &mut self.buffer[..(chunk.len() + 2)])?;
+            self.ec
+                .command(Cmd::Spi, &mut self.buffer[..(chunk.len() + 2)])?;
             if self.buffer[1] != chunk.len() as u8 {
                 return Err(Error::Verify);
             }

--- a/tool/src/legacy.rs
+++ b/tool/src/legacy.rs
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use crate::{
-    Error,
-    Pmc,
-    SuperIo,
-    Timeout,
-};
+use crate::{Error, Pmc, SuperIo, Timeout};
 
 /// Run some EC commands on previous proprietary firmware
 pub struct EcLegacy<T: Timeout> {
@@ -17,9 +12,7 @@ impl<T: Timeout> EcLegacy<T> {
     pub unsafe fn new(primary: bool, timeout: T) -> Result<Self, Error> {
         let mut sio = SuperIo::new(if primary { 0x2E } else { 0x4E });
 
-        let id =
-            (sio.read(0x20) as u16) << 8 |
-            (sio.read(0x21) as u16);
+        let id = (sio.read(0x20) as u16) << 8 | (sio.read(0x21) as u16);
 
         match id {
             0x5570 | 0x8587 => (),

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -16,7 +16,6 @@
 
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::needless_range_loop)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
@@ -52,7 +51,7 @@ pub use self::super_io::SuperIo;
 #[cfg(feature = "redox_hwio")]
 mod super_io;
 
-pub use self::timeout::Timeout;
 #[cfg(feature = "std")]
 pub use self::timeout::StdTimeout;
+pub use self::timeout::Timeout;
 mod timeout;

--- a/tool/src/lib.rs
+++ b/tool/src/lib.rs
@@ -6,13 +6,12 @@
 //!
 //! There are some differences between targets and features that are listed below:
 //!  - `AccessHid` requires the `hidapi` feature. Only functional on USB ECs.
-//!  - `AccessLpcDirect` requires the `redox_hwio` feature and a nightly compiler. This method is
+//!  - `AccessLpcDirect` requires the `redox_hwio` feature and an x86 target. This method is
 //!    only recommended for use in firmware with LPC ECs, as mutual exclusion is not guaranteed.
-//!  - `AccessLpcLinux` requires the `std` feature and `linux` target_os. Recommended for LPC ECs,
-//!    as this method can utilize mutual exclusion.
-//!  - `EcLegacy`, `Pmc`, and `SuperIo` all require the `redox_hwio` feature and a nightly
-//!    compiler. It is only recommended to use these in firmware, as mutual exclusion is not
-//!    guaranteed.
+//!  - `AccessLpcLinux` requires the `std` feature, `linux` target_os, and x86 target. Recommended
+//!    for LPC ECs, as this method can utilize mutual exclusion.
+//!  - `EcLegacy`, `Pmc`, and `SuperIo` all require the `redox_hwio` feature and an x86 target.
+//!    It is only recommended to use these in firmware, as mutual exclusion is not guaranteed.
 
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::needless_range_loop)]
@@ -33,22 +32,40 @@ mod error;
 pub use self::firmware::Firmware;
 mod firmware;
 
-#[cfg(feature = "redox_hwio")]
+#[cfg(all(
+    feature = "redox_hwio",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 pub use self::legacy::EcLegacy;
-#[cfg(feature = "redox_hwio")]
+#[cfg(all(
+    feature = "redox_hwio",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 mod legacy;
 
-#[cfg(feature = "redox_hwio")]
+#[cfg(all(
+    feature = "redox_hwio",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 pub use self::pmc::Pmc;
-#[cfg(feature = "redox_hwio")]
+#[cfg(all(
+    feature = "redox_hwio",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 mod pmc;
 
 pub use self::spi::{Spi, SpiRom, SpiTarget};
 mod spi;
 
-#[cfg(feature = "redox_hwio")]
+#[cfg(all(
+    feature = "redox_hwio",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 pub use self::super_io::SuperIo;
-#[cfg(feature = "redox_hwio")]
+#[cfg(all(
+    feature = "redox_hwio",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 mod super_io;
 
 #[cfg(feature = "std")]

--- a/tool/src/pmc.rs
+++ b/tool/src/pmc.rs
@@ -2,11 +2,7 @@
 
 use hwio::{Io, Pio};
 
-use crate::{
-    Error,
-    Timeout,
-    timeout
-};
+use crate::{timeout, Error, Timeout};
 
 /// Standard ACPI EC interface
 pub struct Pmc<T: Timeout> {

--- a/tool/src/timeout.rs
+++ b/tool/src/timeout.rs
@@ -12,7 +12,7 @@ macro_rules! timeout {
                 Ok(ok) => {
                     result = Ok(ok);
                     break;
-                },
+                }
                 Err(err) => match err {
                     $crate::Error::WouldBlock => (),
                     _ => {
@@ -48,7 +48,7 @@ impl StdTimeout {
     pub fn new(duration: Duration) -> Self {
         StdTimeout {
             instant: Instant::now(),
-            duration
+            duration,
         }
     }
 }


### PR DESCRIPTION
Limit all interfaces that use port IO to x86 targets.

The tool probably needs a rewrite to handle AArch64. Too much assumes x86 interfaces.