### PR TITLE
Update remaining references to system76_ectool

### DIFF
--- a/scripts/power.sh
+++ b/scripts/power.sh
@@ -97,7 +97,7 @@ do
 
         if [ "${has_ec}" == "1" ]
         then
-            D="$(sudo tool/target/release/system76_ectool fan 0)"
+            D="$(sudo tools/system76_ectool/target/release/system76_ectool fan 0)"
             P="$(echo "(${D} * 100)/255" | bc -lq)"
             F="${F}\t$(printf "%.0f" "${P}")"
         fi
@@ -112,7 +112,7 @@ do
 
             if [ "${has_ec}" == "1" ]
             then
-                D="$(sudo tool/target/release/system76_ectool fan 1)"
+                D="$(sudo tools/system76_ectool/target/release/system76_ectool fan 1)"
                 P="$(echo "(${D} * 100)/255" | bc -lq)"
                 F="${F}\t$(printf "%.0f" "${P}")"
             fi

--- a/src/board/system76/common/common.mk
+++ b/src/board/system76/common/common.mk
@@ -157,8 +157,8 @@ board-common-y += flash/wrapper.c
 PROGRAMMER=$(wildcard /dev/serial/by-id/usb-Arduino*)
 
 console_internal:
-	cargo build --manifest-path tool/Cargo.toml --release
-	sudo tool/target/release/system76_ectool console
+	cargo build --manifest-path tools/system76_ectool/Cargo.toml --release
+	sudo tools/system76_ectool/target/release/system76_ectool console
 
 console_external:
 	sudo test -c "$(PROGRAMMER)"
@@ -171,8 +171,8 @@ console_external_forced:
 	sudo tio -b 1000000 -m INLCRNL -t "$(PROGRAMMER)"
 
 flash_internal: $(BUILD)/ec.rom
-	cargo build --manifest-path tool/Cargo.toml --release
-	sudo tool/target/release/system76_ectool flash $<
+	cargo build --manifest-path tools/system76_ectool/Cargo.toml --release
+	sudo tools/system76_ectool/target/release/system76_ectool flash $<
 
 flash_external: $(BUILD)/ec.rom
 	cargo build --manifest-path tools/ecflash/Cargo.toml --example isp --release


### PR DESCRIPTION
I updated `scripts/ectool.sh` but not all locations where `system76_ectool` is built and called directly.

Fixes: 68befd301632 ("Move tools to subdirectory")