### PR TITLE
Use bit flags for superloop intervals

### DIFF
--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -48,7 +48,6 @@ void timer_2(void) __interrupt(5) {}
 
 uint8_t main_cycle = 0;
 
-#define INTERVAL_1MS    1U
 #define INTERVAL_5MS    5U
 #define INTERVAL_100MS  100U
 #define INTERVAL_250MS  250U
@@ -107,7 +106,6 @@ void main(void) {
 
     INFO("System76 EC board '%s', version '%s'\n", board(), version());
 
-    systick_t last_time_1ms = 0;
     systick_t last_time_5ms = 0;
     systick_t last_time_100ms = 0;
     systick_t last_time_250ms = 0;
@@ -122,32 +120,34 @@ void main(void) {
     __bit evt_1sec = 0;
 
     for (main_cycle = 0;; main_cycle++) {
-        systick_t time = time_get();
+        // Calculate which intervals need to run at systick update.
+        if (evt_systick) {
+            evt_systick = 0;
 
-        // FIXME: These only need to run on systick event instead of every loop.
-        if ((time - last_time_1ms) >= INTERVAL_1MS) {
-            last_time_1ms = time;
+            systick_t time = time_get();
+
             evt_1ms = 1;
-        }
-        if ((time - last_time_5ms) >= INTERVAL_5MS) {
-            last_time_5ms = time;
-            evt_5ms = 1;
-        }
-        if ((time - last_time_100ms) >= INTERVAL_100MS) {
-            last_time_100ms = time;
-            evt_100ms = 1;
-        }
-        if ((time - last_time_250ms) >= INTERVAL_250MS) {
-            last_time_250ms = time;
-            evt_250ms = 1;
-        }
-        if ((time - last_time_500ms) >= INTERVAL_500MS) {
-            last_time_500ms = time;
-            evt_500ms = 1;
-        }
-        if ((time - last_time_1sec) >= INTERVAL_1SEC) {
-            last_time_1sec = time;
-            evt_1sec = 1;
+
+            if ((time - last_time_5ms) >= INTERVAL_5MS) {
+                last_time_5ms = time;
+                evt_5ms = 1;
+            }
+            if ((time - last_time_100ms) >= INTERVAL_100MS) {
+                last_time_100ms = time;
+                evt_100ms = 1;
+            }
+            if ((time - last_time_250ms) >= INTERVAL_250MS) {
+                last_time_250ms = time;
+                evt_250ms = 1;
+            }
+            if ((time - last_time_500ms) >= INTERVAL_500MS) {
+                last_time_500ms = time;
+                evt_500ms = 1;
+            }
+            if ((time - last_time_1sec) >= INTERVAL_1SEC) {
+                last_time_1sec = time;
+                evt_1sec = 1;
+            }
         }
 
         if (evt_1ms) {

--- a/src/arch/8051/include/arch/time.h
+++ b/src/arch/8051/include/arch/time.h
@@ -7,6 +7,9 @@
 
 typedef uint16_t systick_t;
 
+// Event flag for app to hook systick update.
+extern volatile __bit evt_systick;
+
 void time_init(void);
 systick_t time_get(void);
 

--- a/src/arch/8051/time.c
+++ b/src/arch/8051/time.c
@@ -11,6 +11,7 @@
 #define TIMER_RELOAD (0xFFFF - (TICK_INTERVAL_MS * (CONFIG_CLOCK_FREQ_KHZ / OSC_DIVISOR)))
 
 static volatile systick_t time_overflows = 0;
+volatile __bit evt_systick;
 
 void timer_0(void) __interrupt(1) {
     // Hardware automatically clears the the interrupt
@@ -19,6 +20,7 @@ void timer_0(void) __interrupt(1) {
     TR0 = 0;
 
     time_overflows++;
+    evt_systick = 1;
 
     // Reload the values
     TH0 = TIMER_RELOAD >> 8;
@@ -37,6 +39,7 @@ void time_init(void) __critical {
     TF0 = 0;
 
     time_overflows = 0;
+    evt_systick = 0;
 
     // Enable the interrupt
     ET0 = 1;


### PR DESCRIPTION
Add a systick update event flag. The app uses this as a hook this to implement the timer update logic, which will now only run when needed instead of every loop.