### PR TITLE
Update list of models that use 0.5mm keyboard FFC

### DIFF
--- a/docs/mega2560.md
+++ b/docs/mega2560.md
@@ -18,8 +18,9 @@ it uses the ATmega16U2, find a different model.
 A flexible printed circuit (FPC) breakout board is required. It should have:
 
 - 24 pins with 0.1" (2.54mm) pitch
-- One side with 0.5mm pitch FPC connector (for darp10-b (14" model), darp11-b
-(14" model), lemp9, lemp10, lemp11, lemp12, lemp13, galp5, galp6, and galp7)
+- One side with 0.5mm pitch FPC connector
+  - For darp10-b (14" model), darp11-b (14" model), lemp9, lemp10, lemp11,
+    lemp12, lemp13, galp5, galp6, and galp7.
 - One side with 1.0mm pitch FPC connector (for all other models)
 
 Depending on the vendor, the connectors may not come soldered to the board (or

--- a/docs/mega2560.md
+++ b/docs/mega2560.md
@@ -21,7 +21,8 @@ A flexible printed circuit (FPC) breakout board is required. It should have:
 - One side with 0.5mm pitch FPC connector
   - For darp10-b (14" model), darp11-b (14" model), lemp9, lemp10, lemp11,
     lemp12, lemp13, galp5, galp6, and galp7.
-- One side with 1.0mm pitch FPC connector (for all other models)
+- One side with 1.0mm pitch FPC connector
+  - For all other models.
 
 Depending on the vendor, the connectors may not come soldered to the board (or
 at all). A header block will likely not be provided, so male breakaway

--- a/docs/mega2560.md
+++ b/docs/mega2560.md
@@ -18,7 +18,8 @@ it uses the ATmega16U2, find a different model.
 A flexible printed circuit (FPC) breakout board is required. It should have:
 
 - 24 pins with 0.1" (2.54mm) pitch
-- One side with 0.5mm pitch FPC connector (for lemp9, lemp10, lemp11, galp5, and galp6)
+- One side with 0.5mm pitch FPC connector (for darp10-b (14" model), darp11-b
+(14" model), lemp9, lemp10, lemp11, lemp12, lemp13, galp5, galp6, and galp7)
 - One side with 1.0mm pitch FPC connector (for all other models)
 
 Depending on the vendor, the connectors may not come soldered to the board (or


### PR DESCRIPTION
Support had a customer asking about the pitch on a darp11, and I noticed this list could use an update. Hopefully darp10-b and darp11-b are clear enough about 0.5mm only being for the 14" model.