### PR TITLE
Add notes about variants

### DIFF
--- a/src/board/system76/bonw15-b/Makefile.mk
+++ b/src/board/system76/bonw15-b/Makefile.mk
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - 256K EC e-flash
+# - TBT5 JHL9540 (Barlow Ridge) controller
+
 board-y += ../bonw15/board.c
 board-y += ../bonw15/gpio.c
 

--- a/src/board/system76/bonw15/Makefile.mk
+++ b/src/board/system76/bonw15/Makefile.mk
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - 128K EC e-flash
+# - TBT4 JHL8540 (Maple Ridge) controller
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/darp10-b/Makefile.mk
+++ b/src/board/system76/darp10-b/Makefile.mk
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - Arrow Lake (ARL-H) chipset
+# - 14" display
+# - 16x8 keyboard matrix
+# - KBLED using DAC interface
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/darp10/Makefile.mk
+++ b/src/board/system76/darp10/Makefile.mk
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - Meteor Lake (MTL-H) chipset
+# - 16" display
+# - 18x8 keyboard matrix
+# - KBLED using PWM interface
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/darp11-b/Makefile.mk
+++ b/src/board/system76/darp11-b/Makefile.mk
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - Meteor Lake (MTL-H) chipset
+# - 14" display
+# - 16x8 keyboard matrix
+# - KBLED using DAC interface
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/darp11/Makefile.mk
+++ b/src/board/system76/darp11/Makefile.mk
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - Arrow Lake (ARL-H) chipset
+# - 16" display
+# - 18x8 keyboard matrix
+# - KBLED using PWM interface
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/galp3-c/Makefile.mk
+++ b/src/board/system76/galp3-c/Makefile.mk
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - Whiskey Lake (WHL-U) chipset
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/gaze16-3050/Makefile.mk
+++ b/src/board/system76/gaze16-3050/Makefile.mk
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - NVIDIA RTX 3050 dGPU
+# - Realtek Ethernet controller
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/gaze16-3060-b/Makefile.mk
+++ b/src/board/system76/gaze16-3060-b/Makefile.mk
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - NVIDIA RTX 3060 dGPU
+# - Onboard Intel I219-V Ethernet controller
+
 board-y += ../gaze16-3060/board.c
 board-y += ../gaze16-3060/gpio.c
 

--- a/src/board/system76/gaze16-3060/Makefile.mk
+++ b/src/board/system76/gaze16-3060/Makefile.mk
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - NVIDIA RTX 3060 dGPU
+# - Realtek Ethernet controller
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/gaze17-3050/Makefile.mk
+++ b/src/board/system76/gaze17-3050/Makefile.mk
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - NVIDIA RTX 3050 dGPU
+# - Realtek Ethernet controller
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/gaze17-3060-b/Makefile.mk
+++ b/src/board/system76/gaze17-3060-b/Makefile.mk
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - NVIDIA RTX 3060 dGPU
+# - Onboard Intel I219-V Ethernet controller
+
 board-y += ../gaze17-3060/board.c
 board-y += ../gaze17-3060/gpio.c
 

--- a/src/board/system76/lemp13-b/Makefile.mk
+++ b/src/board/system76/lemp13-b/Makefile.mk
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - 14" display
+# - 16x8 keyboard matrix
+# - KBLED uses DAC interface
+# - Sane keyboard layout
+
 board-y += board.c
 board-y += gpio.c
 

--- a/src/board/system76/lemp13/Makefile.mk
+++ b/src/board/system76/lemp13/Makefile.mk
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+# Variant with:
+# - 14" display
+# - 16x8 keyboard matrix
+# - KBLED uses DAC interface
+# - Cursed keyboard layout
+
 board-y += board.c
 board-y += gpio.c
 


### PR DESCRIPTION
Our variant IDs are nondescript, inconsistent, and unintuitive.
Add some notes to the Makefiles to more quickly identify them.
Some extra notes:

- `gaze17-3060` doesn't exist
  - It was copied from `gaze16` variants
- `lemp13` only had a 14" option with different keyboard layouts
  - I've chosen to label the original layout "cursed"
- Some models are a refresh without any significant changes
  - `darp10`/`darp11`, `oryp6`/`oryp7`
  - Potential to merge them at some point?