### PR TITLE
Replace objcopy with makebin

### DIFF
--- a/src/arch/8051/toolchain.mk
+++ b/src/arch/8051/toolchain.mk
@@ -31,9 +31,9 @@ sim: $(BUILD)/ec.rom
 
 # Convert from Intel Hex file to binary file
 $(BUILD)/ec.rom: $(BUILD)/ec.ihx
-	@echo "  OBJCOPY   $(subst $(BUILD)/,,$@)"
+	@echo "  MAKEBIN   $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
-	objcopy -I ihex -O binary --gap-fill=0xFF --pad-to=$(CONFIG_EC_FLASH_SIZE) $< $@
+	makebin -s $(CONFIG_EC_FLASH_SIZE) $< $@
 
 # Link object files into Intel Hex file
 $(BUILD)/ec.ihx: $(OBJ)

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -35,13 +35,13 @@ FLASH_CC=\
 $(BUILD)/include/flash.h: $(FLASH_BUILD)/flash.rom
 	@echo "  XXD       $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
-	xxd -include < $< > $@
+	xxd -include -s $(FLASH_OFFSET) < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(FLASH_BUILD)/flash.rom: $(FLASH_BUILD)/flash.ihx
-	@echo "  OBJCOPY   $(subst $(BUILD)/,,$@)"
+	@echo "  MAKEBIN   $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
-	objcopy -I ihex -O binary $< $@
+	makebin -p $< $@
 
 # Link object files into Intel Hex file
 $(FLASH_BUILD)/flash.ihx: $(FLASH_OBJ)

--- a/src/board/system76/common/scratch/scratch.mk
+++ b/src/board/system76/common/scratch/scratch.mk
@@ -34,13 +34,13 @@ SCRATCH_CC=\
 $(BUILD)/include/scratch.h: $(SCRATCH_BUILD)/scratch.rom
 	@echo "  XXD       $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
-	xxd -include < $< > $@
+	xxd -include -s $(SCRATCH_OFFSET) < $< > $@
 
 # Convert from Intel Hex file to binary file
 $(SCRATCH_BUILD)/scratch.rom: $(SCRATCH_BUILD)/scratch.ihx
-	@echo "  OBJCOPY   $(subst $(BUILD)/,,$@)"
+	@echo "  MAKEBIN   $(subst $(BUILD)/,,$@)"
 	mkdir -p $(@D)
-	objcopy -I ihex -O binary $< $@
+	makebin -p $< $@
 
 # Link object files into Intel Hex file
 $(SCRATCH_BUILD)/scratch.ihx: $(SCRATCH_OBJ)


### PR DESCRIPTION
This reverts commit d36fb62 ("Replace makebin with objcopy").

Using objcopy from GCC 14.2 with the IHX produced by SDCC 4.5.0 results in an incorrectly sized ROM. Revert to using the tool provided by the SDCC toolchain.

Produces different `flash.rom` and `scratch.rom`, but `ec.rom` is identical.