### PR TITLE
Move eSPI init/event from board to app

### DIFF
--- a/src/app/main/main.c
+++ b/src/app/main/main.c
@@ -3,6 +3,7 @@
 #include <app/battery.h>
 #include <app/board.h>
 #include <app/ecpm.h>
+#include <app/espi.h>
 #include <app/fan.h>
 #include <app/gctrl.h>
 #include <app/kbc.h>
@@ -92,6 +93,9 @@ void init(void) {
 
     // Must happen last
     power_init();
+#if CONFIG_BUS_ESPI
+    espi_init();
+#endif
     board_init();
     (void)battery_load_thresholds();
 }
@@ -124,7 +128,10 @@ void main(void) {
             usbpd_event();
             // Handle power states
             power_event();
-
+#if CONFIG_BUS_ESPI
+            // eSPI events
+            espi_event();
+#endif
             // Board-specific events
             board_event();
             // Checks for keyboard/mouse packets from host

--- a/src/board/system76/addw3/board.c
+++ b/src/board/system76/addw3/board.c
@@ -2,13 +2,10 @@
 
 #include <app/battery.h>
 #include <app/board.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/addw4/board.c
+++ b/src/board/system76/addw4/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/bonw15/board.c
+++ b/src/board/system76/bonw15/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/darp10-b/board.c
+++ b/src/board/system76/darp10-b/board.c
@@ -2,12 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
     battery_charger_disable();
 
     // Allow backlight to be turned on
@@ -17,7 +15,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/darp10/board.c
+++ b/src/board/system76/darp10/board.c
@@ -2,12 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
     battery_charger_disable();
 
     // Allow backlight to be turned on
@@ -17,7 +15,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/darp11-b/board.c
+++ b/src/board/system76/darp11-b/board.c
@@ -2,12 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
     battery_charger_disable();
 
     // Allow backlight to be turned on
@@ -17,7 +15,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/darp11/board.c
+++ b/src/board/system76/darp11/board.c
@@ -2,12 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
     battery_charger_disable();
 
     // Allow backlight to be turned on
@@ -17,7 +15,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/darp7/board.c
+++ b/src/board/system76/darp7/board.c
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <app/board.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Allow CPU to boot
     gpio_set(&SB_KBCRST_N, true);
     // Allow backlight to be turned on
@@ -22,7 +19,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/darp8/board.c
+++ b/src/board/system76/darp8/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -24,7 +21,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/darp9/board.c
+++ b/src/board/system76/darp9/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -23,7 +20,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/galp5/board.c
+++ b/src/board/system76/galp5/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -26,7 +23,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/galp6/board.c
+++ b/src/board/system76/galp6/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Allow backlight to be turned on
     gpio_set(&BKL_EN, true);
     // Enable camera
@@ -22,7 +19,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/gaze16-3050/board.c
+++ b/src/board/system76/gaze16-3050/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/gaze16-3060/board.c
+++ b/src/board/system76/gaze16-3060/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/gaze17-3050/board.c
+++ b/src/board/system76/gaze17-3050/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/gaze17-3060/board.c
+++ b/src/board/system76/gaze17-3060/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/gaze18/board.c
+++ b/src/board/system76/gaze18/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/gaze20/board.c
+++ b/src/board/system76/gaze20/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/lemp10/board.c
+++ b/src/board/system76/lemp10/board.c
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <app/board.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Allow CPU to boot
     gpio_set(&SB_KBCRST_N, true);
     // Allow backlight to be turned on
@@ -23,7 +20,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/lemp11/board.c
+++ b/src/board/system76/lemp11/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -25,7 +22,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/lemp12/board.c
+++ b/src/board/system76/lemp12/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -25,8 +22,6 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 
     // Hack to drain LDO_3V3 capacitors

--- a/src/board/system76/lemp13-b/board.c
+++ b/src/board/system76/lemp13-b/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/lemp13/board.c
+++ b/src/board/system76/lemp13/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/oryp11/board.c
+++ b/src/board/system76/oryp11/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/oryp12/board.c
+++ b/src/board/system76/oryp12/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -19,7 +16,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/oryp8/board.c
+++ b/src/board/system76/oryp8/board.c
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include <app/board.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Allow backlight to be turned on
     gpio_set(&BKL_EN, true);
     // Enable camera
@@ -15,7 +12,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/oryp9/board.c
+++ b/src/board/system76/oryp9/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -21,7 +18,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }

--- a/src/board/system76/serw13/board.c
+++ b/src/board/system76/serw13/board.c
@@ -2,13 +2,10 @@
 
 #include <app/board.h>
 #include <app/battery.h>
-#include <app/espi.h>
 #include <board/gpio.h>
 #include <ec/ec.h>
 
 void board_init(void) {
-    espi_init();
-
     // Make sure charger is in off state, also enables PSYS
     battery_charger_disable();
 
@@ -21,7 +18,5 @@ void board_init(void) {
 }
 
 void board_event(void) {
-    espi_event();
-
     ec_read_post_codes();
 }


### PR DESCRIPTION
These calls do not depend on any board-specific functionality, only that eSPI is used.