### PR TITLE
peci: Fix eSPI host becoming unresponsive

### DIFF
--- a/src/app/main/peci.c
+++ b/src/app/main/peci.c
@@ -93,11 +93,21 @@ bool peci_get_temp(int16_t *const data) {
 
     // Set upstream enable
     ESUCTRL0 |= ESUCTRL0_ENABLE;
+
+    // Wait for upstream to be available
+    systick_t start = time_get();
+    while (ESUCTRL0 & ESUCTRL0_BUSY) {
+        if ((time_get() - start) >= PECI_ESPI_TIMEOUT) {
+            DEBUG("peci_get_temp: upstream busy\n");
+            return false;
+        }
+    }
+
     // Set upstream go
     ESUCTRL0 |= ESUCTRL0_GO;
 
     // Wait until upstream done
-    systick_t start = time_get();
+    start = time_get();
     while (!(ESUCTRL0 & ESUCTRL0_DONE)) {
         if ((time_get() - start) >= PECI_ESPI_TIMEOUT) {
             DEBUG("peci_get_temp: upstream timeout\n");
@@ -189,11 +199,21 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
 
     // Set upstream enable
     ESUCTRL0 |= ESUCTRL0_ENABLE;
+
+    // Wait for upstream to be available
+    systick_t start = time_get();
+    while (ESUCTRL0 & ESUCTRL0_BUSY) {
+        if ((time_get() - start) >= PECI_ESPI_TIMEOUT) {
+            DEBUG("peci_wr_pkg_config: upstream busy\n");
+            return false;
+        }
+    }
+
     // Set upstream go
     ESUCTRL0 |= ESUCTRL0_GO;
 
     // Wait until upstream done
-    systick_t start = time_get();
+    start = time_get();
     while (!(ESUCTRL0 & ESUCTRL0_DONE)) {
         DEBUG("peci_wr_pkg_config: wait upstream\n");
         if ((time_get() - start) >= PECI_ESPI_TIMEOUT) {

--- a/src/app/main/peci.c
+++ b/src/app/main/peci.c
@@ -63,7 +63,7 @@ void peci_init(void) {}
 bool peci_get_temp(int16_t *const data) {
     //TODO: Wait for completion?
     // Clear upstream status
-    ESUCTRL0 = ESUCTRL0;
+    ESUCTRL0 = ESUCTRL0_CH_DISABLED | ESUCTRL0_DONE;
     // Clear OOB status
     ESOCTRL0 = ESOCTRL0;
 
@@ -114,7 +114,7 @@ bool peci_get_temp(int16_t *const data) {
             return false;
         }
     }
-    // Clear upstream done status
+    // Clear upstream done status and disable initiating upstream transactions
     ESUCTRL0 = ESUCTRL0_DONE;
 
     // Wait for response
@@ -156,7 +156,7 @@ bool peci_get_temp(int16_t *const data) {
 int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
     //TODO: Wait for completion?
     // Clear upstream status
-    ESUCTRL0 = ESUCTRL0;
+    ESUCTRL0 = ESUCTRL0_CH_DISABLED | ESUCTRL0_DONE;
     // Clear OOB status
     ESOCTRL0 = ESOCTRL0;
 
@@ -221,7 +221,7 @@ int16_t peci_wr_pkg_config(uint8_t index, uint16_t param, uint32_t data) {
             return false;
         }
     }
-    // Clear upstream done status
+    // Clear upstream done status and disable initiating upstream transactions
     ESUCTRL0 = ESUCTRL0_DONE;
 
     // Wait for response

--- a/src/ec/ite/include/ec/espi.h
+++ b/src/ec/ite/include/ec/espi.h
@@ -114,6 +114,7 @@ volatile uint8_t __xdata __at(0x31A3) ESGCTRL3;
 volatile uint8_t __xdata __at(0x31B0) ESUCTRL0;
 #define ESUCTRL0_ENABLE BIT(7)
 #define ESUCTRL0_GO BIT(6)
+#define ESUCTRL0_CH_DISABLED BIT(2)
 #define ESUCTRL0_DONE BIT(1)
 #define ESUCTRL0_BUSY BIT(0)
 


### PR DESCRIPTION
Attempt to address #369.

- Actually clear ESUCTRL0 before starting
- Wait for eSPI upstream busy

### TODO

- Check if clean up is required on timeout/error before returning from the functions