### PR TITLE
Allow SDCC to have a prefix

### DIFF
--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -42,8 +42,8 @@ the [SDCC manual] for more information.
 
 Version 4.0.0 or newer should be used.
 
-**Note**: Fedora installs SDCC binaries to a non-standard location. Ensure that
-`PATH` includes `/usr/libexec/sdcc`.
+**Note**: Fedora installs SDCC binaries with a prefix. Ensure that
+`SDCC_PREFIX=sdcc-` is set when building.
 
 
 [EditorConfig]: https://editorconfig.org/

--- a/src/arch/8051/toolchain.mk
+++ b/src/arch/8051/toolchain.mk
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
-CC = sdcc -mmcs51 -MMD --model-large --code-size $(CODE_SIZE) --xram-size $(SRAM_SIZE) --Werror
+# XXX: On Fedora, SDCC programs have the `sdcc-` prefix.
+SDCC_PREFIX ?=
+SDCC = $(SDCC_PREFIX)sdcc
+CC = $(SDCC) -mmcs51 -MMD --model-large --code-size $(CODE_SIZE) --xram-size $(SRAM_SIZE) --Werror
 
 AS = sdas8051
 ASFLAGS = -plosgff

--- a/src/board/system76/common/flash/flash.mk
+++ b/src/board/system76/common/flash/flash.mk
@@ -21,7 +21,7 @@ FLASH_SRC += $(foreach src, $(flash-y), $(FLASH_DIR)/$(src))
 FLASH_BUILD=$(BUILD)/flash
 FLASH_OBJ=$(sort $(patsubst src/%.c,$(FLASH_BUILD)/%.rel,$(FLASH_SRC)))
 FLASH_CC=\
-	sdcc \
+	$(SDCC) \
 	-mmcs51 \
 	-MMD \
 	--model-large \

--- a/src/board/system76/common/scratch/scratch.mk
+++ b/src/board/system76/common/scratch/scratch.mk
@@ -22,7 +22,7 @@ SCRATCH_SRC += $(foreach src, $(scratch-y), $(SCRATCH_DIR)/$(src))
 SCRATCH_BUILD=$(BUILD)/scratch
 SCRATCH_OBJ=$(sort $(patsubst src/%.c,$(SCRATCH_BUILD)/%.rel,$(SCRATCH_SRC)))
 SCRATCH_CC=\
-	sdcc \
+	$(SDCC) \
 	-mmcs51 \
 	-MMD \
 	--model-small \


### PR DESCRIPTION
Fedora installs SDCC to `/usr/libexec` and provides scripts in `/usr/bin` with the prefix `sdcc-`. Allow overriding SDCC name and setting a prefix.

Note: SDCC is broken on Fedora 42 and requires updating `PATH` explicitly anyways.

Link: https://bugzilla.redhat.com/show_bug.cgi?id=2344453